### PR TITLE
feat: add typed contract client layer for all three Soroban contracts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ CONTRACT_ZK_VERIFIER=<your-contract-id>
 # Frontend configuration
 VITE_STELLAR_NETWORK=testnet
 VITE_STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+VITE_CONTRACT_QUORUM_PROOF=<your-contract-id>
+VITE_CONTRACT_SBT_REGISTRY=<your-contract-id>
+VITE_CONTRACT_ZK_VERIFIER=<your-contract-id>

--- a/frontend/src/lib/contracts/quorumProof.ts
+++ b/frontend/src/lib/contracts/quorumProof.ts
@@ -1,0 +1,192 @@
+/**
+ * quorumProof.ts — Typed contract client for the QuorumProof contract.
+ * All RPC calls are centralised here; UI components must not call RPC directly.
+ */
+
+import {
+  Contract,
+  Networks,
+  rpc as StellarRpc,
+  scValToNative,
+  nativeToScVal,
+  Address,
+  Account,
+  Keypair,
+  TransactionBuilder,
+  BASE_FEE,
+  xdr,
+} from '@stellar/stellar-sdk';
+
+// ---------------------------------------------------------------------------
+// Types mirroring the on-chain contract structs
+// ---------------------------------------------------------------------------
+
+export interface Credential {
+  id: bigint;
+  subject: string;
+  issuer: string;
+  credential_type: number;
+  metadata_hash: Uint8Array;
+  revoked: boolean;
+  expires_at: bigint | null;
+}
+
+export interface QuorumSlice {
+  id: bigint;
+  creator: string;
+  attestors: string[];
+  threshold: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const RPC_URL =
+  import.meta.env.VITE_STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+const NETWORK = (import.meta.env.VITE_STELLAR_NETWORK ?? 'testnet') as string;
+
+const PASSPHRASES: Record<string, string> = {
+  testnet: Networks.TESTNET,
+  mainnet: Networks.PUBLIC,
+  futurenet: Networks.FUTURENET,
+};
+
+function getPassphrase(): string {
+  return PASSPHRASES[NETWORK] ?? Networks.TESTNET;
+}
+
+function getServer(): StellarRpc.Server {
+  return new StellarRpc.Server(RPC_URL, { allowHttp: false });
+}
+
+function getContractId(): string {
+  const id = import.meta.env.VITE_CONTRACT_QUORUM_PROOF ?? '';
+  if (!id) throw new Error('VITE_CONTRACT_QUORUM_PROOF is not set');
+  return id;
+}
+
+async function simulate<T>(method: string, args: xdr.ScVal[] = []): Promise<T> {
+  const contractId = getContractId();
+  const server = getServer();
+  const contract = new Contract(contractId);
+
+  const dummyKeypair = Keypair.random();
+  const dummyAccount = new Account(dummyKeypair.publicKey(), '0');
+
+  const tx = new TransactionBuilder(dummyAccount, {
+    fee: BASE_FEE,
+    networkPassphrase: getPassphrase(),
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const result = await server.simulateTransaction(tx);
+
+  if (StellarRpc.Api.isSimulationError(result)) {
+    throw new Error(result.error ?? 'Simulation failed');
+  }
+  if (!result.result) throw new Error('No result returned from simulation');
+
+  return scValToNative(result.result.retval) as T;
+}
+
+function u64(value: bigint | number): xdr.ScVal {
+  return nativeToScVal(BigInt(value), { type: 'u64' });
+}
+
+function addr(stellarAddress: string): xdr.ScVal {
+  return new Address(stellarAddress).toScVal();
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Issue a new credential. Returns the new credential ID. */
+export async function issueCredential(
+  issuer: string,
+  subject: string,
+  credentialType: number,
+  metadataHash: Uint8Array,
+  expiresAt: bigint | null = null,
+): Promise<bigint> {
+  return simulate<bigint>('issue_credential', [
+    addr(issuer),
+    addr(subject),
+    nativeToScVal(credentialType, { type: 'u32' }),
+    xdr.ScVal.scvBytes(metadataHash),
+    expiresAt !== null
+      ? xdr.ScVal.scvVec([u64(expiresAt)])
+      : xdr.ScVal.scvVoid(),
+  ]);
+}
+
+/** Retrieve a credential by ID. */
+export async function getCredential(credentialId: bigint | number): Promise<Credential> {
+  return simulate<Credential>('get_credential', [u64(credentialId)]);
+}
+
+/** Revoke a credential. Caller must be the issuer or subject. */
+export async function revokeCredential(
+  caller: string,
+  credentialId: bigint | number,
+): Promise<void> {
+  return simulate<void>('revoke_credential', [addr(caller), u64(credentialId)]);
+}
+
+/** Create a quorum slice. Returns the new slice ID. */
+export async function createSlice(
+  creator: string,
+  attestors: string[],
+  threshold: number,
+): Promise<bigint> {
+  const attestorVec = xdr.ScVal.scvVec(attestors.map(addr));
+  return simulate<bigint>('create_slice', [
+    addr(creator),
+    attestorVec,
+    nativeToScVal(threshold, { type: 'u32' }),
+  ]);
+}
+
+/** Add an attestor to an existing slice. Only the slice creator can call this. */
+export async function addAttestor(
+  creator: string,
+  sliceId: bigint | number,
+  attestor: string,
+): Promise<void> {
+  return simulate<void>('add_attestor', [addr(creator), u64(sliceId), addr(attestor)]);
+}
+
+/** Attest a credential using a quorum slice. */
+export async function attest(
+  attestor: string,
+  credentialId: bigint | number,
+  sliceId: bigint | number,
+): Promise<void> {
+  return simulate<void>('attest', [addr(attestor), u64(credentialId), u64(sliceId)]);
+}
+
+/** Check if a credential has met its quorum threshold. */
+export async function isAttested(
+  credentialId: bigint | number,
+  sliceId: bigint | number,
+): Promise<boolean> {
+  return simulate<boolean>('is_attested', [u64(credentialId), u64(sliceId)]);
+}
+
+/** Get all attestor addresses for a credential. */
+export async function getAttestors(credentialId: bigint | number): Promise<string[]> {
+  return simulate<string[]>('get_attestors', [u64(credentialId)]);
+}
+
+/** Get all credential IDs issued to a subject address. */
+export async function getCredentialsBySubject(subject: string): Promise<bigint[]> {
+  return simulate<bigint[]>('get_credentials_by_subject', [addr(subject)]);
+}
+
+/** Check whether a credential is expired. */
+export async function isExpired(credentialId: bigint | number): Promise<boolean> {
+  return simulate<boolean>('is_expired', [u64(credentialId)]);
+}

--- a/frontend/src/lib/contracts/sbtRegistry.ts
+++ b/frontend/src/lib/contracts/sbtRegistry.ts
@@ -1,0 +1,127 @@
+/**
+ * sbtRegistry.ts — Typed contract client for the SBT Registry contract.
+ * Soulbound tokens are non-transferable by design; no transfer method is exposed.
+ */
+
+import {
+  Contract,
+  Networks,
+  rpc as StellarRpc,
+  scValToNative,
+  nativeToScVal,
+  Address,
+  Account,
+  Keypair,
+  TransactionBuilder,
+  BASE_FEE,
+  xdr,
+} from '@stellar/stellar-sdk';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SoulboundToken {
+  id: bigint;
+  owner: string;
+  credential_id: bigint;
+  metadata_uri: Uint8Array;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const RPC_URL =
+  import.meta.env.VITE_STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+const NETWORK = (import.meta.env.VITE_STELLAR_NETWORK ?? 'testnet') as string;
+
+const PASSPHRASES: Record<string, string> = {
+  testnet: Networks.TESTNET,
+  mainnet: Networks.PUBLIC,
+  futurenet: Networks.FUTURENET,
+};
+
+function getPassphrase(): string {
+  return PASSPHRASES[NETWORK] ?? Networks.TESTNET;
+}
+
+function getServer(): StellarRpc.Server {
+  return new StellarRpc.Server(RPC_URL, { allowHttp: false });
+}
+
+function getContractId(): string {
+  const id = import.meta.env.VITE_CONTRACT_SBT_REGISTRY ?? '';
+  if (!id) throw new Error('VITE_CONTRACT_SBT_REGISTRY is not set');
+  return id;
+}
+
+async function simulate<T>(method: string, args: xdr.ScVal[] = []): Promise<T> {
+  const contractId = getContractId();
+  const server = getServer();
+  const contract = new Contract(contractId);
+
+  const dummyKeypair = Keypair.random();
+  const dummyAccount = new Account(dummyKeypair.publicKey(), '0');
+
+  const tx = new TransactionBuilder(dummyAccount, {
+    fee: BASE_FEE,
+    networkPassphrase: getPassphrase(),
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const result = await server.simulateTransaction(tx);
+
+  if (StellarRpc.Api.isSimulationError(result)) {
+    throw new Error(result.error ?? 'Simulation failed');
+  }
+  if (!result.result) throw new Error('No result returned from simulation');
+
+  return scValToNative(result.result.retval) as T;
+}
+
+function u64(value: bigint | number): xdr.ScVal {
+  return nativeToScVal(BigInt(value), { type: 'u64' });
+}
+
+function addr(stellarAddress: string): xdr.ScVal {
+  return new Address(stellarAddress).toScVal();
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// NOTE: Transfer is intentionally omitted — SBTs are non-transferable.
+// ---------------------------------------------------------------------------
+
+/**
+ * Mint a soulbound token bound to `owner`.
+ * Non-transferability is enforced at the contract level; no transfer wrapper exists.
+ */
+export async function mintSbt(
+  owner: string,
+  credentialId: bigint | number,
+  metadataUri: Uint8Array,
+): Promise<bigint> {
+  return simulate<bigint>('mint', [
+    addr(owner),
+    u64(credentialId),
+    xdr.ScVal.scvBytes(metadataUri),
+  ]);
+}
+
+/** Retrieve a soulbound token by ID. */
+export async function getToken(tokenId: bigint | number): Promise<SoulboundToken> {
+  return simulate<SoulboundToken>('get_token', [u64(tokenId)]);
+}
+
+/** Return the owner address of a token. */
+export async function ownerOf(tokenId: bigint | number): Promise<string> {
+  return simulate<string>('owner_of', [u64(tokenId)]);
+}
+
+/** Return all token IDs owned by a given address. */
+export async function getTokensByOwner(owner: string): Promise<bigint[]> {
+  return simulate<bigint[]>('get_tokens_by_owner', [addr(owner)]);
+}

--- a/frontend/src/lib/contracts/useContractClient.ts
+++ b/frontend/src/lib/contracts/useContractClient.ts
@@ -1,0 +1,44 @@
+/**
+ * useContractClient.ts — Unified React hook that exposes all three contract clients.
+ *
+ * Usage:
+ *   const { quorumProof, sbtRegistry, zkVerifier } = useContractClient();
+ *   const cred = await quorumProof.getCredential(1n);
+ */
+
+import * as quorumProof from './quorumProof';
+import * as sbtRegistry from './sbtRegistry';
+import * as zkVerifier from './zkVerifier';
+
+export type { Credential, QuorumSlice } from './quorumProof';
+export type { SoulboundToken } from './sbtRegistry';
+export type { ClaimType, ProofRequest } from './zkVerifier';
+
+export interface ContractClient {
+  quorumProof: typeof quorumProof;
+  sbtRegistry: typeof sbtRegistry;
+  zkVerifier: typeof zkVerifier;
+  /** Contract addresses resolved from env vars (empty string if not set). */
+  addresses: {
+    quorumProof: string;
+    sbtRegistry: string;
+    zkVerifier: string;
+  };
+}
+
+/**
+ * Returns stable references to all three typed contract clients.
+ * The hook itself is synchronous — individual methods return Promises.
+ */
+export function useContractClient(): ContractClient {
+  return {
+    quorumProof,
+    sbtRegistry,
+    zkVerifier,
+    addresses: {
+      quorumProof: import.meta.env.VITE_CONTRACT_QUORUM_PROOF ?? '',
+      sbtRegistry: import.meta.env.VITE_CONTRACT_SBT_REGISTRY ?? '',
+      zkVerifier: import.meta.env.VITE_CONTRACT_ZK_VERIFIER ?? '',
+    },
+  };
+}

--- a/frontend/src/lib/contracts/zkVerifier.ts
+++ b/frontend/src/lib/contracts/zkVerifier.ts
@@ -1,0 +1,138 @@
+/**
+ * zkVerifier.ts — Typed contract client for the ZK Verifier contract.
+ */
+
+import {
+  Contract,
+  Networks,
+  rpc as StellarRpc,
+  scValToNative,
+  nativeToScVal,
+  Account,
+  Keypair,
+  TransactionBuilder,
+  BASE_FEE,
+  xdr,
+} from '@stellar/stellar-sdk';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Mirrors the on-chain ClaimType enum variants. */
+export type ClaimType = 'HasDegree' | 'HasLicense' | 'HasEmploymentHistory';
+
+export interface ProofRequest {
+  credential_id: bigint;
+  claim_type: ClaimType;
+  nonce: bigint;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const RPC_URL =
+  import.meta.env.VITE_STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+const NETWORK = (import.meta.env.VITE_STELLAR_NETWORK ?? 'testnet') as string;
+
+const PASSPHRASES: Record<string, string> = {
+  testnet: Networks.TESTNET,
+  mainnet: Networks.PUBLIC,
+  futurenet: Networks.FUTURENET,
+};
+
+function getPassphrase(): string {
+  return PASSPHRASES[NETWORK] ?? Networks.TESTNET;
+}
+
+function getServer(): StellarRpc.Server {
+  return new StellarRpc.Server(RPC_URL, { allowHttp: false });
+}
+
+function getContractId(): string {
+  const id = import.meta.env.VITE_CONTRACT_ZK_VERIFIER ?? '';
+  if (!id) throw new Error('VITE_CONTRACT_ZK_VERIFIER is not set');
+  return id;
+}
+
+async function simulate<T>(method: string, args: xdr.ScVal[] = []): Promise<T> {
+  const contractId = getContractId();
+  const server = getServer();
+  const contract = new Contract(contractId);
+
+  const dummyKeypair = Keypair.random();
+  const dummyAccount = new Account(dummyKeypair.publicKey(), '0');
+
+  const tx = new TransactionBuilder(dummyAccount, {
+    fee: BASE_FEE,
+    networkPassphrase: getPassphrase(),
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const result = await server.simulateTransaction(tx);
+
+  if (StellarRpc.Api.isSimulationError(result)) {
+    throw new Error(result.error ?? 'Simulation failed');
+  }
+  if (!result.result) throw new Error('No result returned from simulation');
+
+  return scValToNative(result.result.retval) as T;
+}
+
+function u64(value: bigint | number): xdr.ScVal {
+  return nativeToScVal(BigInt(value), { type: 'u64' });
+}
+
+/** Encode a ClaimType string as the matching on-chain enum ScVal. */
+function claimTypeToScVal(claimType: ClaimType): xdr.ScVal {
+  return xdr.ScVal.scvVec([xdr.ScVal.scvSymbol(claimType)]);
+}
+
+/** Convert a hex string to Uint8Array. */
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.replace(/^0x/, '');
+  if (clean.length % 2 !== 0) throw new Error('Invalid hex string');
+  const bytes = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(clean.substring(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a proof request for a given credential and claim type.
+ * Returns a ProofRequest containing a nonce tied to the current ledger sequence.
+ */
+export async function generateProofRequest(
+  credentialId: bigint | number,
+  claimType: ClaimType,
+): Promise<ProofRequest> {
+  return simulate<ProofRequest>('generate_proof_request', [
+    u64(credentialId),
+    claimTypeToScVal(claimType),
+  ]);
+}
+
+/**
+ * Verify a ZK proof for a claim.
+ * @param proof - raw proof bytes or a hex-encoded string
+ */
+export async function verifyClaim(
+  credentialId: bigint | number,
+  claimType: ClaimType,
+  proof: Uint8Array | string,
+): Promise<boolean> {
+  const proofBytes = typeof proof === 'string' ? hexToBytes(proof) : proof;
+  return simulate<boolean>('verify_claim', [
+    u64(credentialId),
+    claimTypeToScVal(claimType),
+    xdr.ScVal.scvBytes(proofBytes),
+  ]);
+}


### PR DESCRIPTION
closes #78
- Add src/lib/contracts/quorumProof.ts with typed wrappers for issue_credential, get_credential, revoke_credential, create_slice, add_attestor, attest, is_attested, get_attestors
- Add src/lib/contracts/sbtRegistry.ts with SBT non-transferability enforcement (no transfer method exposed)
- Add src/lib/contracts/zkVerifier.ts with wrappers for verify_claim and generate_proof_request
- Add src/lib/contracts/useContractClient.ts unified React hook
- Update .env.example with VITE_CONTRACT_* env var keys