### PR TITLE
Fix #168: Add test for get_slice not found with SliceNotFound error

### DIFF
--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -1127,6 +1127,16 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "SliceNotFound")]
+    fn test_get_slice_not_found() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        // Try to get a slice that doesn't exist
+        client.get_slice(&999u64);
+    }
+
+    #[test]
     #[should_panic(expected = "unauthorized")]
     fn test_pause_unauthorized_panics() {
         let env = Env::default();


### PR DESCRIPTION
## Description
This PR adds a test for the \`get_slice\` function to ensure it properly returns \`ContractError::SliceNotFound\` when attempting to retrieve a non-existent slice.

## Type of Change
- ✅ Bug fix (test addition for existing fix)

## Issue
Closes: #168

## Changes Made
- Added \`test_get_slice_not_found\` test that verifies \`get_slice\` panics with \`SliceNotFound\` error when given a non-existent slice ID

## Testing
- The test uses \`#[should_panic(expected = \"SliceNotFound\")]\` to verify the correct error is returned
- Note: Tests were not run as per task requirements

## Notes
- The \`get_slice\` function already uses \`panic_with_error!(&env, ContractError::SliceNotFound)\` (line 383)
- A test snapshot already existed at \`test_snapshots/tests/test_get_slice_not_found.1.json\` but the corresponding test function was missing" --base main