### PR TITLE
fix: resolve smart contract bugs in quorum_proof tests

### DIFF
--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -1228,12 +1228,13 @@ mod tests {
         let id = client.issue_credential(&issuer, &subject, &1u32, &metadata, &None);
 
         env.ledger().set(LedgerInfo {
-            timestamp: ts,
+            timestamp: 1_000,
             protocol_version: 20,
             sequence_number: 100,
             network_id: Default::default(),
             base_reserve: 10,
             min_persistent_entry_ttl: 4096,
+            min_temp_entry_ttl: 16,
             max_entry_ttl: 6_312_000,
         });
 
@@ -1446,17 +1447,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "only subject or issuer can revoke")]
-    fn test_unauthorized_revoke_credential() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (client, _) = setup(&env);
-        let issuer = Address::generate(&env);
-        let subject = Address::generate(&env);
-        client.issue_credential(&issuer, &subject, &1u32, &Bytes::new(&env), &None);
-    }
-
-    #[test]
     #[should_panic]
     fn test_pause_blocks_attest() {
         let env = Env::default();
@@ -1499,12 +1489,8 @@ mod tests {
         let creator = Address::generate(&env);
         let slice_id = client.create_slice(&creator, &attestors, &weights, &1u32);
 
-        client.pause(&admin);
-        client.attest(&attestor, &cred_id, &slice_id);
-        client.attest(&attestor1, &cred_id, &slice_id);
-        client.attest(&attestor1, &cred_id, &slice_id);
         assert!(!client.is_attested(&cred_id, &slice_id));
-        client.attest(&attestor2, &cred_id, &slice_id);
+        client.attest(&attestor, &cred_id, &slice_id);
         assert!(client.is_attested(&cred_id, &slice_id));
     }
 
@@ -1539,6 +1525,14 @@ mod tests {
         let attestor = Address::generate(&env);
         let metadata = Bytes::from_slice(&env, b"ipfs://QmTest");
         let id = client.issue_credential(&issuer, &subject, &1u32, &metadata, &None);
+        let mut attestors = Vec::new(&env);
+        attestors.push_back(attestor.clone());
+        let mut weights = Vec::new(&env);
+        weights.push_back(1u32);
+        let slice_id = client.create_slice(&issuer, &attestors, &weights, &1u32);
+        client.revoke_credential(&issuer, &id);
+        client.attest(&attestor, &id, &slice_id);
+    }
 
     // --- slice management ---
 
@@ -1821,28 +1815,6 @@ mod tests {
     }
 
     // --- batch issue ---
-
-    #[test]
-    #[should_panic(expected = "credential is revoked")]
-    fn test_attest_revoked_credential_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (client, _) = setup(&env);
-        let issuer = Address::generate(&env);
-        let subject = Address::generate(&env);
-        let attestor = Address::generate(&env);
-        let metadata = Bytes::from_slice(&env, b"ipfs://QmTest");
-
-        let cred_id = client.issue_credential(&issuer, &subject, &1u32, &metadata, &None);
-        let mut attestors = Vec::new(&env);
-        attestors.push_back(attestor.clone());
-        let mut weights = Vec::new(&env);
-        weights.push_back(1u32);
-        let slice_id = client.create_slice(&issuer, &attestors, &weights, &1u32);
-
-        client.revoke_credential(&issuer, &cred_id);
-        client.attest(&attestor, &cred_id, &slice_id);
-    }
 
     #[test]
     fn test_add_attestor_success() {
@@ -2357,7 +2329,6 @@ mod tests {
         // Attempting to attest a revoked credential must panic
         client.attest(&attestor, &cred_id, &slice_id);
     }
-}
 
     #[test]
     fn test_get_attestation_count() {
@@ -2508,7 +2479,6 @@ mod tests {
         // Unauthorized address should not be able to revoke
         client.revoke_credential(&unauthorized, &id);
     }
-}
 
     // Issue #48: Full Credential Lifecycle End-to-End
     #[test]


### PR DESCRIPTION
closes #212 
closes #213 
closes #214 
closes #215 

fix(quorum_proof): resolve compile errors and test bugs in lib.rs

## Problems Fixed

### 1. test_storage_persists_across_ledgers — compile error
- `timestamp: ts` referenced an undefined variable `ts`
- `LedgerInfo` struct was missing the required `min_temp_entry_ttl` field
- Fixed by using a concrete timestamp value (1_000) and adding the missing field

### 2. test_quorum_slice_and_attestation — compile error + dead code
- Referenced undefined variables: `admin`, `attestor1`, `attestor2`
- Called `client.pause(&admin)` which is unrelated to the test intent
- Multiple attest calls on undefined variables were dead code / compile errors
- Fixed by removing all invalid calls and consolidating to a single
  `attest` + `is_attested` assertion using the already-defined `attestor`

### 3. test_attest_revoked_credential_panics (first copy) — incomplete test
- Test body was truncated: only issued a credential, never created a slice,
  never revoked, and never called attest — so the expected panic could never fire
- Fixed by completing the body: create slice, revoke credential, then attest
  (which should panic with "credential is revoked")

### 4. Duplicate test_attest_revoked_credential_panics — compile error
- Two functions with the same name existed in the same module
- Removed the second (redundant) copy

### 5. Duplicate test_unauthorized_revoke_credential — compile error
- Two functions with the same name existed in the same module
- First copy had the wrong expected panic message ("only subject or issuer
  can revoke") which does not match the actual panic in revoke_credential
  ("only the original issuer can revoke"), and had a broken body that never
  called revoke_credential
- Removed the broken first copy, keeping the correct second copy

### 6. Premature closing braces — structural bug
- Two stray `}` braces were closing the `mod tests` block early
- This left a large number of tests (test_get_attestation_count,
  test_full_credential_lifecycle_e2e, test_attest_by_non_member_panics,
  and many others) outside the test module entirely
- Removed both premature braces so all tests are correctly scoped
  within `mod tests`
