### PR TITLE
Fix double-revocation: Add check and test for already-revoked credent…

### DIFF
--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -97,6 +97,7 @@ pub fn issue_credential(
             caller == credential.subject || caller == credential.issuer,
             "only subject or issuer can revoke"
         );
+        assert!(!credential.revoked, "credential already revoked");
         credential.revoked = true;
         env.storage()
             .instance()

--- a/test_double_revocation.rs
+++ b/test_double_revocation.rs
@@ -1,0 +1,22 @@
+#[test]
+#[should_panic(expected = "credential already revoked")]
+fn test_double_revocation_rejection() {
+    use soroban_sdk::testutils::{Address as _};
+    use soroban_sdk::{Bytes, Env};
+    
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, quorum_proof::QuorumProofContract);
+    let client = quorum_proof::QuorumProofContractClient::new(&env, &contract_id);
+
+    let issuer = Address::generate(&env);
+    let subject = Address::generate(&env);
+    let metadata = Bytes::from_slice(&env, b"ipfs://QmTest");
+    let id = client.issue_credential(&issuer, &subject, &1u32, &metadata);
+
+    // First revocation should succeed
+    client.revoke_credential(&issuer, &id);
+
+    // Second revocation should panic
+    client.revoke_credential(&issuer, &id);
+}


### PR DESCRIPTION
## Summary
Fixes issue where [revoke_credential](cci:1://file:///home/henry-peters/Desktop/celestine/QuorumProof/contracts/quorum_proof/src/lib.rs:87:4-105:5) silently succeeded on already-revoked credentials and re-wrote storage unnecessarily.

## Changes
- **Added check**: `assert!(!credential.revoked, "credential already revoked");` in [revoke_credential](cci:1://file:///home/henry-peters/Desktop/celestine/QuorumProof/contracts/quorum_proof/src/lib.rs:87:4-105:5) function
- **Structured error**: Clear panic message when attempting to revoke already-revoked credential  
- **Prevents unnecessary storage writes**: Stops execution before re-writing storage
- **Added test**: [test_double_revocation_rejection](cci:1://file:///tmp/test_addition.rs:0:0-18:5) to verify the fix works correctly

## Technical Details
The fix adds a simple assertion before setting `credential.revoked = true` that checks if the credential is already revoked. If it is, the function panics with a structured error message instead of silently proceeding and re-writing the storage.

## Test Coverage
-  First revocation works normally
-  Second revocation panics with "credential already revoked" message
-  Existing authorization tests continue to pass

Fixes the issue described in the task requirements.

closes #3 