### PR TITLE
fix: switch SbtRegistry to persistent storage with TTL extension

### DIFF
--- a/contracts/sbt_registry/src/lib.rs
+++ b/contracts/sbt_registry/src/lib.rs
@@ -1,6 +1,14 @@
 #![no_std]
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, Env, Vec};
 
+/// TTL constants for persistent storage.
+/// Mirrors the strategy used in quorum_proof:
+/// - STANDARD_TTL: 16_384 ledgers (~3 hours at 5s/ledger) — minimum threshold before bump
+/// - EXTENDED_TTL: 524_288 ledgers (~4 days) — target TTL after bump
+/// SBTs represent permanent credentials, so persistent storage with TTL extension is required.
+const STANDARD_TTL: u32 = 16_384;
+const EXTENDED_TTL: u32 = 524_288;
+
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
@@ -25,46 +33,66 @@ pub struct SbtRegistryContract;
 #[contractimpl]
 impl SbtRegistryContract {
     /// Mint a soulbound token. Non-transferable by design.
+    /// Token data is stored in persistent storage with TTL extension to ensure
+    /// permanent credentials are not lost to storage expiry.
     pub fn mint(env: Env, owner: Address, credential_id: u64, metadata_uri: Bytes) -> u64 {
         owner.require_auth();
+
+        // TokenCount lives in instance storage — it's a lightweight counter accessed on every mint.
         let id: u64 = env
             .storage()
             .instance()
             .get(&DataKey::TokenCount)
             .unwrap_or(0u64)
             + 1;
+
         let token = SoulboundToken {
             id,
             owner: owner.clone(),
             credential_id,
             metadata_uri,
         };
+
+        // Token data goes into persistent storage so it survives beyond instance TTL.
         env.storage()
-            .instance()
+            .persistent()
             .set(&DataKey::Token(id), &token);
         env.storage()
-            .instance()
+            .persistent()
+            .extend_ttl(&DataKey::Token(id), STANDARD_TTL, EXTENDED_TTL);
+
+        env.storage()
+            .persistent()
             .set(&DataKey::Owner(id), &owner);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Owner(id), STANDARD_TTL, EXTENDED_TTL);
+
         env.storage()
             .instance()
             .set(&DataKey::TokenCount, &id);
-        // Track token ID under the owner's address for reverse lookup
+
+        // Reverse lookup: track all token IDs under the owner's address.
         let mut owner_tokens: Vec<u64> = env
             .storage()
-            .instance()
+            .persistent()
             .get(&DataKey::OwnerTokens(owner.clone()))
             .unwrap_or(Vec::new(&env));
         owner_tokens.push_back(id);
         env.storage()
-            .instance()
-            .set(&DataKey::OwnerTokens(owner), &owner_tokens);
+            .persistent()
+            .set(&DataKey::OwnerTokens(owner.clone()), &owner_tokens);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::OwnerTokens(owner), STANDARD_TTL, EXTENDED_TTL);
+
         id
     }
 
     /// Get a soulbound token by ID.
     pub fn get_token(env: Env, token_id: u64) -> SoulboundToken {
         env.storage()
-            .instance()
+            .persistent()
             .get(&DataKey::Token(token_id))
             .expect("token not found")
     }
@@ -72,7 +100,7 @@ impl SbtRegistryContract {
     /// Verify ownership of a token.
     pub fn owner_of(env: Env, token_id: u64) -> Address {
         env.storage()
-            .instance()
+            .persistent()
             .get(&DataKey::Owner(token_id))
             .expect("token not found")
     }
@@ -80,7 +108,7 @@ impl SbtRegistryContract {
     /// Return all token IDs owned by a given address.
     pub fn get_tokens_by_owner(env: Env, owner: Address) -> Vec<u64> {
         env.storage()
-            .instance()
+            .persistent()
             .get(&DataKey::OwnerTokens(owner))
             .unwrap_or(Vec::new(&env))
     }
@@ -89,7 +117,7 @@ impl SbtRegistryContract {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{testutils::Address as _, testutils::Events, Bytes, Env};
+    use soroban_sdk::{testutils::Address as _, testutils::Ledger, Bytes, Env};
 
     #[test]
     fn test_mint_and_ownership() {
@@ -176,5 +204,45 @@ mod tests {
         let tokens_b = client.get_tokens_by_owner(&owner_b);
         assert_eq!(tokens_b.len(), 1);
         assert_eq!(tokens_b.get(0).unwrap(), id_b1);
+    }
+
+    /// Verifies that token data persists in persistent storage after advancing the ledger
+    /// well past the default instance TTL. The TTL extension on mint ensures the token
+    /// remains accessible at EXTENDED_TTL ledgers (~4 days).
+    #[test]
+    fn test_token_persists_after_ttl_bump() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, SbtRegistryContract);
+        let client = SbtRegistryContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let uri = Bytes::from_slice(&env, b"ipfs://QmSBT");
+        let token_id = client.mint(&owner, &42u64, &uri);
+
+        // Advance the ledger sequence well past the default instance TTL (4096 ledgers)
+        // but within the EXTENDED_TTL (524_288 ledgers) to confirm persistent storage holds.
+        env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+            timestamp: 0,
+            protocol_version: 21,
+            sequence_number: 100_000,
+            network_id: Default::default(),
+            base_reserve: 10,
+            min_temp_entry_ttl: 16,
+            min_persistent_entry_ttl: STANDARD_TTL,
+            max_entry_ttl: EXTENDED_TTL + 1,
+        });
+
+        // Token and ownership must still be retrievable from persistent storage.
+        let token = client.get_token(&token_id);
+        assert_eq!(token.id, token_id);
+        assert_eq!(token.owner, owner);
+        assert_eq!(token.credential_id, 42u64);
+
+        assert_eq!(client.owner_of(&token_id), owner);
+
+        let tokens = client.get_tokens_by_owner(&owner);
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens.get(0).unwrap(), token_id);
     }
 }


### PR DESCRIPTION
- Move Token(id), Owner(id), and OwnerTokens(Address) from instance storage to persistent storage so SBT data survives beyond instance TTL
- TokenCount intentionally stays in instance storage (lightweight counter)
- Add extend_ttl() after each persistent write on mint using the same STANDARD_TTL (16_384) / EXTENDED_TTL (524_288) constants already established in quorum_proof
- Add test_token_persists_after_ttl_bump: advances ledger to sequence 100_000 (past default instance TTL) and asserts token data is still accessible from persistent storage

closed #20 