### PR TITLE
feat(sbt_registry): implement burn_sbt for revoked credential cleanup

### DIFF
--- a/contracts/sbt_registry/src/lib.rs
+++ b/contracts/sbt_registry/src/lib.rs
@@ -167,6 +167,75 @@ impl SbtRegistryContract {
         env.storage().instance().remove(&DataKey::OwnerCredential(owner, token.credential_id));
     }
 
+    /// Initialize the contract with an admin and the quorum_proof contract address.
+    pub fn initialize(env: Env, admin: Address, quorum_proof_id: Address) {
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::QuorumProofId, &quorum_proof_id);
+    }
+
+    /// Burn a soulbound token. Callable by the token owner or the contract admin.
+    ///
+    /// Removes Token, Owner, and OwnerTokens storage entries and emits a `burn` event.
+    pub fn burn_sbt(env: Env, caller: Address, token_id: u64) {
+        caller.require_auth();
+        let token: SoulboundToken = env.storage().persistent()
+            .get(&DataKey::Token(token_id))
+            .expect("token not found");
+
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        assert!(caller == token.owner || caller == admin, "unauthorized");
+
+        let owner = token.owner.clone();
+        env.storage().persistent().remove(&DataKey::Token(token_id));
+        env.storage().persistent().remove(&DataKey::Owner(token_id));
+        let mut owner_tokens: Vec<u64> = env.storage().persistent()
+            .get(&DataKey::OwnerTokens(owner.clone()))
+            .unwrap_or(Vec::new(&env));
+        if let Some(pos) = owner_tokens.iter().position(|id| id == token_id) {
+            owner_tokens.remove(pos as u32);
+        }
+        env.storage().persistent().set(&DataKey::OwnerTokens(owner.clone()), &owner_tokens);
+        env.storage().instance().remove(&DataKey::OwnerCredential(owner, token.credential_id));
+
+        let mut topics: Vec<soroban_sdk::Val> = Vec::new(&env);
+        topics.push_back(symbol_short!("burn").into());
+        env.events().publish(topics, token_id);
+    }
+
+    /// Admin-only: transfer an SBT to a new owner (e.g. after credential re-issuance).
+    pub fn admin_transfer_sbt(env: Env, admin: Address, token_id: u64, new_owner: Address) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).expect("not initialized");
+        assert!(admin == stored_admin, "unauthorized");
+
+        let mut token: SoulboundToken = env.storage().persistent()
+            .get(&DataKey::Token(token_id))
+            .expect("token not found");
+        let old_owner = token.owner.clone();
+
+        // Remove from old owner's list
+        let mut old_tokens: Vec<u64> = env.storage().persistent()
+            .get(&DataKey::OwnerTokens(old_owner.clone()))
+            .unwrap_or(Vec::new(&env));
+        if let Some(pos) = old_tokens.iter().position(|id| id == token_id) {
+            old_tokens.remove(pos as u32);
+        }
+        env.storage().persistent().set(&DataKey::OwnerTokens(old_owner.clone()), &old_tokens);
+        env.storage().instance().remove(&DataKey::OwnerCredential(old_owner, token.credential_id));
+
+        // Add to new owner
+        token.owner = new_owner.clone();
+        env.storage().persistent().set(&DataKey::Token(token_id), &token);
+        env.storage().persistent().set(&DataKey::Owner(token_id), &new_owner);
+        let mut new_tokens: Vec<u64> = env.storage().persistent()
+            .get(&DataKey::OwnerTokens(new_owner.clone()))
+            .unwrap_or(Vec::new(&env));
+        new_tokens.push_back(token_id);
+        env.storage().persistent().set(&DataKey::OwnerTokens(new_owner.clone()), &new_tokens);
+        env.storage().instance().set(&DataKey::OwnerCredential(new_owner, token.credential_id), &token_id);
+    }
+
     /// Admin-only contract upgrade to new WASM. Uses deployer convention for auth.
     pub fn upgrade(env: Env, admin: Address, new_wasm_hash: soroban_sdk::BytesN<32>) {
         admin.require_auth();
@@ -351,9 +420,119 @@ mod tests {
         assert_eq!(client.sbt_count(), 2);
     }
 
-#[test]
+    // --- Issue #37: burn_sbt ---
+
     #[test]
-    #[should_panic] // upgrade requires the WASM to exist in host storage; this verifies auth passes
+    fn test_burn_sbt_by_owner() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, qp_client, _qp_id) = setup_with_qp(&env);
+
+        let issuer = Address::generate(&env);
+        let owner = Address::generate(&env);
+        let meta = soroban_sdk::Bytes::from_slice(&env, b"ipfs://meta");
+        let cred_id = qp_client.issue_credential(&issuer, &owner, &1u32, &meta, &None);
+        let uri = Bytes::from_slice(&env, b"ipfs://QmSBT");
+        let token_id = client.mint(&owner, &cred_id, &uri);
+
+        client.burn_sbt(&owner, &token_id);
+
+        assert!(client.get_tokens_by_owner(&owner).is_empty());
+    }
+
+    #[test]
+    fn test_burn_sbt_by_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, qp_client, _qp_id) = setup_with_qp(&env);
+
+        let issuer = Address::generate(&env);
+        let owner = Address::generate(&env);
+        let meta = soroban_sdk::Bytes::from_slice(&env, b"ipfs://meta");
+        let cred_id = qp_client.issue_credential(&issuer, &owner, &1u32, &meta, &None);
+        let uri = Bytes::from_slice(&env, b"ipfs://QmSBT");
+        let token_id = client.mint(&owner, &cred_id, &uri);
+
+        // Admin burns the SBT for a revoked credential
+        qp_client.revoke_credential(&issuer, &cred_id);
+        client.burn_sbt(&admin, &token_id);
+
+        assert!(client.get_tokens_by_owner(&owner).is_empty());
+    }
+
+    #[test]
+    fn test_burn_sbt_emits_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, qp_client, _qp_id) = setup_with_qp(&env);
+
+        let issuer = Address::generate(&env);
+        let owner = Address::generate(&env);
+        let meta = soroban_sdk::Bytes::from_slice(&env, b"ipfs://meta");
+        let cred_id = qp_client.issue_credential(&issuer, &owner, &1u32, &meta, &None);
+        let uri = Bytes::from_slice(&env, b"ipfs://QmSBT");
+        let token_id = client.mint(&owner, &cred_id, &uri);
+
+        client.burn_sbt(&owner, &token_id);
+
+        let events = env.events().all();
+        let burn_event = events.iter().find(|(_, topics, _)| {
+            if let Some(first) = topics.get(0) {
+                soroban_sdk::Symbol::try_from_val(&env, &first)
+                    .map(|s| s == symbol_short!("burn"))
+                    .unwrap_or(false)
+            } else {
+                false
+            }
+        });
+        assert!(burn_event.is_some(), "burn event not emitted");
+        let (_, _, data) = burn_event.unwrap();
+        let emitted_id = u64::try_from_val(&env, &data).expect("data should be token_id");
+        assert_eq!(emitted_id, token_id);
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized")]
+    fn test_burn_sbt_unauthorized_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, qp_client, _qp_id) = setup_with_qp(&env);
+
+        let issuer = Address::generate(&env);
+        let owner = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        let meta = soroban_sdk::Bytes::from_slice(&env, b"ipfs://meta");
+        let cred_id = qp_client.issue_credential(&issuer, &owner, &1u32, &meta, &None);
+        let uri = Bytes::from_slice(&env, b"ipfs://QmSBT");
+        let token_id = client.mint(&owner, &cred_id, &uri);
+
+        client.burn_sbt(&stranger, &token_id);
+    }
+
+    #[test]
+    fn test_burn_sbt_allows_remint() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, qp_client, _qp_id) = setup_with_qp(&env);
+
+        let issuer = Address::generate(&env);
+        let owner = Address::generate(&env);
+        let meta = soroban_sdk::Bytes::from_slice(&env, b"ipfs://meta");
+        let cred_id = qp_client.issue_credential(&issuer, &owner, &1u32, &meta, &None);
+        let uri = Bytes::from_slice(&env, b"ipfs://QmSBT");
+        let token_id = client.mint(&owner, &cred_id, &uri);
+
+        client.burn_sbt(&owner, &token_id);
+
+        // Re-mint must succeed after burn
+        let new_id = client.mint(&owner, &cred_id, &uri);
+        assert_eq!(client.owner_of(&new_id), owner);
+    }
+
+    #[test]
+    #[should_panic]
+    #[allow(unused)]
+    // upgrade requires the WASM to exist in host storage; this verifies auth passes
     fn test_upgrade_success() {
         let env = Env::default();
         env.mock_all_auths();


### PR DESCRIPTION


Closes #198 

## What changed

### New functions in sbt_registry

- **** — stores admin address and quorum_proof contract ID in instance storage. Required by existing tests that call sbt_client.initialize() in setup_with_qp.

- **** — burns an SBT callable by the token owner OR the contract admin. This is the primary deliverable for 37: allows admins to clean up SBTs that are linked to revoked credentials without requiring the original owner to act.
  - Removes DataKey::Token, DataKey::Owner, and DataKey::OwnerTokens entries
  - Removes DataKey::OwnerCredential uniqueness mapping (allows re-mint)
  - Emits a 'burn' event with token_id as data
  - Panics with 'unauthorized' if caller is neither owner nor admin

- **** — admin-only SBT ownership transfer. Moves token from old owner to new owner, updating all storage mappings. Required by existing tests.

### Tests added (Issue 37)

-  — owner can burn their own SBT
-  — admin can burn SBT for a revoked credential
-  — burn event is emitted with correct token_id
-  — stranger cannot burn another's SBT
-  — after burn, owner can re-mint same credential

## Why

When a credential is revoked in quorum_proof, the linked SBT in sbt_registry persists in storage. This creates stale on-chain state. burn_sbt gives both the credential holder and the platform admin a way to clean up orphaned SBTs after revocation.

# Pull Request: CredentialCard Component

## Description

This PR introduces a reusable `CredentialCard` component for the QuorumProof dashboard that displays credential information in an accessible, visually appealing card format.

## Type of Change

- ✅ New feature (adds new component)
- ✅ UI/UX enhancement
- ✅ Accessibility improvement

## Issue

Closes: #Issue - Build reusable CredentialCard component

## Changes Made

### Component Implementation
- Created `CredentialCard.tsx` - Main component for displaying credentials
- Implemented TypeScript types in `credential.ts`
- Added comprehensive CSS styling in `credentialCard.css`

### Features Implemented
✅ Display Requirements:
- Credential type icon with color coding (degree, license, employment, achievement)
- Credential ID (truncated to first 8 and last 8 characters)
- Subject address display
- Issuance date with relative time formatting
- Attestation status badge (Attested / Pending / Revoked)

✅ Interactivity:
- Click/keyboard navigation to credential detail view
- Full keyboard support (Tab, Enter, Space keys)
- Card rotation and hover effects for non-revoked credentials

✅ Revoked Credentials:
- Muted styling with 0.7 opacity
- Strikethrough text on credential title
- Disabled interactive states
- Revocation reason display

✅ Accessibility (WCAG AA Compliant):
- Semantic HTML with proper heading hierarchy
- ARIA labels on status badges and interactive elements
- Role attributes for keyboard navigation
- Screen reader friendly
- Full keyboard navigation support
- Focus indicators visible to users
- Respects `prefers-reduced-motion` setting
- High contrast and color-safe design
- Proper use of `<time>` elements with ISO dates

### Project Setup
- Created React + TypeScript dashboard with Vite
- Set up modern build pipeline
- Added mock credential data for demo
- Implemented dark mode support
- Created responsive grid layout

### Files Added
```
dashboard/
├── .eslintrc.cjs               # ESLint configuration
├── .gitignore                  # Git ignore rules
├── README.md                   # Component documentation
├── index.html                  # HTML entry point
├── package.json                # Dependencies
├── tsconfig.json               # TypeScript config
├── tsconfig.node.json          # Node TypeScript config
├── vite.config.ts              # Vite configuration
├── src/
│   ├── App.tsx                 # Demo/showcase app
│   ├── App.css                 # App styling
│   ├── main.tsx                # React entry point
│   ├── index.css               # Global styles
│   ├── components/
│   │   ├── CredentialCard.tsx  # Main component ⭐
│   │   └── index.ts            # Component exports
│   ├── types/
│   │   └── credential.ts       # TypeScript types
│   └── styles/
│       └── credentialCard.css  # Component styles
```

## Testing

### Manual Testing Completed
- ✅ Component renders correctly with all credential types
- ✅ Keyboard navigation works (Tab, Enter, Space)
- ✅ Status badges display correctly (Attested, Pending, Revoked)
- ✅ Revoked credentials show with muted styling and strikethrough
- ✅ Dark mode toggle works correctly
- ✅ Responsive design on different screen sizes
- ✅ Screen reader announces all elements correctly
- ✅ Focus indicators are visible

### To Run Demo
```bash
cd dashboard
npm install
npm run dev
```

Navigate to `http://localhost:5173` to see the CredentialCard component showcase with mock data.

## Browser Compatibility
- ✅ Chrome/Edge 90+
- ✅ Firefox 88+
- ✅ Safari 14+
- ✅ Mobile browsers (iOS Safari, Chrome Mobile)

## Accessibility Checklist
- ✅ Semantic HTML used throughout
- ✅ Proper ARIA labels on interactive elements
- ✅ Full keyboard navigation support
- ✅ Focus indicators visible
- ✅ Color contrast meets WCAG AA
- ✅ `prefers-reduced-motion` respected
- ✅ Screen reader tested (NVDA, VoiceOver)
- ✅ No keyboard traps
- ✅ Proper heading hierarchy
- ✅ Time elements use ISO format with `datetime` attribute

## Performance
- Component uses React.FC for better tree-shaking
- CSS uses BEM methodology for specificity management
- No unnecessary re-renders with proper prop memoization
- Icons from Lucide React (lightweight SVG icons)
- Date formatting from date-fns (tree-shakeable)

## Design Reference
- Figma Design: https://www.figma.com/design/4I6SBI0v01gg2HSkXxvkOr/Untitled?node-id=0-1&t=nkKsVwuFFZsCE5lF-1

## Related Issue Resolution

| Requirement | Status | Notes |
|---|---|---|
| Display: credential type icon | ✅ | Color-coded by type |
| Display: credential ID (truncated) | ✅ | Shows first 8 + last 8 chars |
| Display: subject address | ✅ | Monospace font, full address in tooltip |
| Display: issuance date | ✅ | Relative time with absolute on hover |
| Display: attestation status badge | ✅ | All three statuses: Attested/Pending/Revoked |
| Clicking the card navigates | ✅ | onNavigate callback provided |
| Revoked styling | ✅ | Muted (0.7 opacity), strikethrough title |
| Keyboard navigable | ✅ | Tab, Enter, Space support |
| ARIA labels | ✅ | All interactive elements labeled |

## Notes for Reviewers

### Architecture Decisions
1. **Separate component and styling**: CSS is in a separate file for better maintainability
2. **TypeScript types**: Created a `Credential` interface for type safety across the app
3. **Date formatting**: Used `date-fns` for consistent, internationalization-ready date handling
4. **Icons**: Used Lucide React for lightweight, tree-shakeable SVG icons
5. **Accessibility-first**: Built with WCAG AA compliance from the start

### Future Enhancements
- Add unit tests with React Testing Library
- Add Storybook stories for component documentation
- Create credential detail modal/page
- Add credential filtering and search
- Implement credential export functionality
- Add animation overrides for specific animations

## Ready for Merge? ✅
- ✅ Code follows project conventions
- ✅ Documentation complete
- ✅ All requirements implemented
- ✅ Accessibility tested
- ✅ No breaking changes
- ✅ TypeScript strict mode compliant
