### PR TITLE
Fix/credential expiry check in revoke

### DIFF
--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -311,12 +311,19 @@ impl QuorumProofContract {
     }
 
     /// Revoke a credential. Only the original issuer can revoke.
+    /// Panics with "credential has expired" if the credential is expired.
     pub fn revoke_credential(env: Env, issuer: Address, credential_id: u64) {
         issuer.require_auth();
         Self::require_not_paused(&env);
         let mut credential: Credential = env.storage().instance().get(&DataKey::Credential(credential_id)).expect("credential not found");
         assert!(issuer == credential.issuer, "only the original issuer can revoke");
         assert!(!credential.revoked, "credential already revoked");
+        if let Some(expires_at) = credential.expires_at {
+            assert!(
+                env.ledger().timestamp() < expires_at,
+                "credential has expired"
+            );
+        }
         credential.revoked = true;
         env.storage()
             .instance()


### PR DESCRIPTION
"## Summary
This PR fixes issue #169 by adding a credential expiry check to the `revoke_credential` function.

## Problem
The `credential.expires_at` field was only being checked in `get_credential` and `is_attested`, but NOT in `revoke_credential`. This meant expired credentials could still be revoked, which is inconsistent behavior.

## Solution
Added expiry validation to `revoke_credential` following the same pattern used in `get_credential`. Now when attempting to revoke an expired credential, it will panic with the message \"credential has expired\".

## Changes
- [`contracts/quorum_proof/src/lib.rs`](contracts/quorum_proof/src/lib.rs:314): Added expiry check in `revoke_credential` function that asserts `env.ledger().timestamp() < expires_at` when the credential has an expiry set.

## Verification
- The fix follows the same pattern as `get_credential` which also uses `assert!` to panic with \"credential has expired\"
- `is_attested` uses a different pattern (returning `false`) as it needs to gracefully handle expired credentials for quorum validation
- `revoke_credential` should prevent revoking expired credentials as it doesn't make logical sense to revoke a credential that has already expired" 

closes #169 