### PR TITLE
feat: build credential dashboard page

### DIFF
--- a/.kiro/specs/credential-dashboard/.config.kiro
+++ b/.kiro/specs/credential-dashboard/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "34f1895b-08e9-42e1-9145-42a31d592779", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/credential-dashboard/design.md
+++ b/.kiro/specs/credential-dashboard/design.md
@@ -1,0 +1,442 @@
+# Design Document: Credential Dashboard
+
+## Overview
+
+The Credential Dashboard is a wallet-gated React page at `/dashboard` that lets engineers view all on-chain verifiable credentials issued to their Stellar address. It surfaces three data domains per credential: the credential metadata, the attestation status, and the quorum slice composition (attestors + threshold).
+
+The feature is built inside the existing `frontend/` React 19 + TypeScript application. It reuses the `useFreighter` wallet hook, the `quorumProof` typed contract client, and the existing routing in `App.tsx`. The existing `Dashboard.tsx` is a partial implementation that uses `getAttestors` as an attestation proxy and lacks `getSlice` support — this design replaces it with a complete implementation.
+
+### Key Design Decisions
+
+1. **`getSlice` added to `stellar.ts`**: The shared RPC module is the canonical place for read-only contract calls used by multiple pages. `getSlice` is added there (and re-exported from `quorumProof.ts` for typed access).
+
+2. **Slice ID association strategy**: The `Credential` struct has no `slice_id` field. The dashboard uses a two-phase approach: first attempt `isAttested(credId, sliceId)` + `getSlice(sliceId)` when a slice ID is known (stored in `localStorage` under `qp-slice-id`, matching the vanilla JS prototype), and fall back to `getAttestors(credId).length > 0` as an attestation proxy when no slice ID is available.
+
+3. **Existing `Dashboard.tsx` is replaced**: The current file is incomplete (missing `getSlice`, uses `getAttestors` only). The new implementation is a full rewrite that satisfies all requirements.
+
+4. **Component decomposition**: Logic is split into `CredentialCard`, `EmptyState`, and `WalletGate` components to keep `Dashboard.tsx` focused on data fetching and layout orchestration.
+
+5. **Role labels are UI-layer only**: The on-chain `QuorumSlice` has no role labels. The dashboard assigns them by attestor index using a fixed array (`['Lead Verifier', 'Co-Verifier', 'Auditor', 'Reviewer', 'Observer']`), matching the vanilla JS prototype.
+
+---
+
+## Architecture
+
+```mermaid
+graph TD
+    A[App.tsx /dashboard route] --> B[Dashboard.tsx]
+    B --> C[useFreighter hook]
+    B --> D[WalletGate component]
+    B --> E[CredentialCard component]
+    B --> F[EmptyState component]
+    E --> G[stellar.ts / quorumProof.ts]
+    G --> H[Soroban RPC]
+
+    subgraph "Data Flow"
+        C -->|address| B
+        B -->|address| G
+        G -->|getCredentialsBySubject| H
+        G -->|getCredential| H
+        G -->|isAttested / getAttestors| H
+        G -->|getSlice| H
+    end
+```
+
+### Data Fetching Strategy
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant D as Dashboard
+    participant S as stellar.ts
+    participant R as Soroban RPC
+
+    U->>D: Connect wallet
+    D->>S: getCredentialsBySubject(address)
+    S->>R: simulate get_credentials_by_subject
+    R-->>S: [id1, id2, ...]
+    S-->>D: bigint[]
+
+    par For each credential ID
+        D->>S: getCredential(id)
+        S->>R: simulate get_credential
+        R-->>S: Credential struct
+        S-->>D: Credential
+
+        alt sliceId known (localStorage)
+            D->>S: isAttested(credId, sliceId)
+            D->>S: getSlice(sliceId)
+        else no sliceId
+            D->>S: getAttestors(credId)
+        end
+    end
+
+    D->>U: Render credential grid
+```
+
+---
+
+## Components and Interfaces
+
+### `Dashboard.tsx` (rewrite)
+
+The top-level page component. Owns all async data fetching and renders the appropriate state (loading, error, empty, or credential grid).
+
+```typescript
+// State shape
+interface CredCardData {
+  credential: Credential;       // from quorumProof.ts
+  attested: boolean;            // from isAttested or getAttestors fallback
+  slice: QuorumSlice | null;    // from getSlice, null if unavailable
+  expired: boolean;             // from isExpired
+  sliceError: boolean;          // true if getSlice failed
+  credError: string | null;     // per-card fetch error message
+}
+```
+
+Responsibilities:
+- Read `address` from `useFreighter`
+- Read `sliceId` from `localStorage` (`qp-slice-id`)
+- On `address` change: fetch all credential IDs, then fetch each card's data in parallel
+- Render `WalletGate` when no address, loading spinner while fetching, error card on failure, `EmptyState` when zero credentials, or `dashboard-grid` of `CredentialCard`s
+
+### `WalletGate.tsx`
+
+Renders the wallet connection prompt. Shown when `address` is null and `isInitializing` is false.
+
+Props:
+```typescript
+interface WalletGateProps {
+  hasFreighter: boolean;
+  connect: () => Promise<void>;
+}
+```
+
+Renders:
+- "Connect Wallet" button (calls `connect()`)
+- If `!hasFreighter`: message + link to `https://freighter.app`
+
+### `CredentialCard.tsx`
+
+Renders a single credential's full summary. Receives pre-fetched data — no async calls inside.
+
+Props:
+```typescript
+interface CredentialCardProps {
+  data: CredCardData;
+  sliceId: bigint | null;
+}
+```
+
+Renders:
+- Header: credential type label + status badge with `aria-label`
+- Body: credential ID (truncated), issuer (truncated + `title`), metadata, expiry
+- Quorum slice section: attestors list with role labels, threshold progress, or error/empty states
+- Footer: "View Public Page →" link to `/verify?credentialId=<id>`
+
+### `EmptyState.tsx`
+
+Renders the empty state when a connected wallet has zero credentials.
+
+Props:
+```typescript
+interface EmptyStateProps {
+  address: string;
+}
+```
+
+Renders:
+- Icon + title + description
+- Connected address display
+- "Request Credential Issuance" CTA button
+
+---
+
+## Data Models
+
+### On-chain types (from `quorumProof.ts`)
+
+```typescript
+interface Credential {
+  id: bigint;
+  subject: string;
+  issuer: string;
+  credential_type: number;
+  metadata_hash: Uint8Array;
+  revoked: boolean;
+  expires_at: bigint | null;
+}
+
+interface QuorumSlice {
+  id: bigint;
+  creator: string;
+  attestors: string[];
+  threshold: number;
+}
+```
+
+### `getSlice` — new function to add to `stellar.ts`
+
+```typescript
+/**
+ * Retrieve a quorum slice by ID.
+ * Returns the QuorumSlice struct: { id, creator, attestors, threshold }
+ */
+export async function getSlice(sliceId: bigint | number): Promise<QuorumSlice> {
+  const sliceVal = nativeToScVal(BigInt(sliceId), { type: 'u64' });
+  return simulate(CONTRACT_ID, 'get_slice', [sliceVal]);
+}
+```
+
+This function must also be added to `quorumProof.ts` using the existing `simulate` helper and `u64` encoder already present in that file.
+
+### Attestation Status Derivation
+
+The `AttestationStatus` type is a UI-layer concept derived from on-chain data:
+
+```typescript
+type AttestationStatus = 'attested' | 'pending' | 'revoked' | 'expired';
+
+function deriveStatus(
+  revoked: boolean,
+  expired: boolean,
+  attested: boolean
+): AttestationStatus {
+  if (revoked) return 'revoked';
+  if (expired) return 'expired';
+  if (attested) return 'attested';
+  return 'pending';
+}
+```
+
+Priority order: `revoked` > `expired` > `attested` > `pending`.
+
+### Address Truncation
+
+```typescript
+function formatAddress(addr: string): string {
+  if (!addr || addr.length < 10) return addr || '—';
+  return addr.slice(0, 8) + '…' + addr.slice(-6);
+}
+```
+
+Full address is always available via `title` attribute on the element.
+
+### Role Label Assignment
+
+```typescript
+const ATTESTOR_ROLES = ['Lead Verifier', 'Co-Verifier', 'Auditor', 'Reviewer', 'Observer'];
+
+function attestorRole(index: number): string {
+  return ATTESTOR_ROLES[index] ?? `Member ${index + 1}`;
+}
+```
+
+### Credential Type Labels
+
+```typescript
+const CREDENTIAL_TYPES: Record<number, string> = {
+  1: '🎓 Degree',
+  2: '🏛️ License',
+  3: '💼 Employment',
+  4: '📜 Certification',
+  5: '🔬 Research',
+};
+```
+
+### localStorage Keys
+
+| Key | Purpose |
+|-----|---------|
+| `qp-slice-id` | Optional global quorum slice ID used for `isAttested` + `getSlice` calls |
+
+---
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Status Derivation Correctness
+
+*For any* combination of `revoked` (boolean), `expired` (boolean), and `attested` (boolean) values, the `deriveStatus` function must return exactly one of `'revoked'`, `'expired'`, `'attested'`, or `'pending'`, and the priority order must be respected: `revoked` > `expired` > `attested` > `pending`. Specifically: if `revoked` is true the result is always `'revoked'` regardless of other inputs; if `revoked` is false and `expired` is true the result is always `'expired'`; if both are false and `attested` is true the result is `'attested'`; otherwise `'pending'`.
+
+**Validates: Requirements 3.1, 3.2, 3.3, 3.4**
+
+---
+
+### Property 2: Card Count Matches Credential ID Count
+
+*For any* non-empty list of credential IDs returned by `getCredentialsBySubject`, the number of `CredentialCard` elements rendered in the dashboard grid must equal the number of IDs in the list.
+
+**Validates: Requirements 2.2**
+
+---
+
+### Property 3: Partial Failure Resilience
+
+*For any* list of credential IDs where a subset of individual credential fetches fail, the dashboard must still render a `CredentialCard` for every successfully fetched credential, and the failed cards must show an inline error rather than crashing the entire grid.
+
+**Validates: Requirements 2.5**
+
+---
+
+### Property 4: Credential Card Required Fields
+
+*For any* `Credential` struct with a valid `credential_type`, `issuer`, `id`, and `metadata_hash`, the rendered `CredentialCard` must contain: the truncated credential ID (first 8 chars + `…` + last 6 chars of the string representation), the credential type label from `CREDENTIAL_TYPES`, the truncated issuer address, and — when `expires_at` is non-null — the formatted expiration date.
+
+**Validates: Requirements 2.6, 2.7**
+
+---
+
+### Property 5: Attestor Address Truncation with Full Address on Hover
+
+*For any* Stellar address string of length ≥ 10, the `formatAddress` function must return a string of the form `<first 8 chars>…<last 6 chars>`, and the corresponding DOM element must have a `title` attribute equal to the full untruncated address.
+
+**Validates: Requirements 4.2**
+
+---
+
+### Property 6: Slice Section Renders Role Labels, Count, and Threshold
+
+*For any* `QuorumSlice` with N attestors and threshold T, the rendered slice section must: display each attestor's address truncated via `formatAddress`, display the role label for each attestor at index i (from `ATTESTOR_ROLES[i]` or `Member ${i+1}` fallback), display the total attestor count N, and display the threshold value T.
+
+**Validates: Requirements 4.3, 4.4**
+
+---
+
+### Property 7: Aria-Label Contains Attestation Status
+
+*For any* `CredentialCard` rendered with a derived `AttestationStatus`, the element bearing the status badge must have an `aria-label` attribute that contains the status string (`'Attested'`, `'Pending'`, `'Revoked'`, or `'Expired'`).
+
+**Validates: Requirements 3.5**
+
+---
+
+### Property 8: EmptyState Displays Connected Address
+
+*For any* connected wallet address string, the `EmptyState` component must render that address visibly in its output so the engineer can confirm the correct wallet is connected.
+
+**Validates: Requirements 5.4**
+
+---
+
+## Error Handling
+
+### Top-Level Fetch Failure (Requirement 2.4)
+
+If `getCredentialsBySubject` throws, the dashboard sets `error` state and renders an error card with the error message and a "Retry" button that re-triggers the fetch effect. The credential grid is not rendered.
+
+### Per-Card Fetch Failure (Requirement 2.5)
+
+Each credential's data is fetched in a `Promise.all` where individual failures are caught per-card. A failed card stores `credError: string` in its `CredCardData`. `CredentialCard` renders an inline error panel for that card while other cards render normally.
+
+### `is_attested` Failure (Requirement 3.6)
+
+If `isAttested(credId, sliceId)` throws, the error is caught, logged to `console.error`, and `attested` defaults to `false` (resulting in `'pending'` status). This prevents a single RPC failure from blocking the card render.
+
+### `getSlice` Failure (Requirement 4.5)
+
+If `getSlice(sliceId)` throws, `slice` is set to `null` and `sliceError` is set to `true`. The `CredentialCard` renders "Slice unavailable" in the slice section. All other credential data renders normally.
+
+### Freighter Not Installed (Requirement 1.5)
+
+`useFreighter` sets `hasFreighter: false` when the extension is not detected. `WalletGate` checks this flag and renders an install prompt with a link to `https://freighter.app` instead of the "Connect Wallet" button.
+
+### No Slice ID Available
+
+When `localStorage` has no `qp-slice-id`, `isAttested` cannot be called (it requires both `credentialId` and `sliceId`). The fallback is `getAttestors(credId)` — if the returned array is non-empty, `attested` is set to `true`. The slice section renders "No slice data available" since `getSlice` is not called.
+
+---
+
+## Testing Strategy
+
+### Dual Testing Approach
+
+Both unit tests and property-based tests are required. They are complementary:
+- Unit tests cover specific examples, integration points, and edge cases
+- Property tests verify universal correctness across all inputs
+
+### Property-Based Testing Library
+
+Use **fast-check** (`npm install --save-dev fast-check`), which is the standard PBT library for TypeScript/JavaScript.
+
+Each property test must run a minimum of **100 iterations** (fast-check default is 100; set `{ numRuns: 100 }` explicitly).
+
+Each property test must include a comment referencing the design property it validates:
+```
+// Feature: credential-dashboard, Property N: <property_text>
+```
+
+### Property Tests
+
+Each correctness property from the design maps to exactly one property-based test:
+
+**P1 — Status Derivation Correctness**
+```typescript
+// Feature: credential-dashboard, Property 1: Status derivation correctness
+fc.assert(fc.property(
+  fc.boolean(), fc.boolean(), fc.boolean(),
+  (revoked, expired, attested) => {
+    const status = deriveStatus(revoked, expired, attested);
+    if (revoked) return status === 'revoked';
+    if (expired) return status === 'expired';
+    if (attested) return status === 'attested';
+    return status === 'pending';
+  }
+), { numRuns: 100 });
+```
+
+**P2 — Card Count Matches Credential ID Count**
+Generate a random array of bigint IDs, mock `getCredential` to resolve for each, render `Dashboard`, and assert the number of rendered `CredentialCard` elements equals the array length.
+
+**P3 — Partial Failure Resilience**
+Generate a random array of IDs where a random subset throws on `getCredential`. Assert that the number of successfully rendered cards equals the number of non-throwing IDs, and the failing cards show inline errors.
+
+**P4 — Credential Card Required Fields**
+Generate random `Credential` objects (varying `credential_type`, `issuer`, `id`, `expires_at`). Render `CredentialCard` and assert the truncated ID, type label, and truncated issuer are present. When `expires_at` is non-null, assert the expiry date is present.
+
+**P5 — Attestor Address Truncation**
+Generate random strings of length ≥ 10. Assert `formatAddress(s) === s.slice(0,8) + '…' + s.slice(-6)`. For the DOM test, generate random `QuorumSlice` objects and assert each attestor element has `title === fullAddress`.
+
+**P6 — Slice Section Renders Role Labels, Count, Threshold**
+Generate random `QuorumSlice` objects (varying attestor count and threshold). Render the slice section and assert: each attestor's truncated address appears, each role label appears, the count and threshold values appear.
+
+**P7 — Aria-Label Contains Status**
+Generate random `CredCardData` objects with random statuses. Render `CredentialCard` and assert the status badge element's `aria-label` contains the expected status string.
+
+**P8 — EmptyState Displays Connected Address**
+Generate random Stellar address strings. Render `EmptyState` with each address and assert the address string appears in the rendered output.
+
+### Unit Tests
+
+Unit tests focus on specific examples, integration points, and edge cases not covered by property tests:
+
+- **WalletGate renders connect button** when `hasFreighter: true` (Req 1.2)
+- **WalletGate renders install prompt + freighter.app link** when `hasFreighter: false` (Req 1.5)
+- **Dashboard shows loading indicator** when `isInitializing: true` (Req 1.3)
+- **Dashboard shows wallet gate** when `address: null, isInitializing: false` (Req 1.1)
+- **Dashboard triggers fetch on address change** without page reload (Req 1.4)
+- **Dashboard shows loading spinner** while fetching credentials (Req 2.3)
+- **Dashboard shows error card with retry** when `getCredentialsBySubject` throws (Req 2.4)
+- **EmptyState renders** when credential list is empty (Req 5.1)
+- **EmptyState contains descriptive message** (Req 5.2)
+- **EmptyState contains "Request Credential Issuance" CTA** (Req 5.3)
+- **`getSlice` failure renders "Slice unavailable"** in slice section (Req 4.5)
+- **Zero attestors renders "No attestors assigned"** (Req 4.6)
+- **`is_attested` failure defaults to Pending** and logs to console (Req 3.6)
+- **`getSlice` is called** when a sliceId is present in localStorage (Req 4.1)
+- **`getCredentialsBySubject` is called** with the connected address (Req 2.1)
+
+### Test File Locations
+
+```
+frontend/src/
+  __tests__/
+    deriveStatus.test.ts          # P1 property test
+    formatAddress.test.ts         # P5 property test (pure function)
+    CredentialCard.test.tsx       # P4, P6, P7 property tests + unit tests
+    EmptyState.test.tsx           # P8 property test + unit tests
+    Dashboard.test.tsx            # P2, P3 property tests + unit tests
+    WalletGate.test.tsx           # unit tests
+```

--- a/.kiro/specs/credential-dashboard/requirements.md
+++ b/.kiro/specs/credential-dashboard/requirements.md
@@ -1,0 +1,98 @@
+# Requirements Document
+
+## Introduction
+
+The Credential Dashboard is the primary interface for engineers to view and manage their on-chain verifiable credentials issued via the QuorumProof Soroban smart contract system. The dashboard is wallet-gated (requires a connected Freighter wallet) and surfaces three key data domains: issued credentials, per-credential attestation status, and the quorum slice composition (attestor addresses and role labels) for each credential. Engineers with no credentials are shown an empty state with a call-to-action to request issuance.
+
+The feature integrates with the existing `frontend/` React/TypeScript application, reusing the `useFreighter` wallet hook, the `quorumProof` contract client (`get_credentials_by_subject`, `is_attested`, `get_slice`), and the existing routing setup in `App.tsx`.
+
+## Glossary
+
+- **Dashboard**: The `/dashboard` route and page component that is the main entry point for authenticated engineers.
+- **Wallet_Gate**: The access control mechanism that requires a connected Freighter wallet before credential data is fetched or displayed.
+- **Credential**: An on-chain record issued to an engineer's Stellar address, represented by the `Credential` struct from the `quorumProof` contract.
+- **Attestation_Status**: The computed state of a credential — one of `Attested`, `Pending`, or `Revoked` — derived from the `is_attested` and `revoked` fields.
+- **Quorum_Slice**: A named group of attestor addresses and their role labels, retrieved via `get_slice` from the `quorumProof` contract.
+- **Attestor**: A Stellar address that is a member of a Quorum_Slice and may sign credentials.
+- **Empty_State**: The UI shown when a connected wallet has zero credentials on-chain.
+- **CTA**: Call-to-action — a UI element prompting the engineer to request credential issuance.
+- **Freighter**: The Stellar browser wallet extension used for wallet connection.
+- **Dashboard_Page**: The React component rendered at the `/dashboard` route.
+- **Credential_Card**: A UI component that displays a single credential's summary, status, and quorum slice.
+- **Contract_Client**: The typed TypeScript wrappers in `frontend/src/lib/contracts/` that call Soroban RPC simulation endpoints.
+
+---
+
+## Requirements
+
+### Requirement 1: Wallet-Gated Route
+
+**User Story:** As an engineer, I want the dashboard to require a connected wallet, so that only my own credentials are displayed and no data is leaked to unauthenticated visitors.
+
+#### Acceptance Criteria
+
+1. WHEN a user navigates to `/dashboard` without a connected Freighter wallet, THE Dashboard_Page SHALL display a wallet connection prompt instead of credential data.
+2. WHEN a user navigates to `/dashboard` without a connected Freighter wallet, THE Dashboard_Page SHALL render a "Connect Wallet" button that invokes the Freighter connection flow.
+3. WHEN the Freighter wallet connection is initializing, THE Dashboard_Page SHALL display a loading indicator and SHALL NOT render credential data.
+4. WHEN a user successfully connects their Freighter wallet, THE Dashboard_Page SHALL begin fetching credentials for the connected address without requiring a page reload.
+5. IF the Freighter extension is not installed, THEN THE Dashboard_Page SHALL display a message directing the user to install Freighter and SHALL provide a link to `https://freighter.app`.
+
+---
+
+### Requirement 2: Fetch and Display Credentials
+
+**User Story:** As an engineer, I want to see all credentials issued to my wallet address, so that I have a complete view of my on-chain identity.
+
+#### Acceptance Criteria
+
+1. WHEN a wallet address is connected, THE Dashboard_Page SHALL call `get_credentials_by_subject` with the connected address to retrieve all credential IDs.
+2. WHEN credential IDs are retrieved, THE Dashboard_Page SHALL fetch the full `Credential` struct for each ID and render a Credential_Card per credential.
+3. WHILE credential data is being fetched, THE Dashboard_Page SHALL display a loading indicator in place of the credential grid.
+4. IF the `get_credentials_by_subject` call fails, THEN THE Dashboard_Page SHALL display an error message describing the failure and SHALL provide a retry action.
+5. IF a single credential fetch fails, THEN THE Dashboard_Page SHALL display an inline error on that Credential_Card and SHALL continue rendering successfully fetched credentials.
+6. THE Credential_Card SHALL display the credential ID (truncated to first 8 and last 6 characters), credential type label, issuer address (truncated), and issuance date.
+7. WHEN a credential has an expiration date, THE Credential_Card SHALL display the expiration date.
+
+---
+
+### Requirement 3: Attestation Status per Credential
+
+**User Story:** As an engineer, I want to see the attestation status of each credential, so that I know which credentials are verified, pending review, or revoked.
+
+#### Acceptance Criteria
+
+1. THE Dashboard_Page SHALL derive the Attestation_Status for each credential using the `revoked` field and the result of `is_attested`.
+2. WHEN a credential's `revoked` field is `true`, THE Credential_Card SHALL display the status as `Revoked` with a visually distinct indicator (red/error color).
+3. WHEN a credential is not revoked and `is_attested` returns `true`, THE Credential_Card SHALL display the status as `Attested` with a success indicator (green/success color).
+4. WHEN a credential is not revoked and `is_attested` returns `false`, THE Credential_Card SHALL display the status as `Pending` with a neutral indicator (yellow/warning color).
+5. THE Credential_Card SHALL expose the Attestation_Status via an `aria-label` attribute so screen readers can announce the status.
+6. IF the `is_attested` call fails for a credential, THEN THE Credential_Card SHALL display the status as `Pending` and SHALL log the error to the browser console.
+
+---
+
+### Requirement 4: Quorum Slice Composition
+
+**User Story:** As an engineer, I want to see the quorum slice members for each credential, so that I understand which institutions have attested or are expected to attest my credentials.
+
+#### Acceptance Criteria
+
+1. WHEN a Credential_Card is rendered, THE Dashboard_Page SHALL call `get_slice` to retrieve the Quorum_Slice associated with that credential.
+2. THE Credential_Card SHALL display each Attestor address in the Quorum_Slice, truncated to first 8 and last 6 characters, with the full address available on hover via a `title` attribute.
+3. WHERE a role label is available for an Attestor in the Quorum_Slice, THE Credential_Card SHALL display the role label alongside the attestor address.
+4. THE Credential_Card SHALL display the total count of attestors in the Quorum_Slice and the threshold required for attestation.
+5. IF the `get_slice` call fails for a credential, THEN THE Credential_Card SHALL display a "Slice unavailable" message in place of the attestor list and SHALL NOT block rendering of other credential data.
+6. WHEN the Quorum_Slice has zero attestors, THE Credential_Card SHALL display "No attestors assigned" in the slice section.
+
+---
+
+### Requirement 5: Empty State with CTA
+
+**User Story:** As an engineer with no issued credentials, I want to see a helpful empty state, so that I know my wallet is connected but I have no credentials yet and understand how to get one.
+
+#### Acceptance Criteria
+
+1. WHEN a connected wallet address has zero credentials returned by `get_credentials_by_subject`, THE Dashboard_Page SHALL display the Empty_State component instead of a credential grid.
+2. THE Empty_State SHALL include a descriptive message indicating that no credentials have been issued to the connected address.
+3. THE Empty_State SHALL include a CTA button or link labeled "Request Credential Issuance" that directs the engineer toward the issuance flow.
+4. THE Empty_State SHALL display the connected wallet address so the engineer can confirm the correct wallet is connected.
+5. THE Empty_State SHALL be visually distinct from the loading state and the error state so engineers can differentiate between "no credentials", "loading", and "error" conditions.

--- a/.kiro/specs/credential-dashboard/tasks.md
+++ b/.kiro/specs/credential-dashboard/tasks.md
@@ -1,0 +1,161 @@
+# Implementation Plan: Credential Dashboard
+
+## Overview
+
+Rewrite `Dashboard.tsx` with full `getSlice` support, decompose into `WalletGate`, `CredentialCard`, and `EmptyState` components, add `getSlice` to the contract clients, and cover all correctness properties with property-based and unit tests.
+
+## Tasks
+
+- [x] 1. Add `getSlice` to contract clients
+  - [x] 1.1 Add `getSlice(sliceId)` to `frontend/src/stellar.ts`
+    - Export `async function getSlice(sliceId)` using the existing `simulate` helper and `nativeToScVal(BigInt(sliceId), { type: 'u64' })`
+    - Return type is the `QuorumSlice` plain object `{ id, creator, attestors, threshold }`
+    - _Requirements: 4.1_
+  - [x] 1.2 Add `getSlice(sliceId: bigint | number): Promise<QuorumSlice>` to `frontend/src/lib/contracts/quorumProof.ts`
+    - Use the existing `simulate<QuorumSlice>` helper and `u64` encoder already in that file
+    - _Requirements: 4.1_
+
+- [x] 2. Create `WalletGate` component
+  - [x] 2.1 Create `frontend/src/components/WalletGate.tsx`
+    - Props: `{ hasFreighter: boolean; connect: () => Promise<void> }`
+    - When `hasFreighter` is true: render a "Connect Wallet" button that calls `connect()`
+    - When `hasFreighter` is false: render an install prompt with a link to `https://freighter.app`
+    - _Requirements: 1.1, 1.2, 1.5_
+  - [ ]* 2.2 Write unit tests for `WalletGate` in `frontend/src/__tests__/WalletGate.test.tsx`
+    - Test: renders connect button when `hasFreighter: true`
+    - Test: renders install prompt + freighter.app link when `hasFreighter: false`
+    - _Requirements: 1.2, 1.5_
+
+- [x] 3. Create `EmptyState` component
+  - [x] 3.1 Create `frontend/src/components/EmptyState.tsx`
+    - Props: `{ address: string }`
+    - Render: icon, descriptive message, connected address display, "Request Credential Issuance" CTA button/link
+    - Use `.empty-state` CSS class
+    - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5_
+  - [ ]* 3.2 Write property test P8 in `frontend/src/__tests__/EmptyState.test.tsx`
+    - **Property 8: EmptyState displays connected address**
+    - **Validates: Requirements 5.4**
+    - Generate random address strings; assert the address appears in rendered output
+    - `{ numRuns: 100 }`
+  - [ ]* 3.3 Write unit tests for `EmptyState` in `frontend/src/__tests__/EmptyState.test.tsx`
+    - Test: renders descriptive message (Req 5.2)
+    - Test: renders "Request Credential Issuance" CTA (Req 5.3)
+    - Test: visually distinct from loading/error states (Req 5.5)
+    - _Requirements: 5.1, 5.2, 5.3_
+
+- [x] 4. Implement pure utility functions and `deriveStatus`
+  - [x] 4.1 Create `frontend/src/lib/credentialUtils.ts` with exported pure functions
+    - `deriveStatus(revoked: boolean, expired: boolean, attested: boolean): AttestationStatus`
+    - `formatAddress(addr: string): string` — `addr.slice(0,8) + '…' + addr.slice(-6)` for length ≥ 10
+    - `attestorRole(index: number): string` — `ATTESTOR_ROLES[index] ?? \`Member ${index + 1}\``
+    - `credTypeLabel(n: number | bigint): string`
+    - `formatTimestamp(ts: number | bigint | null | undefined): string`
+    - Export `AttestationStatus` type and `ATTESTOR_ROLES` constant
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 4.2, 4.3_
+  - [ ]* 4.2 Write property test P1 in `frontend/src/__tests__/deriveStatus.test.ts`
+    - **Property 1: Status derivation correctness**
+    - **Validates: Requirements 3.1, 3.2, 3.3, 3.4**
+    - `fc.assert(fc.property(fc.boolean(), fc.boolean(), fc.boolean(), ...))`
+    - Assert priority: revoked > expired > attested > pending
+    - `{ numRuns: 100 }`
+  - [ ]* 4.3 Write property test P5 (pure function part) in `frontend/src/__tests__/formatAddress.test.ts`
+    - **Property 5: Attestor address truncation**
+    - **Validates: Requirements 4.2**
+    - Generate strings of length ≥ 10; assert result equals `s.slice(0,8) + '…' + s.slice(-6)`
+    - `{ numRuns: 100 }`
+
+- [x] 5. Create `CredentialCard` component
+  - [x] 5.1 Create `frontend/src/components/CredentialCard.tsx`
+    - Props: `{ data: CredCardData; sliceId: bigint | null }`
+    - Import `CredCardData` type and utility functions from `credentialUtils.ts`
+    - Header: credential type label + status badge with `aria-label` containing the status string
+    - Body: truncated credential ID, truncated issuer with `title` attribute, metadata, optional expiry
+    - Quorum slice section: if `data.sliceError` → "Slice unavailable"; if `data.slice` → attestor list with role labels, count, threshold; if no slice → "No slice data available"; if zero attestors → "No attestors assigned"
+    - Each attestor element: truncated address + `title={fullAddress}` + role label
+    - Footer: "View Public Page →" link to `/verify?credentialId=<id>`
+    - If `data.credError` is set: render inline error panel instead of body
+    - Use `.cred-card`, `.cred-card__header`, `.badge`, `.attestor-mini-list` CSS classes
+    - _Requirements: 2.6, 2.7, 3.2, 3.3, 3.4, 3.5, 4.2, 4.3, 4.4, 4.5, 4.6_
+  - [ ]* 5.2 Write property test P4 in `frontend/src/__tests__/CredentialCard.test.tsx`
+    - **Property 4: Credential card required fields**
+    - **Validates: Requirements 2.6, 2.7**
+    - Generate random `Credential` objects; assert truncated ID, type label, truncated issuer present; when `expires_at` non-null assert expiry date present
+    - `{ numRuns: 100 }`
+  - [ ]* 5.3 Write property test P5 (DOM part) in `frontend/src/__tests__/CredentialCard.test.tsx`
+    - **Property 5: Attestor address truncation with full address on hover**
+    - **Validates: Requirements 4.2**
+    - Generate random `QuorumSlice` objects; assert each attestor element has `title === fullAddress`
+    - `{ numRuns: 100 }`
+  - [ ]* 5.4 Write property test P6 in `frontend/src/__tests__/CredentialCard.test.tsx`
+    - **Property 6: Slice section renders role labels, count, and threshold**
+    - **Validates: Requirements 4.3, 4.4**
+    - Generate random `QuorumSlice` objects; assert role labels, count, and threshold appear
+    - `{ numRuns: 100 }`
+  - [ ]* 5.5 Write property test P7 in `frontend/src/__tests__/CredentialCard.test.tsx`
+    - **Property 7: Aria-label contains attestation status**
+    - **Validates: Requirements 3.5**
+    - Generate random `CredCardData` objects; assert status badge `aria-label` contains the status string
+    - `{ numRuns: 100 }`
+  - [ ]* 5.6 Write unit tests for `CredentialCard` in `frontend/src/__tests__/CredentialCard.test.tsx`
+    - Test: renders "Slice unavailable" when `sliceError: true` (Req 4.5)
+    - Test: renders "No attestors assigned" when slice has zero attestors (Req 4.6)
+    - Test: renders inline error panel when `credError` is set (Req 2.5)
+    - _Requirements: 2.5, 4.5, 4.6_
+
+- [ ] 6. Checkpoint — Ensure all component tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 7. Rewrite `Dashboard.tsx`
+  - [x] 7.1 Rewrite `frontend/src/pages/Dashboard.tsx`
+    - Import `useFreighter`, `WalletGate`, `CredentialCard`, `EmptyState` components
+    - Import `getCredentialsBySubject`, `getCredential`, `isAttested`, `getAttestors`, `getSlice`, `isExpired` from `stellar.ts`
+    - Import `deriveStatus` and `CredCardData` from `credentialUtils.ts`
+    - On mount: read `sliceId` from `localStorage.getItem('qp-slice-id')`
+    - On `address` change: fetch all credential IDs via `getCredentialsBySubject(address)`, then fetch each card's data in parallel using `Promise.allSettled` or per-card try/catch
+    - Per-card fetch: call `getCredential(id)`, `isExpired(id)`, and either `isAttested(id, sliceId)` + `getSlice(sliceId)` (when sliceId known) or `getAttestors(id)` fallback; catch `isAttested` failures → log + default `attested: false`; catch `getSlice` failures → `slice: null, sliceError: true`
+    - Render states: `isInitializing` → loading spinner; `!address && !isInitializing` → `<WalletGate>`; `loading` → loading spinner; `error` → error card with retry button; `cards.length === 0` → `<EmptyState address={address} />`; otherwise → `dashboard-grid` of `<CredentialCard>`s
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 2.5, 3.6, 4.1_
+  - [ ]* 7.2 Write property test P2 in `frontend/src/__tests__/Dashboard.test.tsx`
+    - **Property 2: Card count matches credential ID count**
+    - **Validates: Requirements 2.2**
+    - Generate random arrays of bigint IDs; mock `getCredential` to resolve for each; assert rendered card count equals ID array length
+    - `{ numRuns: 100 }`
+  - [ ]* 7.3 Write property test P3 in `frontend/src/__tests__/Dashboard.test.tsx`
+    - **Property 3: Partial failure resilience**
+    - **Validates: Requirements 2.5**
+    - Generate random ID arrays where a random subset throws on `getCredential`; assert successfully fetched cards render normally and failed cards show inline errors
+    - `{ numRuns: 100 }`
+  - [ ]* 7.4 Write unit tests for `Dashboard` in `frontend/src/__tests__/Dashboard.test.tsx`
+    - Test: shows loading indicator when `isInitializing: true` (Req 1.3)
+    - Test: shows `WalletGate` when `address: null, isInitializing: false` (Req 1.1)
+    - Test: triggers fetch on address change without page reload (Req 1.4)
+    - Test: shows loading spinner while fetching credentials (Req 2.3)
+    - Test: shows error card with retry when `getCredentialsBySubject` throws (Req 2.4)
+    - Test: renders `EmptyState` when credential list is empty (Req 5.1)
+    - Test: calls `getSlice` when sliceId present in localStorage (Req 4.1)
+    - Test: calls `getCredentialsBySubject` with connected address (Req 2.1)
+    - Test: `is_attested` failure defaults to Pending and logs to console (Req 3.6)
+    - _Requirements: 1.1, 1.3, 1.4, 2.1, 2.3, 2.4, 4.1, 5.1_
+
+- [x] 8. Update component exports
+  - [x] 8.1 Update `frontend/src/components/index.ts` to export `WalletGate`, `CredentialCard`, and `EmptyState`
+    - _Requirements: 1.1, 2.2, 5.1_
+
+- [x] 9. Verify `App.tsx` routing
+  - [x] 9.1 Confirm `/dashboard` route in `frontend/src/App.tsx` points to the rewritten `Dashboard` component
+    - No changes expected; verify the import path and route definition are correct
+    - _Requirements: 1.1_
+
+- [ ] 10. Final checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- `deriveStatus` priority: `revoked` > `expired` > `attested` > `pending`
+- Role labels are UI-layer only: `['Lead Verifier', 'Co-Verifier', 'Auditor', 'Reviewer', 'Observer']`
+- `isAttested` requires both `credentialId` and `sliceId` — fall back to `getAttestors(credId).length > 0` when no sliceId in localStorage
+- Slice ID stored in localStorage under key `qp-slice-id`
+- PBT library: fast-check (already in devDependencies); test runner: vitest (already configured)
+- Each property test must include comment: `// Feature: credential-dashboard, Property N: <property_text>`
+- Each property test must set `{ numRuns: 100 }` explicitly

--- a/frontend/src/components/CredentialCard.tsx
+++ b/frontend/src/components/CredentialCard.tsx
@@ -1,0 +1,135 @@
+import { Link } from 'react-router-dom';
+import {
+  type CredCardData,
+  deriveStatus,
+  formatAddress,
+  attestorRole,
+  credTypeLabel,
+  formatTimestamp,
+} from '../lib/credentialUtils';
+import { decodeMetadataHash } from '../stellar';
+
+interface CredentialCardProps {
+  data: CredCardData;
+  sliceId: bigint | null;
+}
+
+const STATUS_CONFIG = {
+  attested: { label: 'Attested', icon: '✅', badgeClass: 'badge--green' },
+  pending:  { label: 'Pending',  icon: '⏳', badgeClass: 'badge--blue'  },
+  revoked:  { label: 'Revoked',  icon: '🚫', badgeClass: 'badge--red'   },
+  expired:  { label: 'Expired',  icon: '⏰', badgeClass: 'badge--gray'  },
+};
+
+export function CredentialCard({ data, sliceId }: CredentialCardProps) {
+  const { credential, attested, slice, expired, sliceError, credError } = data;
+
+  const status = deriveStatus(credential.revoked, expired, attested);
+  const { label, icon, badgeClass } = STATUS_CONFIG[status];
+  const metaStr = decodeMetadataHash(credential.metadata_hash);
+  const idStr = credential.id.toString();
+
+  return (
+    <div className="cred-card">
+      {/* Header */}
+      <div className={`cred-card__header cred-card__header--${status}`}>
+        <div className="cred-card__type">{credTypeLabel(credential.credential_type)}</div>
+        <div
+          className={`badge ${badgeClass}`}
+          aria-label={`Attestation status: ${label}`}
+        >
+          {icon} {label}
+        </div>
+      </div>
+
+      {/* Body */}
+      {credError ? (
+        <div className="cred-card__body cred-card__body--error">
+          <div style={{ fontSize: '24px', marginBottom: '8px' }}>⚠️</div>
+          <div style={{ color: 'var(--red)', fontSize: '13px' }}>Failed to load</div>
+          <div style={{ color: 'var(--text-muted)', fontSize: '11px', marginTop: '4px' }}>
+            {credError}
+          </div>
+        </div>
+      ) : (
+        <div className="cred-card__body">
+          <h3 className="cred-card__id">
+            Credential #{idStr.length > 14 ? idStr.slice(0, 8) + '…' + idStr.slice(-6) : idStr}
+          </h3>
+
+          <div className="cred-card__meta">
+            <div className="meta-row">
+              <span className="meta-label">Issuer</span>
+              <span className="meta-value mono" title={credential.issuer}>
+                {formatAddress(credential.issuer)}
+              </span>
+            </div>
+            <div className="meta-row">
+              <span className="meta-label">Metadata</span>
+              <span className="meta-value mono">{metaStr || '—'}</span>
+            </div>
+            {credential.expires_at && (
+              <div className="meta-row">
+                <span className="meta-label">Expires</span>
+                <span className="meta-value">{formatTimestamp(credential.expires_at)}</span>
+              </div>
+            )}
+            {sliceId && (
+              <div className="meta-row">
+                <span className="meta-label">Slice</span>
+                <span className="meta-value mono">#{sliceId.toString()}</span>
+              </div>
+            )}
+          </div>
+
+          {/* Quorum Slice Section */}
+          <div className="cred-card__attestors">
+            <div className="attestors-header">
+              <span className="meta-label">Quorum Slice</span>
+              {slice && (
+                <span className="badge badge--gray" style={{ fontSize: '10px' }}>
+                  {slice.attestors.length}/{slice.threshold} threshold
+                </span>
+              )}
+            </div>
+
+            {sliceError ? (
+              <div className="attestors-empty">Slice unavailable</div>
+            ) : !slice ? (
+              <div className="attestors-empty">No slice data available</div>
+            ) : slice.attestors.length === 0 ? (
+              <div className="attestors-empty">No attestors assigned</div>
+            ) : (
+              <div className="attestor-mini-list">
+                {slice.attestors.map((addr, i) => (
+                  <div key={addr} className="attestor-mini-item">
+                    <span className="attestor-mini-item__avatar">{i + 1}</span>
+                    <div className="attestor-mini-item__info">
+                      <span className="mono" title={addr}>
+                        {formatAddress(addr)}
+                      </span>
+                      <span className="attestor-mini-item__role">
+                        {attestorRole(i)}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Footer */}
+      <div className="cred-card__footer">
+        <Link
+          to={`/verify?credentialId=${credential.id}`}
+          className="btn btn--sm btn--ghost"
+          style={{ width: '100%', textAlign: 'center' }}
+        >
+          View Public Page →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,34 @@
+interface EmptyStateProps {
+  address: string;
+}
+
+export function EmptyState({ address }: EmptyStateProps) {
+  return (
+    <div className="empty-state empty-state--dashboard">
+      <div className="empty-state__icon">📭</div>
+      <div className="empty-state__title">No credentials yet</div>
+      <p className="empty-state__body">
+        No credentials have been issued to this address. Request issuance from a
+        trusted institution to get started.
+      </p>
+      <div className="empty-state__address">
+        <span className="meta-label">Connected address</span>
+        <span className="mono" style={{ fontSize: '12px', wordBreak: 'break-all' }}>
+          {address}
+        </span>
+      </div>
+      <div className="empty-state__actions">
+        <button
+          className="btn btn--primary"
+          onClick={() =>
+            alert(
+              'Credential issuance request flow coming soon.\nContact your institution with your Stellar address.'
+            )
+          }
+        >
+          ✦ Request Credential Issuance
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/WalletGate.tsx
+++ b/frontend/src/components/WalletGate.tsx
@@ -1,0 +1,38 @@
+interface WalletGateProps {
+  hasFreighter: boolean;
+  connect: () => Promise<void>;
+}
+
+export function WalletGate({ hasFreighter, connect }: WalletGateProps) {
+  return (
+    <div className="wallet-guard-card">
+      <div className="wallet-guard__icon">🔐</div>
+      <h2 className="wallet-guard__title">Connect Your Wallet</h2>
+
+      {hasFreighter ? (
+        <>
+          <p className="wallet-guard__sub">
+            Connect your Freighter wallet to view your credentials.
+          </p>
+          <button className="btn btn--primary" onClick={connect}>
+            Connect Wallet
+          </button>
+        </>
+      ) : (
+        <>
+          <p className="wallet-guard__sub">
+            Freighter wallet extension is required to use this dashboard.
+          </p>
+          <a
+            href="https://freighter.app"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn btn--primary"
+          >
+            Install Freighter
+          </a>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,0 +1,5 @@
+export { WalletGate } from './WalletGate';
+export { CredentialCard } from './CredentialCard';
+export { EmptyState } from './EmptyState';
+export { Navbar } from './Navbar';
+export { AppLayout } from './AppLayout';

--- a/frontend/src/lib/contracts/quorumProof.ts
+++ b/frontend/src/lib/contracts/quorumProof.ts
@@ -190,3 +190,8 @@ export async function getCredentialsBySubject(subject: string): Promise<bigint[]
 export async function isExpired(credentialId: bigint | number): Promise<boolean> {
   return simulate<boolean>('is_expired', [u64(credentialId)]);
 }
+
+/** Retrieve a quorum slice by ID. Returns { id, creator, attestors, threshold }. */
+export async function getSlice(sliceId: bigint | number): Promise<QuorumSlice> {
+  return simulate<QuorumSlice>('get_slice', [u64(sliceId)]);
+}

--- a/frontend/src/lib/credentialUtils.ts
+++ b/frontend/src/lib/credentialUtils.ts
@@ -1,0 +1,68 @@
+import type { Credential, QuorumSlice } from './contracts/quorumProof';
+
+export type AttestationStatus = 'attested' | 'pending' | 'revoked' | 'expired';
+
+export interface CredCardData {
+  credential: Credential;
+  attested: boolean;
+  slice: QuorumSlice | null;
+  expired: boolean;
+  sliceError: boolean;
+  credError: string | null;
+}
+
+export const CREDENTIAL_TYPES: Record<number, string> = {
+  1: '🎓 Degree',
+  2: '🏛️ License',
+  3: '💼 Employment',
+  4: '📜 Certification',
+  5: '🔬 Research',
+};
+
+export const ATTESTOR_ROLES = [
+  'Lead Verifier',
+  'Co-Verifier',
+  'Auditor',
+  'Reviewer',
+  'Observer',
+];
+
+/** Derive attestation status with priority: revoked > expired > attested > pending */
+export function deriveStatus(
+  revoked: boolean,
+  expired: boolean,
+  attested: boolean
+): AttestationStatus {
+  if (revoked) return 'revoked';
+  if (expired) return 'expired';
+  if (attested) return 'attested';
+  return 'pending';
+}
+
+/** Truncate a Stellar address to first 8 + last 6 chars */
+export function formatAddress(addr: string): string {
+  if (!addr || addr.length < 10) return addr || '—';
+  return addr.slice(0, 8) + '…' + addr.slice(-6);
+}
+
+/** Get role label for an attestor by index */
+export function attestorRole(index: number): string {
+  return ATTESTOR_ROLES[index] ?? `Member ${index + 1}`;
+}
+
+/** Get human-readable credential type label */
+export function credTypeLabel(n: number | bigint): string {
+  return CREDENTIAL_TYPES[Number(n)] || `Type ${n}`;
+}
+
+/** Format a Unix timestamp (seconds) to a readable date string */
+export function formatTimestamp(
+  ts: number | bigint | null | undefined
+): string {
+  if (!ts) return 'Never';
+  return new Date(Number(ts) * 1000).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,166 +1,109 @@
-import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState, useEffect, useCallback } from 'react';
 import { Navbar } from '../components/Navbar';
+import { WalletGate } from '../components/WalletGate';
+import { CredentialCard } from '../components/CredentialCard';
+import { EmptyState } from '../components/EmptyState';
 import { useFreighter } from '../lib/hooks/useFreighter';
 import {
   getCredentialsBySubject,
   getCredential,
-  isExpired,
+  isAttested,
   getAttestors,
-  decodeMetadataHash,
+  getSlice,
+  isExpired,
 } from '../stellar';
-
-const CREDENTIAL_TYPES: Record<number, string> = {
-  1: '🎓 Degree',
-  2: '🏛️ License',
-  3: '💼 Employment',
-  4: '📜 Certification',
-  5: '🔬 Research',
-};
-
-function credTypeLabel(n: number | bigint) {
-  return CREDENTIAL_TYPES[Number(n)] || `Type ${n}`;
-}
-
-function formatTimestamp(ts: number | bigint | null | undefined) {
-  if (!ts) return 'Never';
-  const d = new Date(Number(ts) * 1000);
-  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
-}
-
-function formatAddress(addr: string) {
-  if (!addr || addr.length < 10) return addr || '—';
-  return addr.slice(0, 8) + '…' + addr.slice(-6);
-}
-
-interface CredentialData {
-  id: bigint;
-  subject: string;
-  issuer: string;
-  credential_type: number;
-  metadata_hash: Uint8Array;
-  revoked: boolean;
-  expires_at: bigint | null;
-}
-
-interface CredCard {
-  credential: CredentialData;
-  attestors: string[];
-  expired: boolean;
-}
-
-function CredentialCard({ card }: { card: CredCard }) {
-  const navigate = useNavigate();
-  const { credential, attestors, expired } = card;
-  const metaStr = decodeMetadataHash(credential.metadata_hash);
-
-  let statusClass: string, statusLabel: string, statusIcon: string;
-  if (credential.revoked) {
-    statusClass = 'revoked'; statusIcon = '🚫'; statusLabel = 'Revoked';
-  } else if (expired) {
-    statusClass = 'expired'; statusIcon = '⏰'; statusLabel = 'Expired';
-  } else if (attestors.length === 0) {
-    statusClass = 'pending'; statusIcon = '⏳'; statusLabel = 'Pending Attestation';
-  } else {
-    statusClass = 'valid'; statusIcon = '✅'; statusLabel = 'Attested';
-  }
-
-  return (
-    <div className="cred-card">
-      <div className={`cred-card__header cred-card__header--${statusClass}`}>
-        <div className="cred-card__type">{credTypeLabel(credential.credential_type)}</div>
-        <div className={`badge badge--${statusClass}`}>{statusIcon} {statusLabel}</div>
-      </div>
-      <div className="cred-card__body">
-        <h3 className="cred-card__id">Credential #{credential.id.toString()}</h3>
-        <div className="cred-card__meta">
-          <div className="meta-row">
-            <span className="meta-label">Issuer</span>
-            <span className="meta-value mono" title={credential.issuer}>{formatAddress(credential.issuer)}</span>
-          </div>
-          <div className="meta-row">
-            <span className="meta-label">Metadata</span>
-            <span className="meta-value mono">{metaStr}</span>
-          </div>
-          {credential.expires_at && (
-            <div className="meta-row">
-              <span className="meta-label">Expires</span>
-              <span className="meta-value">{formatTimestamp(credential.expires_at)}</span>
-            </div>
-          )}
-        </div>
-        <div className="cred-card__attestors">
-          <div className="attestors-header">
-            <span className="meta-label">Quorum Slice Attestors</span>
-            <span className={`badge badge--${attestors.length > 0 ? 'gray' : 'red'}`} style={{ fontSize: '10px' }}>
-              {attestors.length} Node{attestors.length !== 1 ? 's' : ''}
-            </span>
-          </div>
-          {attestors.length === 0 ? (
-            <div className="attestors-empty">Awaiting slice signatures</div>
-          ) : (
-            <div className="attestor-mini-list">
-              {attestors.map((addr) => (
-                <div key={addr} className="attestor-mini-item">
-                  <span>🏛️</span>
-                  <span className="mono" title={addr}>{formatAddress(addr)}</span>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
-      <div className="cred-card__footer">
-        <button
-          className="btn btn--sm btn--ghost"
-          style={{ width: '100%' }}
-          onClick={() => navigate(`/verify?credentialId=${credential.id}`)}
-        >
-          View Public Page →
-        </button>
-      </div>
-    </div>
-  );
-}
+import { type CredCardData } from '../lib/credentialUtils';
 
 export function Dashboard() {
-  const { address, isInitializing, connect } = useFreighter();
-  const [cards, setCards] = useState<CredCard[]>([]);
+  const { address, hasFreighter, isInitializing, connect, disconnect } = useFreighter();
+  const [cards, setCards] = useState<CredCardData[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [retryKey, setRetryKey] = useState(0);
+
+  const fetchCredentials = useCallback(async (walletAddress: string) => {
+    setLoading(true);
+    setError(null);
+    setCards([]);
+
+    const sliceIdRaw = localStorage.getItem('qp-slice-id');
+    const sliceId = sliceIdRaw ? BigInt(sliceIdRaw) : null;
+
+    try {
+      const ids: bigint[] = await getCredentialsBySubject(walletAddress);
+
+      if (!ids || ids.length === 0) {
+        setCards([]);
+        return;
+      }
+
+      const results = await Promise.all(
+        ids.map(async (id): Promise<CredCardData> => {
+          try {
+            const [credential, expired] = await Promise.all([
+              getCredential(id),
+              isExpired(id).catch(() => false),
+            ]);
+
+            let attested = false;
+            let slice = null;
+            let sliceError = false;
+
+            if (sliceId !== null) {
+              attested = await isAttested(id, sliceId).catch((err) => {
+                console.error(`isAttested failed for credential ${id}:`, err);
+                return false;
+              });
+              try {
+                slice = await getSlice(sliceId);
+              } catch (err) {
+                console.error(`getSlice failed for slice ${sliceId}:`, err);
+                sliceError = true;
+              }
+            } else {
+              const attestors: string[] = await getAttestors(id).catch(() => []);
+              attested = attestors.length > 0;
+            }
+
+            return { credential, attested, slice, expired, sliceError, credError: null };
+          } catch (err) {
+            // Per-card error — return a placeholder so the grid still renders
+            const msg = err instanceof Error ? err.message : 'Failed to load credential';
+            return {
+              credential: {
+                id,
+                subject: '',
+                issuer: '',
+                credential_type: 0,
+                metadata_hash: new Uint8Array(),
+                revoked: false,
+                expires_at: null,
+              },
+              attested: false,
+              slice: null,
+              expired: false,
+              sliceError: false,
+              credError: msg,
+            };
+          }
+        })
+      );
+
+      setCards(results);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load credentials.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
     if (!address) return;
-    setLoading(true);
-    setError(null);
+    fetchCredentials(address);
+  }, [address, retryKey, fetchCredentials]);
 
-    const fetchAll = async () => {
-      try {
-        const ids: bigint[] = await getCredentialsBySubject(address);
-        if (!ids || ids.length === 0) {
-          setCards([]);
-          return;
-        }
-        const results = await Promise.all(
-          ids.map(async (id) => {
-            const [credential, attestors, expired] = await Promise.all([
-              getCredential(id),
-              getAttestors(id),
-              isExpired(id).catch(() => false),
-            ]);
-            return { credential, attestors, expired } as CredCard;
-          })
-        );
-        setCards(results);
-      } catch (err: unknown) {
-        setError(err instanceof Error ? err.message : 'Failed to load credentials.');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchAll();
-  }, [address]);
+  const sliceIdRaw = localStorage.getItem('qp-slice-id');
+  const sliceId = sliceIdRaw ? BigInt(sliceIdRaw) : null;
 
   return (
     <>
@@ -169,33 +112,27 @@ export function Dashboard() {
         <header className="dashboard-header">
           <div>
             <h1 className="dashboard-title">Credential Dashboard</h1>
-            <p className="dashboard-subtitle">Manage and track your verifiable credentials</p>
+            <p className="dashboard-subtitle">Your verifiable credentials on Stellar Soroban</p>
           </div>
-
-          {/* Wallet state */}
-          {!isInitializing && !address && (
-            <div className="wallet-sim-card">
-              <div className="wallet-sim__label">Connect your Freighter wallet to view credentials</div>
-              <button className="btn btn--primary" onClick={connect}>Connect Wallet</button>
-            </div>
-          )}
           {address && (
             <div className="wallet-sim-card">
               <div className="wallet-sim__label">Connected Address</div>
-              <div className="mono" style={{ fontSize: '13px', wordBreak: 'break-all' }}>{address}</div>
+              <div className="mono" style={{ fontSize: '12px', wordBreak: 'break-all' }}>
+                {address}
+              </div>
+              <button
+                className="btn btn--ghost btn--sm"
+                style={{ marginTop: '8px' }}
+                onClick={disconnect}
+              >
+                Disconnect
+              </button>
             </div>
           )}
         </header>
 
         <div className="dashboard-content">
-          {!address && !isInitializing && (
-            <div className="empty-state">
-              <div className="empty-state__icon">👛</div>
-              <div className="empty-state__title">No wallet connected</div>
-              <p>Connect your Freighter wallet to view your credentials.</p>
-            </div>
-          )}
-
+          {/* Wallet initializing */}
           {isInitializing && (
             <div className="loading-state">
               <div className="spinner" />
@@ -203,6 +140,12 @@ export function Dashboard() {
             </div>
           )}
 
+          {/* No wallet connected */}
+          {!isInitializing && !address && (
+            <WalletGate hasFreighter={hasFreighter} connect={connect} />
+          )}
+
+          {/* Loading credentials */}
           {address && loading && (
             <div className="loading-state">
               <div className="spinner" />
@@ -210,38 +153,58 @@ export function Dashboard() {
             </div>
           )}
 
+          {/* Top-level fetch error */}
           {address && !loading && error && (
             <div className="error-card">
               <div className="error-card__icon">⚠️</div>
               <div>
                 <div className="error-card__title">Could Not Load Credentials</div>
                 <div className="error-card__msg">{error}</div>
+                <button
+                  className="btn btn--ghost btn--sm"
+                  style={{ marginTop: '12px' }}
+                  onClick={() => setRetryKey((k: number) => k + 1)}
+                >
+                  Retry
+                </button>
               </div>
             </div>
           )}
 
+          {/* Empty state */}
           {address && !loading && !error && cards.length === 0 && (
-            <div className="empty-state" style={{ marginTop: 48, border: '1px dashed var(--border)', borderRadius: 'var(--radius-lg)' }}>
-              <div className="empty-state__icon">📭</div>
-              <div className="empty-state__title">No credentials found</div>
-              <p>You haven't been issued any credentials yet.</p>
-            </div>
+            <EmptyState address={address} />
           )}
 
-          {cards.length > 0 && (
+          {/* Credential grid */}
+          {address && !loading && !error && cards.length > 0 && (
             <div className="dashboard-grid">
-              {cards.map((card) => (
-                <CredentialCard key={card.credential.id.toString()} card={card} />
+              {cards.map((card: CredCardData) => (
+                <CredentialCard
+                  key={card.credential.id.toString()}
+                  data={card}
+                  sliceId={sliceId}
+                />
               ))}
             </div>
           )}
         </div>
       </main>
+
       <footer className="footer">
         <div className="container">
-          Powered by <a href="https://stellar.org" target="_blank" rel="noopener">Stellar Soroban</a>
-          {' · '}
-          <a href="https://github.com/Phantomcall/QuorumProof" target="_blank" rel="noopener">QuorumProof</a>
+          Powered by{' '}
+          <a href="https://stellar.org" target="_blank" rel="noopener">
+            Stellar Soroban
+          </a>{' '}
+          ·{' '}
+          <a
+            href="https://github.com/Phantomcall/QuorumProof"
+            target="_blank"
+            rel="noopener"
+          >
+            QuorumProof
+          </a>
         </div>
       </footer>
     </>

--- a/frontend/src/stellar.ts
+++ b/frontend/src/stellar.ts
@@ -137,6 +137,16 @@ export async function isExpired(credentialId) {
 }
 
 /**
+ * Retrieve a quorum slice by ID.
+ * Returns the QuorumSlice struct: { id, creator, attestors, threshold }
+ * @returns {Promise<{id: bigint, creator: string, attestors: string[], threshold: number}>}
+ */
+export async function getSlice(sliceId) {
+  const sliceVal = nativeToScVal(BigInt(sliceId), { type: 'u64' });
+  return simulate(CONTRACT_ID, 'get_slice', [sliceVal]);
+}
+
+/**
  * Verify a ZK claim against the ZK verifier contract.
  * @param {number|string} credentialId
  * @param {string} claimType  e.g. "has_degree"


### PR DESCRIPTION
feat: Credential Dashboard — wallet-gated credential viewer with attestation status and quorum slice composition

Summary
Builds the main dashboard page at /dashboard where engineers can view all their on-chain verifiable credentials, their attestation status, and the quorum slice composition for each credential. The page is wallet-gated via Freighter and integrates with the QuorumProof Soroban smart contract.

What Changed
New files

WalletGate.tsx
 — wallet connection gate; shows "Connect Wallet" button when Freighter is installed, or an install prompt linking to https://freighter.app when it isn't
CredentialCard.tsx
 — per-credential card displaying type, truncated ID/issuer, attestation status badge with aria-label, quorum slice attestors with role labels, threshold count, and a "View Public Page" link
EmptyState.tsx
 — empty state shown when a connected wallet has no credentials; displays the connected address and a "Request Credential Issuance" CTA
index.ts
 — barrel export for all components
credentialUtils.ts
 — pure utility functions: deriveStatus, formatAddress, attestorRole, credTypeLabel, formatTimestamp, and the CredCardData / AttestationStatus types
Modified files

Dashboard.tsx
 — full rewrite; wallet-gated data fetching, parallel per-card loading, per-card error isolation, retry on top-level failure, and all render states (initializing / no wallet / loading / error / empty / grid)
stellar.ts
 — added getSlice(sliceId) (was missing)
quorumProof.ts
 — added typed getSlice(sliceId: bigint | number): Promise<QuorumSlice>
Key Design Decisions
Slice ID association — the Credential struct has no slice_id field on-chain. The dashboard reads an optional qp-slice-id from localStorage. When present it calls isAttested(credId, sliceId) + getSlice(sliceId) for full attestation and slice data. When absent it falls back to getAttestors(credId).length > 0 as an attestation proxy and shows "No slice data available" in the slice section.

Attestation status priority — revoked > expired > attested > pending. Derived by deriveStatus(revoked, expired, attested) in credentialUtils.ts.

Role labels are UI-layer only — the on-chain QuorumSlice struct has no role label field. Labels are assigned by attestor index: ['Lead Verifier', 'Co-Verifier', 'Auditor', 'Reviewer', 'Observer'].

Per-card error isolation — individual credential fetch failures do not crash the grid. Failed cards render an inline error panel while successfully fetched cards render normally.

isAttested failure handling — if the RPC call throws, the error is logged to console.error and attested defaults to false, resulting in Pending status. This prevents a single RPC failure from blocking the card render.

Behaviour by State
State	What renders
Freighter initializing	Loading spinner
No wallet connected	WalletGate — connect button or install prompt
Fetching credentials	Loading spinner
Top-level fetch error	Error card with Retry button
Wallet connected, zero credentials	EmptyState with address + CTA
Credentials loaded	Grid of CredentialCard components
Files Changed
frontend/src/
  components/
    CredentialCard.tsx       (new)
    EmptyState.tsx           (new)
    WalletGate.tsx           (new)
    index.ts                 (new)
  lib/
    credentialUtils.ts       (new)
    contracts/
      quorumProof.ts         (modified — added getSlice)
  pages/
    Dashboard.tsx            (rewritten)
  stellar.ts                 (modified — added getSlice)
.kiro/specs/credential-dashboard/
  requirements.md            (new)
  design.md                  (new)
  tasks.md                   (new)
Testing
The optional PBT tasks (P1–P8 with fast-check) are scaffolded in the spec but not implemented in this PR to keep scope focused. The implementation is structured to make them straightforward to add — deriveStatus, formatAddress, and attestorRole are all pure exported functions in credentialUtils.ts.

To run the app locally:



cd frontend
pnpm dev

Closes #79 