### PR TITLE
feat: credential sharing UI, profile page, comparison tool, and audit trail (#319 #320 #321 #322)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ const Verify = lazy(() => import('./pages/Verify').then(module => ({ default: mo
 const QuorumSlice = lazy(() => import('./pages/QuorumSlice').then(module => ({ default: module.default })));
 const CredentialDetail = lazy(() => import('./pages/CredentialDetail').then(module => ({ default: module.default })));
 const IssueCredential = lazy(() => import('./pages/IssueCredential').then(module => ({ default: module.default })));
+const Profile = lazy(() => import('./pages/Profile').then(module => ({ default: module.default })));
 
 // Loading fallback
 const LoadingFallback = () => (
@@ -48,6 +49,7 @@ function AppContent() {
           <Route path="/slice/new" element={<WalletGuard><QuorumSlice /></WalletGuard>} />
           <Route path="/credential/issue" element={<WalletGuard><IssueCredential /></WalletGuard>} />
           <Route path="/credential/:id" element={<CredentialDetail />} />
+          <Route path="/profile" element={<WalletGuard><Profile /></WalletGuard>} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </Suspense>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ const QuorumSlice = lazy(() => import('./pages/QuorumSlice').then(module => ({ d
 const CredentialDetail = lazy(() => import('./pages/CredentialDetail').then(module => ({ default: module.default })));
 const IssueCredential = lazy(() => import('./pages/IssueCredential').then(module => ({ default: module.default })));
 const Profile = lazy(() => import('./pages/Profile').then(module => ({ default: module.default })));
+const CredentialCompare = lazy(() => import('./pages/CredentialCompare').then(module => ({ default: module.default })));
 
 // Loading fallback
 const LoadingFallback = () => (
@@ -50,6 +51,7 @@ function AppContent() {
           <Route path="/credential/issue" element={<WalletGuard><IssueCredential /></WalletGuard>} />
           <Route path="/credential/:id" element={<CredentialDetail />} />
           <Route path="/profile" element={<WalletGuard><Profile /></WalletGuard>} />
+          <Route path="/compare" element={<CredentialCompare />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </Suspense>

--- a/frontend/src/__tests__/AuditTrail.test.tsx
+++ b/frontend/src/__tests__/AuditTrail.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * AuditTrail.test.tsx
+ * Tests for the credential audit trail UI — issue #321
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { AuditTrail, buildAuditEvents } from '../components/AuditTrail';
+import type { Credential } from '../lib/contracts/quorumProof';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const BASE_CREDENTIAL: Credential = {
+  id: 1n,
+  subject: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNN',
+  issuer:  'GBAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNN',
+  credential_type: 1,
+  metadata_hash: new Uint8Array(),
+  revoked: false,
+  expires_at: null,
+};
+
+const ATTESTORS = [
+  'GCAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNN',
+  'GDAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNN',
+];
+
+// ── buildAuditEvents (pure logic) ─────────────────────────────────────────────
+
+describe('buildAuditEvents', () => {
+  it('always includes an issued event as the first entry', () => {
+    const events = buildAuditEvents(BASE_CREDENTIAL, [], false);
+    expect(events[0].type).toBe('issued');
+    expect(events[0].label).toBe('Credential Issued');
+  });
+
+  it('includes one attested event per attestor', () => {
+    const events = buildAuditEvents(BASE_CREDENTIAL, ATTESTORS, false);
+    const attested = events.filter((e) => e.type === 'attested');
+    expect(attested).toHaveLength(2);
+  });
+
+  it('labels attestation events with sequential numbers', () => {
+    const events = buildAuditEvents(BASE_CREDENTIAL, ATTESTORS, false);
+    const attested = events.filter((e) => e.type === 'attested');
+    expect(attested[0].label).toBe('Attestation #1');
+    expect(attested[1].label).toBe('Attestation #2');
+  });
+
+  it('includes a revoked event when credential is revoked', () => {
+    const cred = { ...BASE_CREDENTIAL, revoked: true };
+    const events = buildAuditEvents(cred, [], false);
+    expect(events.some((e) => e.type === 'revoked')).toBe(true);
+  });
+
+  it('does not include a revoked event when credential is not revoked', () => {
+    const events = buildAuditEvents(BASE_CREDENTIAL, [], false);
+    expect(events.some((e) => e.type === 'revoked')).toBe(false);
+  });
+
+  it('includes an expired event when expired and has expires_at', () => {
+    const cred = { ...BASE_CREDENTIAL, expires_at: 1700000000n };
+    const events = buildAuditEvents(cred, [], true);
+    expect(events.some((e) => e.type === 'expired')).toBe(true);
+  });
+
+  it('does not include an expired event when not expired', () => {
+    const events = buildAuditEvents(BASE_CREDENTIAL, [], false);
+    expect(events.some((e) => e.type === 'expired')).toBe(false);
+  });
+
+  it('returns only the issued event for a fresh credential with no attestors', () => {
+    const events = buildAuditEvents(BASE_CREDENTIAL, [], false);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('issued');
+  });
+
+  it('orders events: issued → attested → revoked', () => {
+    const cred = { ...BASE_CREDENTIAL, revoked: true };
+    const events = buildAuditEvents(cred, ATTESTORS, false);
+    const types = events.map((e) => e.type);
+    expect(types[0]).toBe('issued');
+    expect(types[1]).toBe('attested');
+    expect(types[2]).toBe('attested');
+    expect(types[3]).toBe('revoked');
+  });
+});
+
+// ── AuditTrail component ──────────────────────────────────────────────────────
+
+describe('AuditTrail component', () => {
+  it('renders the audit trail container', () => {
+    render(<AuditTrail credential={BASE_CREDENTIAL} attestors={[]} expired={false} />);
+    expect(screen.getByLabelText('Credential audit trail')).toBeInTheDocument();
+  });
+
+  it('renders the issued event', () => {
+    render(<AuditTrail credential={BASE_CREDENTIAL} attestors={[]} expired={false} />);
+    expect(screen.getByText('Credential Issued')).toBeInTheDocument();
+  });
+
+  it('renders an attestation event for each attestor', () => {
+    render(<AuditTrail credential={BASE_CREDENTIAL} attestors={ATTESTORS} expired={false} />);
+    expect(screen.getByText('Attestation #1')).toBeInTheDocument();
+    expect(screen.getByText('Attestation #2')).toBeInTheDocument();
+  });
+
+  it('renders the revoked event when credential is revoked', () => {
+    const cred = { ...BASE_CREDENTIAL, revoked: true };
+    render(<AuditTrail credential={cred} attestors={[]} expired={false} />);
+    expect(screen.getByText('Credential Revoked')).toBeInTheDocument();
+  });
+
+  it('does not render the revoked event when not revoked', () => {
+    render(<AuditTrail credential={BASE_CREDENTIAL} attestors={[]} expired={false} />);
+    expect(screen.queryByText('Credential Revoked')).not.toBeInTheDocument();
+  });
+
+  it('renders the expired event when expired', () => {
+    const cred = { ...BASE_CREDENTIAL, expires_at: 1700000000n };
+    render(<AuditTrail credential={cred} attestors={[]} expired={true} />);
+    expect(screen.getByText('Credential Expired')).toBeInTheDocument();
+  });
+
+  it('renders event detail text for the issued event', () => {
+    render(<AuditTrail credential={BASE_CREDENTIAL} attestors={[]} expired={false} />);
+    expect(screen.getByText(/issued by/i)).toBeInTheDocument();
+  });
+
+  it('renders event detail text for each attestor', () => {
+    render(<AuditTrail credential={BASE_CREDENTIAL} attestors={ATTESTORS} expired={false} />);
+    const details = screen.getAllByText(/attested by/i);
+    expect(details).toHaveLength(2);
+  });
+
+  it('renders the correct number of timeline items', () => {
+    render(<AuditTrail credential={BASE_CREDENTIAL} attestors={ATTESTORS} expired={false} />);
+    // issued + 2 attested = 3
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+  });
+
+  it('does not render the connector line on the last event', () => {
+    render(<AuditTrail credential={BASE_CREDENTIAL} attestors={[]} expired={false} />);
+    // Only 1 event (issued), so no audit-line should be rendered
+    const lines = document.querySelectorAll('.audit-line');
+    expect(lines).toHaveLength(0);
+  });
+
+  it('renders connector lines between events', () => {
+    render(<AuditTrail credential={BASE_CREDENTIAL} attestors={ATTESTORS} expired={false} />);
+    // 3 events → 2 lines
+    const lines = document.querySelectorAll('.audit-line');
+    expect(lines).toHaveLength(2);
+  });
+});

--- a/frontend/src/__tests__/ShareCredentialDialog.test.tsx
+++ b/frontend/src/__tests__/ShareCredentialDialog.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * ShareCredentialDialog.test.tsx
+ * Tests for the credential sharing UI — issue #319
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ShareCredentialDialog } from '../components/ShareCredentialDialog';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+// 56-char Stellar address (G + 55 chars)
+const VALID_ADDRESS = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNN';
+const SHORT_ADDRESS = 'GABC123';
+const CRED_ID = '42';
+
+function renderDialog(onClose = vi.fn()) {
+  return render(
+    <ShareCredentialDialog credentialId={CRED_ID} onClose={onClose} />
+  );
+}
+
+async function fillAndAdd(address: string) {
+  await act(async () => {
+    fireEvent.change(screen.getByPlaceholderText('G…'), { target: { value: address } });
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByText('Add'));
+  });
+}
+
+// ── Address validation (pure logic mirrored from component) ──────────────────
+
+function isValidStellarAddress(addr: string): boolean {
+  return addr.startsWith('G') && addr.length >= 56;
+}
+
+describe('isValidStellarAddress', () => {
+  it('accepts a valid Stellar address', () => {
+    expect(isValidStellarAddress(VALID_ADDRESS)).toBe(true);
+  });
+
+  it('rejects an address that does not start with G', () => {
+    expect(isValidStellarAddress('X' + VALID_ADDRESS.slice(1))).toBe(false);
+  });
+
+  it('rejects an address shorter than 56 chars', () => {
+    expect(isValidStellarAddress(SHORT_ADDRESS)).toBe(false);
+  });
+
+  it('rejects an empty string', () => {
+    expect(isValidStellarAddress('')).toBe(false);
+  });
+});
+
+// ── Rendering ────────────────────────────────────────────────────────────────
+
+describe('ShareCredentialDialog rendering', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it('renders the dialog with the credential ID in the title', () => {
+    renderDialog();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(`Share Credential #${CRED_ID}`)).toBeInTheDocument();
+  });
+
+  it('shows the public verification link', () => {
+    renderDialog();
+    expect(screen.getByText(/\/verify\?id=42/)).toBeInTheDocument();
+  });
+
+  it('renders the address input and permission select', () => {
+    renderDialog();
+    expect(screen.getByPlaceholderText('G…')).toBeInTheDocument();
+    expect(screen.getByLabelText('Permission level')).toBeInTheDocument();
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn();
+    renderDialog(onClose);
+    fireEvent.click(screen.getByLabelText('Close share dialog'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when clicking the overlay backdrop', () => {
+    const onClose = vi.fn();
+    renderDialog(onClose);
+    fireEvent.click(screen.getByRole('dialog'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});
+
+// ── Adding shares ─────────────────────────────────────────────────────────────
+
+describe('ShareCredentialDialog — adding addresses', () => {
+  it('shows an error for an invalid address', async () => {
+    renderDialog();
+    await fillAndAdd(SHORT_ADDRESS);
+    expect(screen.getByRole('alert')).toHaveTextContent(/valid Stellar address/i);
+  });
+
+  it('adds a valid address to the shared list', async () => {
+    renderDialog();
+    await fillAndAdd(VALID_ADDRESS);
+    expect(screen.getByText(new RegExp(VALID_ADDRESS.slice(0, 8)))).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('clears the input after a successful add', async () => {
+    renderDialog();
+    const input = screen.getByPlaceholderText('G…') as HTMLInputElement;
+    await fillAndAdd(VALID_ADDRESS);
+    expect(input.value).toBe('');
+  });
+
+  it('shows an error when adding a duplicate address', async () => {
+    renderDialog();
+    await fillAndAdd(VALID_ADDRESS);
+    await fillAndAdd(VALID_ADDRESS);
+    expect(screen.getByRole('alert')).toHaveTextContent(/already added/i);
+  });
+});
+
+// ── Permission management ─────────────────────────────────────────────────────
+
+describe('ShareCredentialDialog — permission management', () => {
+  it('defaults to "view" permission', () => {
+    renderDialog();
+    const select = screen.getByLabelText('Permission level') as HTMLSelectElement;
+    expect(select.value).toBe('view');
+  });
+
+  it('allows changing permission before adding', async () => {
+    renderDialog();
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Permission level'), { target: { value: 'full' } });
+    });
+    await fillAndAdd(VALID_ADDRESS);
+    const entrySelects = screen.getAllByRole('combobox') as HTMLSelectElement[];
+    // The per-entry select is the last one rendered (after the "add" select)
+    const entrySelect = entrySelects[entrySelects.length - 1];
+    expect(entrySelect.value).toBe('full');
+  });
+
+  it('allows changing permission of an existing entry', async () => {
+    renderDialog();
+    await fillAndAdd(VALID_ADDRESS);
+    const entrySelects = screen.getAllByRole('combobox') as HTMLSelectElement[];
+    const entrySelect = entrySelects[entrySelects.length - 1];
+    await act(async () => {
+      fireEvent.change(entrySelect, { target: { value: 'verify' } });
+    });
+    expect(entrySelect.value).toBe('verify');
+  });
+});
+
+// ── Removing shares ───────────────────────────────────────────────────────────
+
+describe('ShareCredentialDialog — removing addresses', () => {
+  it('removes an address from the list', async () => {
+    renderDialog();
+    await fillAndAdd(VALID_ADDRESS);
+    const truncated = VALID_ADDRESS.slice(0, 8);
+    expect(screen.getByText(new RegExp(truncated))).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText(new RegExp(`Remove ${truncated}`, 'i')));
+    });
+    expect(screen.queryByText(new RegExp(truncated))).not.toBeInTheDocument();
+  });
+});
+
+// ── Copy link ─────────────────────────────────────────────────────────────────
+
+describe('ShareCredentialDialog — copy link', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it('calls clipboard.writeText with the verification URL', () => {
+    renderDialog();
+    fireEvent.click(screen.getByLabelText('Copy verification link'));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining(`/verify?id=${CRED_ID}`)
+    );
+  });
+});

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -50,6 +50,9 @@ export function AppLayout({ currentPath, walletAddress, onConnectWallet, network
           <a href="/slice/new" className={`px-3 py-2 rounded ${isActive('/slice/new') ? 'bg-indigo-600 text-white' : 'text-slate-300 hover:bg-slate-700'}`}>
             New Slice
           </a>
+          <a href="/profile" className={`px-3 py-2 rounded ${isActive('/profile') ? 'bg-indigo-600 text-white' : 'text-slate-300 hover:bg-slate-700'}`}>
+            Profile
+          </a>
         </nav>
 
         {/* Wallet and Network */}

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -53,6 +53,9 @@ export function AppLayout({ currentPath, walletAddress, onConnectWallet, network
           <a href="/profile" className={`px-3 py-2 rounded ${isActive('/profile') ? 'bg-indigo-600 text-white' : 'text-slate-300 hover:bg-slate-700'}`}>
             Profile
           </a>
+          <a href="/compare" className={`px-3 py-2 rounded ${isActive('/compare') ? 'bg-indigo-600 text-white' : 'text-slate-300 hover:bg-slate-700'}`}>
+            Compare
+          </a>
         </nav>
 
         {/* Wallet and Network */}

--- a/frontend/src/components/AuditTrail.tsx
+++ b/frontend/src/components/AuditTrail.tsx
@@ -1,0 +1,124 @@
+import type { Credential } from '../lib/contracts/quorumProof';
+import { credTypeLabel, formatAddress, formatTimestamp } from '../lib/credentialUtils';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type AuditEventType = 'issued' | 'attested' | 'revoked' | 'expired';
+
+export interface AuditEvent {
+  type: AuditEventType;
+  label: string;
+  detail: string;
+  icon: string;
+  timestamp: string;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const EVENT_CONFIG: Record<AuditEventType, { icon: string; colorClass: string }> = {
+  issued:   { icon: '📄', colorClass: 'audit-dot--issued'   },
+  attested: { icon: '✅', colorClass: 'audit-dot--attested' },
+  revoked:  { icon: '🚫', colorClass: 'audit-dot--revoked'  },
+  expired:  { icon: '⏰', colorClass: 'audit-dot--expired'  },
+};
+
+export function buildAuditEvents(
+  credential: Credential,
+  attestors: string[],
+  expired: boolean,
+): AuditEvent[] {
+  const events: AuditEvent[] = [];
+
+  // Issued — always first
+  events.push({
+    type: 'issued',
+    label: 'Credential Issued',
+    detail: `${credTypeLabel(credential.credential_type)} issued by ${formatAddress(credential.issuer)} to ${formatAddress(credential.subject)}`,
+    icon: '📄',
+    timestamp: 'Genesis',
+  });
+
+  // Attestations
+  attestors.forEach((addr, idx) => {
+    events.push({
+      type: 'attested',
+      label: `Attestation #${idx + 1}`,
+      detail: `Attested by ${formatAddress(addr)}`,
+      icon: '✅',
+      timestamp: `Attestor ${idx + 1}`,
+    });
+  });
+
+  // Revoked
+  if (credential.revoked) {
+    events.push({
+      type: 'revoked',
+      label: 'Credential Revoked',
+      detail: 'This credential has been revoked and is no longer valid.',
+      icon: '🚫',
+      timestamp: 'Revoked',
+    });
+  }
+
+  // Expired
+  if (expired && credential.expires_at) {
+    events.push({
+      type: 'expired',
+      label: 'Credential Expired',
+      detail: `Expired on ${formatTimestamp(credential.expires_at)}`,
+      icon: '⏰',
+      timestamp: formatTimestamp(credential.expires_at),
+    });
+  }
+
+  return events;
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+interface AuditTrailProps {
+  credential: Credential;
+  attestors: string[];
+  expired: boolean;
+}
+
+export function AuditTrail({ credential, attestors, expired }: AuditTrailProps) {
+  const events = buildAuditEvents(credential, attestors, expired);
+
+  return (
+    <div className="audit-trail" aria-label="Credential audit trail">
+      <ol className="audit-timeline" aria-label="Audit timeline">
+        {events.map((event, idx) => {
+          const { colorClass } = EVENT_CONFIG[event.type];
+          const isLast = idx === events.length - 1;
+          return (
+            <li
+              key={`${event.type}-${idx}`}
+              className="audit-event"
+              data-testid={`audit-event-${event.type}-${idx}`}
+            >
+              {/* Connector line */}
+              {!isLast && <div className="audit-line" aria-hidden="true" />}
+
+              {/* Dot */}
+              <div className={`audit-dot ${colorClass}`} aria-hidden="true">
+                {event.icon}
+              </div>
+
+              {/* Content */}
+              <div className="audit-content">
+                <div className="audit-event__label">{event.label}</div>
+                <div className="audit-event__detail">{event.detail}</div>
+                <div className="audit-event__timestamp">{event.timestamp}</div>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+
+      {events.length === 0 && (
+        <p className="audit-empty">No audit events available.</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ShareCredentialDialog.tsx
+++ b/frontend/src/components/ShareCredentialDialog.tsx
@@ -1,0 +1,176 @@
+import { useState } from 'react';
+
+export type SharePermission = 'view' | 'verify' | 'full';
+
+export interface ShareEntry {
+  address: string;
+  permission: SharePermission;
+}
+
+interface Props {
+  credentialId: string;
+  onClose: () => void;
+}
+
+const PERMISSION_LABELS: Record<SharePermission, { label: string; desc: string }> = {
+  view:   { label: 'View',   desc: 'Can see credential details' },
+  verify: { label: 'Verify', desc: 'Can verify and attest' },
+  full:   { label: 'Full',   desc: 'Full access including export' },
+};
+
+function isValidStellarAddress(addr: string): boolean {
+  return addr.startsWith('G') && addr.length >= 56;
+}
+
+export function ShareCredentialDialog({ credentialId, onClose }: Props) {
+  const [shares, setShares] = useState<ShareEntry[]>([]);
+  const [address, setAddress] = useState('');
+  const [permission, setPermission] = useState<SharePermission>('view');
+  const [error, setError] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  const shareUrl = `${window.location.origin}/verify?id=${credentialId}`;
+
+  function handleAdd() {
+    const trimmed = address.trim();
+    if (!isValidStellarAddress(trimmed)) {
+      setError('Enter a valid Stellar address (starts with G, 56+ chars)');
+      return;
+    }
+    if (shares.some((s) => s.address === trimmed)) {
+      setError('Address already added');
+      return;
+    }
+    setShares((prev) => [...prev, { address: trimmed, permission }]);
+    setAddress('');
+    setError('');
+  }
+
+  function handleRemove(addr: string) {
+    setShares((prev) => prev.filter((s) => s.address !== addr));
+  }
+
+  function handlePermissionChange(addr: string, perm: SharePermission) {
+    setShares((prev) =>
+      prev.map((s) => (s.address === addr ? { ...s, permission: perm } : s))
+    );
+  }
+
+  function handleCopyLink() {
+    navigator.clipboard.writeText(shareUrl).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <div
+      className="share-dialog-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Share credential"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="share-dialog">
+        <div className="share-dialog__header">
+          <h2 className="share-dialog__title">Share Credential #{credentialId}</h2>
+          <button
+            className="share-dialog__close"
+            onClick={onClose}
+            aria-label="Close share dialog"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Public link */}
+        <div className="share-dialog__section">
+          <label className="share-dialog__label">Public verification link</label>
+          <div className="share-dialog__link-row">
+            <span className="share-dialog__link-url" title={shareUrl}>{shareUrl}</span>
+            <button
+              className="btn btn--sm btn--ghost"
+              onClick={handleCopyLink}
+              aria-label="Copy verification link"
+            >
+              {copied ? '✅ Copied' : '📋 Copy'}
+            </button>
+          </div>
+        </div>
+
+        {/* Add address */}
+        <div className="share-dialog__section">
+          <label className="share-dialog__label" htmlFor="share-address">
+            Share with Stellar address
+          </label>
+          <div className="share-dialog__add-row">
+            <input
+              id="share-address"
+              className="share-dialog__input"
+              type="text"
+              placeholder="G…"
+              value={address}
+              onChange={(e) => { setAddress(e.target.value); setError(''); }}
+              aria-describedby={error ? 'share-error' : undefined}
+            />
+            <select
+              className="share-dialog__select"
+              value={permission}
+              onChange={(e) => setPermission(e.target.value as SharePermission)}
+              aria-label="Permission level"
+            >
+              {(Object.keys(PERMISSION_LABELS) as SharePermission[]).map((p) => (
+                <option key={p} value={p}>{PERMISSION_LABELS[p].label}</option>
+              ))}
+            </select>
+            <button className="btn btn--sm btn--primary" onClick={handleAdd}>
+              Add
+            </button>
+          </div>
+          {error && (
+            <p id="share-error" className="share-dialog__error" role="alert">{error}</p>
+          )}
+        </div>
+
+        {/* Shared with list */}
+        {shares.length > 0 && (
+          <div className="share-dialog__section">
+            <label className="share-dialog__label">Shared with</label>
+            <ul className="share-dialog__list" aria-label="Shared addresses">
+              {shares.map(({ address: addr, permission: perm }) => (
+                <li key={addr} className="share-dialog__list-item">
+                  <span className="share-dialog__addr mono" title={addr}>
+                    {addr.slice(0, 8)}…{addr.slice(-6)}
+                  </span>
+                  <select
+                    className="share-dialog__select share-dialog__select--sm"
+                    value={perm}
+                    onChange={(e) => handlePermissionChange(addr, e.target.value as SharePermission)}
+                    aria-label={`Permission for ${addr.slice(0, 8)}…`}
+                  >
+                    {(Object.keys(PERMISSION_LABELS) as SharePermission[]).map((p) => (
+                      <option key={p} value={p} title={PERMISSION_LABELS[p].desc}>
+                        {PERMISSION_LABELS[p].label}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    className="share-dialog__remove"
+                    onClick={() => handleRemove(addr)}
+                    aria-label={`Remove ${addr.slice(0, 8)}…`}
+                  >
+                    ✕
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div className="share-dialog__footer">
+          <button className="btn btn--ghost btn--sm" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,3 +1,5 @@
+export { ShareCredentialDialog } from './ShareCredentialDialog';
+export type { ShareEntry, SharePermission } from './ShareCredentialDialog';
 export { WalletGate } from './WalletGate';
 export { WalletGuard } from './WalletGuard';
 export { CredentialCard } from './CredentialCard';

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,5 +1,7 @@
 export { ShareCredentialDialog } from './ShareCredentialDialog';
 export type { ShareEntry, SharePermission } from './ShareCredentialDialog';
+export { AuditTrail } from './AuditTrail';
+export type { AuditEvent, AuditEventType } from './AuditTrail';
 export { WalletGate } from './WalletGate';
 export { WalletGuard } from './WalletGuard';
 export { CredentialCard } from './CredentialCard';

--- a/frontend/src/pages/CredentialCompare.tsx
+++ b/frontend/src/pages/CredentialCompare.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react';
+import { Navbar } from '../components/Navbar';
+import { getCredential, getAttestors, isExpired } from '../lib/contracts/quorumProof';
+import type { Credential } from '../lib/contracts/quorumProof';
+import { credTypeLabel, formatAddress, formatTimestamp } from '../lib/credentialUtils';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface CredentialInfo {
+  credential: Credential;
+  attestors: string[];
+  expired: boolean;
+}
+
+type FieldKey = 'type' | 'subject' | 'issuer' | 'expires' | 'revoked' | 'attestors';
+
+interface Field {
+  key: FieldKey;
+  label: string;
+  value: (info: CredentialInfo) => string;
+}
+
+// ── Field definitions ─────────────────────────────────────────────────────────
+
+const FIELDS: Field[] = [
+  { key: 'type',      label: 'Type',       value: (i) => credTypeLabel(i.credential.credential_type) },
+  { key: 'subject',   label: 'Subject',    value: (i) => formatAddress(i.credential.subject) },
+  { key: 'issuer',    label: 'Issuer',     value: (i) => formatAddress(i.credential.issuer) },
+  { key: 'expires',   label: 'Expires',    value: (i) => formatTimestamp(i.credential.expires_at) },
+  { key: 'revoked',   label: 'Revoked',    value: (i) => i.credential.revoked ? 'Yes' : 'No' },
+  { key: 'attestors', label: 'Attestors',  value: (i) => i.attestors.length.toString() },
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function loadCredentialInfo(id: string): Promise<CredentialInfo> {
+  const credId = BigInt(id.trim());
+  const [credential, expired, attestors] = await Promise.all([
+    getCredential(credId),
+    isExpired(credId).catch(() => false),
+    getAttestors(credId).catch(() => [] as string[]),
+  ]);
+  return { credential, expired, attestors };
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export default function CredentialCompare() {
+  const [idA, setIdA] = useState('');
+  const [idB, setIdB] = useState('');
+  const [infoA, setInfoA] = useState<CredentialInfo | null>(null);
+  const [infoB, setInfoB] = useState<CredentialInfo | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleCompare() {
+    const trimA = idA.trim();
+    const trimB = idB.trim();
+    if (!trimA || !trimB) { setError('Enter both credential IDs.'); return; }
+    if (trimA === trimB)  { setError('Enter two different credential IDs.'); return; }
+
+    setLoading(true);
+    setError(null);
+    setInfoA(null);
+    setInfoB(null);
+
+    try {
+      const [a, b] = await Promise.all([
+        loadCredentialInfo(trimA),
+        loadCredentialInfo(trimB),
+      ]);
+      setInfoA(a);
+      setInfoB(b);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load credentials.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const hasDiff = (field: Field) =>
+    infoA && infoB && field.value(infoA) !== field.value(infoB);
+
+  return (
+    <>
+      <Navbar />
+      <main className="container" style={{ paddingTop: '40px', maxWidth: '900px', paddingBottom: '64px' }}>
+        <h1 className="compare-title">Compare Credentials</h1>
+        <p className="compare-subtitle">Enter two credential IDs to compare them side-by-side.</p>
+
+        {/* Input row */}
+        <div className="compare-inputs">
+          <div className="compare-input-group">
+            <label className="compare-input-label" htmlFor="cred-id-a">Credential A</label>
+            <input
+              id="cred-id-a"
+              className="compare-input"
+              type="text"
+              placeholder="e.g. 1"
+              value={idA}
+              onChange={(e) => setIdA(e.target.value)}
+              aria-label="Credential A ID"
+            />
+          </div>
+          <div className="compare-vs" aria-hidden="true">VS</div>
+          <div className="compare-input-group">
+            <label className="compare-input-label" htmlFor="cred-id-b">Credential B</label>
+            <input
+              id="cred-id-b"
+              className="compare-input"
+              type="text"
+              placeholder="e.g. 2"
+              value={idB}
+              onChange={(e) => setIdB(e.target.value)}
+              aria-label="Credential B ID"
+            />
+          </div>
+          <button
+            className="btn btn--primary"
+            onClick={handleCompare}
+            disabled={loading}
+            aria-label="Compare credentials"
+          >
+            {loading ? 'Loading…' : 'Compare'}
+          </button>
+        </div>
+
+        {error && (
+          <p className="compare-error" role="alert">{error}</p>
+        )}
+
+        {/* Comparison table */}
+        {infoA && infoB && (
+          <div className="compare-table" role="table" aria-label="Credential comparison">
+            {/* Header */}
+            <div className="compare-row compare-row--header" role="row">
+              <div className="compare-cell compare-cell--label" role="columnheader">Field</div>
+              <div className="compare-cell" role="columnheader">
+                Credential #{infoA.credential.id.toString()}
+              </div>
+              <div className="compare-cell" role="columnheader">
+                Credential #{infoB.credential.id.toString()}
+              </div>
+            </div>
+
+            {FIELDS.map((field) => {
+              const diff = hasDiff(field);
+              return (
+                <div
+                  key={field.key}
+                  className={`compare-row${diff ? ' compare-row--diff' : ''}`}
+                  role="row"
+                  aria-label={diff ? `${field.label}: values differ` : undefined}
+                >
+                  <div className="compare-cell compare-cell--label" role="cell">
+                    {field.label}
+                    {diff && <span className="compare-diff-badge" aria-label="Different">≠</span>}
+                  </div>
+                  <div className="compare-cell" role="cell" data-testid={`field-a-${field.key}`}>
+                    {field.value(infoA)}
+                  </div>
+                  <div className="compare-cell" role="cell" data-testid={`field-b-${field.key}`}>
+                    {field.value(infoB)}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </main>
+
+      <footer className="footer">
+        <div className="container">
+          Powered by{' '}
+          <a href="https://stellar.org" target="_blank" rel="noopener">Stellar Soroban</a>
+          {' · '}
+          <a href="https://github.com/Phantomcall/QuorumProof" target="_blank" rel="noopener">QuorumProof</a>
+        </div>
+      </footer>
+    </>
+  );
+}

--- a/frontend/src/pages/CredentialDetail.tsx
+++ b/frontend/src/pages/CredentialDetail.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Navbar } from '../components/Navbar';
+import { ShareCredentialDialog } from '../components/ShareCredentialDialog';
 import {
   getCredential,
   getAttestors,
@@ -29,6 +30,7 @@ export default function CredentialDetail() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [showShare, setShowShare] = useState(false);
 
   useEffect(() => {
     if (!id) { setError('No credential ID provided'); setLoading(false); return; }
@@ -140,7 +142,14 @@ export default function CredentialDetail() {
             onClick={copyShareLink}
             aria-label="Copy verification link to clipboard"
           >
-            {copied ? '✅ Copied' : '📋 Share'}
+            {copied ? '✅ Copied' : '📋 Copy'}
+          </button>
+          <button
+            className="btn btn--sm btn--primary"
+            onClick={() => setShowShare(true)}
+            aria-label="Open share dialog"
+          >
+            🔗 Share
           </button>
         </div>
 
@@ -273,6 +282,13 @@ export default function CredentialDetail() {
           <a href="https://github.com/Phantomcall/QuorumProof" target="_blank" rel="noopener">QuorumProof</a>
         </div>
       </footer>
+
+      {showShare && id && (
+        <ShareCredentialDialog
+          credentialId={id}
+          onClose={() => setShowShare(false)}
+        />
+      )}
     </>
   );
 }

--- a/frontend/src/pages/CredentialDetail.tsx
+++ b/frontend/src/pages/CredentialDetail.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Navbar } from '../components/Navbar';
 import { ShareCredentialDialog } from '../components/ShareCredentialDialog';
+import { AuditTrail } from '../components/AuditTrail';
 import {
   getCredential,
   getAttestors,
@@ -205,8 +206,7 @@ export default function CredentialDetail() {
         {/* Quorum Slice & Attestation */}
         <div className="detail-card">
           <div className="detail-card__header">
-            <span className="detail-card__title">Attestation History</span>
-            <span
+            <span className="detail-card__title">Attestation History</span>            <span
               className={`badge ${fullyAttested ? 'badge--green' : 'badge--blue'}`}
               role="status"
               aria-label={`Threshold progress: ${thresholdLabel}`}
@@ -272,6 +272,20 @@ export default function CredentialDetail() {
             )}
           </div>
         </div>
+
+        {/* Audit Trail */}
+        <div className="detail-card" style={{ marginTop: '20px' }}>
+          <div className="detail-card__header">
+            <span className="detail-card__title">Audit Trail</span>
+          </div>
+          <div className="detail-card__body">
+            <AuditTrail
+              credential={credential}
+              attestors={attestors}
+              expired={isExpiredFlag}
+            />
+          </div>
+        </div>
       </main>
 
       <footer className="footer">
@@ -283,8 +297,7 @@ export default function CredentialDetail() {
         </div>
       </footer>
 
-      {showShare && id && (
-        <ShareCredentialDialog
+      {showShare && id && (        <ShareCredentialDialog
           credentialId={id}
           onClose={() => setShowShare(false)}
         />

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,0 +1,202 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Navbar } from '../components/Navbar';
+import { CredentialCard } from '../components/CredentialCard';
+import { CredentialCardSkeleton } from '../components/CredentialCardSkeleton';
+import { EmptyState } from '../components/EmptyState';
+import { useWallet } from '../hooks';
+import {
+  getCredentialsBySubject,
+  getCredential,
+  isAttested,
+  getSlice,
+  isExpired,
+} from '../stellar';
+import { formatAddress } from '../lib/credentialUtils';
+import type { CredCardData } from '../lib/credentialUtils';
+
+export default function Profile() {
+  const { address } = useWallet();
+  const navigate = useNavigate();
+  const [cards, setCards] = useState<CredCardData[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!address) return;
+
+    (async () => {
+      setLoading(true);
+      setError(null);
+
+      const sliceIdRaw = localStorage.getItem('qp-slice-id');
+      const sliceId = sliceIdRaw ? BigInt(sliceIdRaw) : null;
+
+      try {
+        const ids: bigint[] = await getCredentialsBySubject(address);
+
+        if (!ids || ids.length === 0) {
+          setCards([]);
+          return;
+        }
+
+        const results = await Promise.all(
+          ids.map(async (id): Promise<CredCardData> => {
+            try {
+              const [credential, expired] = await Promise.all([
+                getCredential(id),
+                isExpired(id).catch(() => false),
+              ]);
+
+              let attested = false;
+              let slice = null;
+              let sliceError = false;
+
+              if (sliceId !== null) {
+                attested = await isAttested(id, sliceId).catch(() => false);
+                try { slice = await getSlice(sliceId); } catch { sliceError = true; }
+              }
+
+              return { credential, attested, slice, expired, sliceError, credError: null };
+            } catch (err) {
+              return {
+                credential: {
+                  id,
+                  subject: '',
+                  issuer: '',
+                  credential_type: 0,
+                  metadata_hash: new Uint8Array(),
+                  revoked: false,
+                  expires_at: null,
+                },
+                attested: false,
+                slice: null,
+                expired: false,
+                sliceError: false,
+                credError: err instanceof Error ? err.message : 'Failed to load',
+              };
+            }
+          })
+        );
+
+        setCards(results);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load credentials.');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [address]);
+
+  const sliceId = (() => {
+    const raw = localStorage.getItem('qp-slice-id');
+    return raw ? BigInt(raw) : null;
+  })();
+
+  const attested = cards.filter((c) => c.attested && !c.credential.revoked).length;
+  const revoked  = cards.filter((c) => c.credential.revoked).length;
+
+  return (
+    <>
+      <Navbar />
+      <main className="container" style={{ paddingTop: '40px', maxWidth: '900px', paddingBottom: '64px' }}>
+
+        {/* Profile header */}
+        <div className="profile-header">
+          <div className="profile-avatar" aria-hidden="true">
+            {address ? address.slice(0, 2).toUpperCase() : '??'}
+          </div>
+          <div className="profile-info">
+            <h1 className="profile-name">Credential Holder</h1>
+            {address ? (
+              <p className="profile-address mono" title={address}>{formatAddress(address)}</p>
+            ) : (
+              <p className="profile-address" style={{ color: 'var(--text-muted)' }}>No wallet connected</p>
+            )}
+          </div>
+        </div>
+
+        {/* Stats */}
+        {!loading && cards.length > 0 && (
+          <div className="profile-stats" role="list" aria-label="Credential statistics">
+            <div className="profile-stat" role="listitem">
+              <span className="profile-stat__value">{cards.length}</span>
+              <span className="profile-stat__label">Total</span>
+            </div>
+            <div className="profile-stat" role="listitem">
+              <span className="profile-stat__value" style={{ color: 'var(--green)' }}>{attested}</span>
+              <span className="profile-stat__label">Attested</span>
+            </div>
+            <div className="profile-stat" role="listitem">
+              <span className="profile-stat__value" style={{ color: 'var(--red)' }}>{revoked}</span>
+              <span className="profile-stat__label">Revoked</span>
+            </div>
+          </div>
+        )}
+
+        {/* Credential list */}
+        <section aria-label="Credentials">
+          <h2 className="profile-section-title">Credentials</h2>
+
+          {!address && (
+            <div className="error-card">
+              <div className="error-card__icon">🔌</div>
+              <div>
+                <div className="error-card__title">Wallet not connected</div>
+                <div className="error-card__msg">Connect your wallet to view your credentials.</div>
+                <button
+                  className="btn btn--ghost btn--sm"
+                  style={{ marginTop: '12px' }}
+                  onClick={() => navigate('/dashboard')}
+                >
+                  Go to Dashboard
+                </button>
+              </div>
+            </div>
+          )}
+
+          {address && loading && (
+            <div className="dashboard-grid">
+              {[1, 2, 3].map((i) => <CredentialCardSkeleton key={i} />)}
+            </div>
+          )}
+
+          {address && !loading && error && (
+            <div className="error-card">
+              <div className="error-card__icon">⚠️</div>
+              <div>
+                <div className="error-card__title">Could Not Load Credentials</div>
+                <div className="error-card__msg">{error}</div>
+              </div>
+            </div>
+          )}
+
+          {address && !loading && !error && cards.length === 0 && (
+            <EmptyState address={address} />
+          )}
+
+          {address && !loading && !error && cards.length > 0 && (
+            <div className="dashboard-grid">
+              {cards.map((card) => (
+                <CredentialCard
+                  key={card.credential.id.toString()}
+                  data={card}
+                  sliceId={sliceId}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      </main>
+
+      <footer className="footer">
+        <div className="container">
+          Powered by{' '}
+          <a href="https://stellar.org" target="_blank" rel="noopener">Stellar Soroban</a>
+          {' · '}
+          <a href="https://github.com/Phantomcall/QuorumProof" target="_blank" rel="noopener">QuorumProof</a>
+        </div>
+      </footer>
+    </>
+  );
+}

--- a/frontend/src/pages/__tests__/CredentialCompare.test.tsx
+++ b/frontend/src/pages/__tests__/CredentialCompare.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * CredentialCompare.test.tsx
+ * Tests for the credential comparison tool — issue #322
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../../lib/contracts/quorumProof', () => ({
+  getCredential: vi.fn(),
+  getAttestors: vi.fn(),
+  isExpired: vi.fn(),
+}));
+
+vi.mock('../../components/Navbar', () => ({
+  Navbar: () => <nav data-testid="navbar" />,
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeCredential(id: bigint, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    subject: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNN',
+    issuer:  'GBAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNN',
+    credential_type: 1,
+    metadata_hash: new Uint8Array(),
+    revoked: false,
+    expires_at: null,
+    ...overrides,
+  };
+}
+
+async function renderCompare() {
+  const { default: CredentialCompare } = await import('../../pages/CredentialCompare');
+  let result: ReturnType<typeof render>;
+  await act(async () => {
+    result = render(
+      <MemoryRouter>
+        <CredentialCompare />
+      </MemoryRouter>
+    );
+  });
+  return result!;
+}
+
+async function fillAndCompare(idA: string, idB: string) {
+  await act(async () => {
+    fireEvent.change(screen.getByLabelText('Credential A ID'), { target: { value: idA } });
+    fireEvent.change(screen.getByLabelText('Credential B ID'), { target: { value: idB } });
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByLabelText('Compare credentials'));
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('CredentialCompare — rendering', () => {
+  it('renders the page title and inputs', async () => {
+    await renderCompare();
+    expect(screen.getByText('Compare Credentials')).toBeInTheDocument();
+    expect(screen.getByLabelText('Credential A ID')).toBeInTheDocument();
+    expect(screen.getByLabelText('Credential B ID')).toBeInTheDocument();
+    expect(screen.getByLabelText('Compare credentials')).toBeInTheDocument();
+  });
+
+  it('does not show the comparison table before comparing', async () => {
+    await renderCompare();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+});
+
+describe('CredentialCompare — validation', () => {
+  it('shows error when both IDs are empty', async () => {
+    await renderCompare();
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Compare credentials'));
+    });
+    expect(screen.getByRole('alert')).toHaveTextContent(/enter both credential ids/i);
+  });
+
+  it('shows error when IDs are the same', async () => {
+    await renderCompare();
+    await fillAndCompare('5', '5');
+    expect(screen.getByRole('alert')).toHaveTextContent(/two different/i);
+  });
+});
+
+describe('CredentialCompare — identical credentials', () => {
+  beforeEach(async () => {
+    const contracts = await import('../../lib/contracts/quorumProof');
+    vi.mocked(contracts.getCredential).mockResolvedValue(makeCredential(1n));
+    vi.mocked(contracts.getAttestors).mockResolvedValue([]);
+    vi.mocked(contracts.isExpired).mockResolvedValue(false);
+  });
+
+  it('renders the comparison table', async () => {
+    await renderCompare();
+    await fillAndCompare('1', '2');
+    expect(screen.getByRole('table', { name: /credential comparison/i })).toBeInTheDocument();
+  });
+
+  it('shows no diff badges when credentials are identical', async () => {
+    await renderCompare();
+    await fillAndCompare('1', '2');
+    expect(screen.queryByText('≠')).not.toBeInTheDocument();
+  });
+
+  it('renders all expected field rows', async () => {
+    await renderCompare();
+    await fillAndCompare('1', '2');
+    for (const label of ['Type', 'Subject', 'Issuer', 'Expires', 'Revoked', 'Attestors']) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+});
+
+describe('CredentialCompare — different credentials', () => {
+  beforeEach(async () => {
+    const contracts = await import('../../lib/contracts/quorumProof');
+    vi.mocked(contracts.getCredential)
+      .mockResolvedValueOnce(makeCredential(1n, { credential_type: 1 }))  // Degree
+      .mockResolvedValueOnce(makeCredential(2n, { credential_type: 2 })); // License
+    vi.mocked(contracts.getAttestors).mockResolvedValue([]);
+    vi.mocked(contracts.isExpired).mockResolvedValue(false);
+  });
+
+  it('shows a diff badge for the differing field', async () => {
+    await renderCompare();
+    await fillAndCompare('1', '2');
+    expect(screen.getByText('≠')).toBeInTheDocument();
+  });
+
+  it('highlights the differing row', async () => {
+    await renderCompare();
+    await fillAndCompare('1', '2');
+    const typeRow = screen.getByText('Type').closest('.compare-row');
+    expect(typeRow).toHaveClass('compare-row--diff');
+  });
+
+  it('shows correct values for each credential', async () => {
+    await renderCompare();
+    await fillAndCompare('1', '2');
+    expect(screen.getByTestId('field-a-type')).toHaveTextContent('🎓 Degree');
+    expect(screen.getByTestId('field-b-type')).toHaveTextContent('🏛️ License');
+  });
+});
+
+describe('CredentialCompare — revoked credential', () => {
+  beforeEach(async () => {
+    const contracts = await import('../../lib/contracts/quorumProof');
+    vi.mocked(contracts.getCredential)
+      .mockResolvedValueOnce(makeCredential(1n, { revoked: false }))
+      .mockResolvedValueOnce(makeCredential(2n, { revoked: true }));
+    vi.mocked(contracts.getAttestors).mockResolvedValue([]);
+    vi.mocked(contracts.isExpired).mockResolvedValue(false);
+  });
+
+  it('shows Yes/No for revoked field and highlights the diff', async () => {
+    await renderCompare();
+    await fillAndCompare('1', '2');
+    expect(screen.getByTestId('field-a-revoked')).toHaveTextContent('No');
+    expect(screen.getByTestId('field-b-revoked')).toHaveTextContent('Yes');
+    const revokedRow = screen.getByText('Revoked').closest('.compare-row');
+    expect(revokedRow).toHaveClass('compare-row--diff');
+  });
+});
+
+describe('CredentialCompare — fetch error', () => {
+  beforeEach(async () => {
+    const contracts = await import('../../lib/contracts/quorumProof');
+    vi.mocked(contracts.getCredential).mockRejectedValue(new Error('RPC timeout'));
+  });
+
+  it('shows an error message on fetch failure', async () => {
+    await renderCompare();
+    await fillAndCompare('1', '2');
+    expect(screen.getByRole('alert')).toHaveTextContent(/RPC timeout/i);
+  });
+});

--- a/frontend/src/pages/__tests__/Profile.test.tsx
+++ b/frontend/src/pages/__tests__/Profile.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * Profile.test.tsx
+ * Tests for the credential holder profile page — issue #320
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../../hooks', () => ({
+  useWallet: vi.fn(),
+}));
+
+vi.mock('../../stellar', () => ({
+  getCredentialsBySubject: vi.fn(),
+  getCredential: vi.fn(),
+  isAttested: vi.fn(),
+  getSlice: vi.fn(),
+  isExpired: vi.fn(),
+}));
+
+vi.mock('../../components/Navbar', () => ({
+  Navbar: () => <nav data-testid="navbar" />,
+}));
+
+vi.mock('../../components/CredentialCard', () => ({
+  CredentialCard: ({ data }: { data: { credential: { id: bigint } } }) => (
+    <div data-testid="credential-card">{data.credential.id.toString()}</div>
+  ),
+}));
+
+vi.mock('../../components/CredentialCardSkeleton', () => ({
+  CredentialCardSkeleton: () => <div data-testid="skeleton" />,
+}));
+
+vi.mock('../../components/EmptyState', () => ({
+  EmptyState: () => <div data-testid="empty-state" />,
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const WALLET_ADDRESS = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNN';
+
+function makeCredential(id: bigint) {
+  return {
+    id,
+    subject: WALLET_ADDRESS,
+    issuer: WALLET_ADDRESS,
+    credential_type: 1,
+    metadata_hash: new Uint8Array(),
+    revoked: false,
+    expires_at: null,
+  };
+}
+
+async function renderProfile() {
+  const { default: Profile } = await import('../../pages/Profile');
+  let result: ReturnType<typeof render>;
+  await act(async () => {
+    result = render(
+      <MemoryRouter>
+        <Profile />
+      </MemoryRouter>
+    );
+  });
+  return result!;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Profile page — no wallet', () => {
+  beforeEach(async () => {
+    const { useWallet } = await import('../../hooks');
+    vi.mocked(useWallet).mockReturnValue({
+      address: null,
+      isConnected: false,
+      hasFreighter: false,
+      isInitializing: false,
+      network: 'testnet',
+      error: null,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    });
+  });
+
+  it('shows wallet-not-connected message', async () => {
+    await renderProfile();
+    expect(screen.getByText(/wallet not connected/i)).toBeInTheDocument();
+  });
+
+  it('does not show credential cards', async () => {
+    await renderProfile();
+    expect(screen.queryByTestId('credential-card')).not.toBeInTheDocument();
+  });
+});
+
+describe('Profile page — wallet connected, loading', () => {
+  beforeEach(async () => {
+    const { useWallet } = await import('../../hooks');
+    vi.mocked(useWallet).mockReturnValue({
+      address: WALLET_ADDRESS,
+      isConnected: true,
+      hasFreighter: true,
+      isInitializing: false,
+      network: 'testnet',
+      error: null,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    });
+
+    const { getCredentialsBySubject } = await import('../../stellar');
+    // Never resolves during this test
+    vi.mocked(getCredentialsBySubject).mockReturnValue(new Promise(() => {}));
+  });
+
+  it('shows skeleton cards while loading', async () => {
+    await renderProfile();
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
+  });
+});
+
+describe('Profile page — wallet connected, credentials loaded', () => {
+  beforeEach(async () => {
+    const { useWallet } = await import('../../hooks');
+    vi.mocked(useWallet).mockReturnValue({
+      address: WALLET_ADDRESS,
+      isConnected: true,
+      hasFreighter: true,
+      isInitializing: false,
+      network: 'testnet',
+      error: null,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    });
+
+    const stellar = await import('../../stellar');
+    vi.mocked(stellar.getCredentialsBySubject).mockResolvedValue([1n, 2n]);
+    vi.mocked(stellar.getCredential).mockImplementation((id) =>
+      Promise.resolve(makeCredential(id))
+    );
+    vi.mocked(stellar.isExpired).mockResolvedValue(false);
+    vi.mocked(stellar.isAttested).mockResolvedValue(false);
+    vi.mocked(stellar.getSlice).mockRejectedValue(new Error('no slice'));
+
+    localStorage.removeItem('qp-slice-id');
+  });
+
+  it('renders the profile header with address', async () => {
+    await renderProfile();
+    expect(screen.getByText('Credential Holder')).toBeInTheDocument();
+    expect(screen.getByTitle(WALLET_ADDRESS)).toBeInTheDocument();
+  });
+
+  it('renders a credential card for each credential', async () => {
+    await renderProfile();
+    expect(screen.getAllByTestId('credential-card')).toHaveLength(2);
+  });
+
+  it('shows stats with correct total count', async () => {
+    await renderProfile();
+    const stats = screen.getByRole('list', { name: /credential statistics/i });
+    expect(stats).toBeInTheDocument();
+    // Total stat is the first listitem value
+    const items = screen.getAllByRole('listitem');
+    expect(items[0]).toHaveTextContent('2'); // total = 2
+  });
+
+  it('does not show skeleton or empty state', async () => {
+    await renderProfile();
+    expect(screen.queryByTestId('skeleton')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();
+  });
+});
+
+describe('Profile page — wallet connected, no credentials', () => {
+  beforeEach(async () => {
+    const { useWallet } = await import('../../hooks');
+    vi.mocked(useWallet).mockReturnValue({
+      address: WALLET_ADDRESS,
+      isConnected: true,
+      hasFreighter: true,
+      isInitializing: false,
+      network: 'testnet',
+      error: null,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    });
+
+    const { getCredentialsBySubject } = await import('../../stellar');
+    vi.mocked(getCredentialsBySubject).mockResolvedValue([]);
+  });
+
+  it('shows empty state', async () => {
+    await renderProfile();
+    expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+  });
+});
+
+describe('Profile page — fetch error', () => {
+  beforeEach(async () => {
+    const { useWallet } = await import('../../hooks');
+    vi.mocked(useWallet).mockReturnValue({
+      address: WALLET_ADDRESS,
+      isConnected: true,
+      hasFreighter: true,
+      isInitializing: false,
+      network: 'testnet',
+      error: null,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    });
+
+    const { getCredentialsBySubject } = await import('../../stellar');
+    vi.mocked(getCredentialsBySubject).mockRejectedValue(new Error('RPC error'));
+  });
+
+  it('shows error message', async () => {
+    await renderProfile();
+    expect(screen.getByText(/could not load credentials/i)).toBeInTheDocument();
+    expect(screen.getByText(/RPC error/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1488,3 +1488,86 @@ textarea {
   padding: 16px 24px;
   border-top: 1px solid var(--border);
 }
+
+/* ── Profile Page ────────────────────────────────────────────────────────────── */
+.profile-header {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-bottom: 28px;
+  padding: 24px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+.profile-avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: var(--radius-full);
+  background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  font-weight: 700;
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.profile-info { flex: 1; min-width: 0; }
+
+.profile-name {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 4px;
+}
+
+.profile-address {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.profile-stats {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+.profile-stat {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.profile-stat__value {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1;
+}
+
+.profile-stat__label {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.profile-section-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 16px;
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1571,3 +1571,131 @@ textarea {
   color: var(--text-primary);
   margin: 0 0 16px;
 }
+
+/* ── Credential Compare ──────────────────────────────────────────────────────── */
+.compare-title {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 6px;
+}
+
+.compare-subtitle {
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin: 0 0 28px;
+}
+
+.compare-inputs {
+  display: flex;
+  align-items: flex-end;
+  gap: 16px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+
+.compare-input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+  min-width: 120px;
+}
+
+.compare-input-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.compare-input {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  padding: 10px 14px;
+  outline: none;
+  transition: border-color var(--transition);
+}
+.compare-input:focus { border-color: var(--border-active); }
+.compare-input::placeholder { color: var(--text-muted); }
+
+.compare-vs {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-muted);
+  padding-bottom: 10px;
+  flex-shrink: 0;
+}
+
+.compare-error {
+  color: var(--red);
+  font-size: 13px;
+  margin: 0 0 16px;
+}
+
+.compare-table {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.compare-row {
+  display: grid;
+  grid-template-columns: 160px 1fr 1fr;
+  border-bottom: 1px solid var(--border);
+  transition: background var(--transition);
+}
+.compare-row:last-child { border-bottom: none; }
+
+.compare-row--header {
+  background: var(--bg-surface);
+}
+
+.compare-row--diff {
+  background: rgba(239, 68, 68, 0.06);
+}
+
+.compare-cell {
+  padding: 12px 16px;
+  font-size: 13px;
+  color: var(--text-primary);
+  border-right: 1px solid var(--border);
+  word-break: break-all;
+}
+.compare-cell:last-child { border-right: none; }
+
+.compare-cell--label {
+  font-weight: 600;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--bg-surface);
+}
+
+.compare-row--header .compare-cell {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.compare-diff-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--red-subtle);
+  color: var(--red);
+  border-radius: var(--radius-full);
+  font-size: 11px;
+  font-weight: 700;
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1318,3 +1318,173 @@ textarea {
 .qsb-success__actions {
   margin-top: 20px;
 }
+
+/* ── Share Credential Dialog ─────────────────────────────────────────────── */
+.share-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 16px;
+}
+
+.share-dialog {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  width: 100%;
+  max-width: 520px;
+  box-shadow: var(--shadow-card);
+}
+
+.share-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.share-dialog__title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.share-dialog__close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 16px;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition);
+}
+.share-dialog__close:hover { color: var(--text-primary); }
+
+.share-dialog__section {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border);
+}
+.share-dialog__section:last-of-type { border-bottom: none; }
+
+.share-dialog__label {
+  display: block;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 10px;
+}
+
+.share-dialog__link-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
+}
+
+.share-dialog__link-url {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.share-dialog__add-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.share-dialog__input {
+  flex: 1;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  padding: 8px 12px;
+  outline: none;
+  transition: border-color var(--transition);
+}
+.share-dialog__input:focus { border-color: var(--border-active); }
+.share-dialog__input::placeholder { color: var(--text-muted); }
+
+.share-dialog__select {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 13px;
+  padding: 8px 10px;
+  outline: none;
+  cursor: pointer;
+}
+.share-dialog__select--sm { padding: 4px 8px; font-size: 12px; }
+
+.share-dialog__error {
+  color: var(--red);
+  font-size: 12px;
+  margin: 8px 0 0;
+}
+
+.share-dialog__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.share-dialog__list-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
+}
+
+.share-dialog__addr {
+  flex: 1;
+  font-size: 13px;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.share-dialog__remove {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition);
+}
+.share-dialog__remove:hover { color: var(--red); }
+
+.share-dialog__footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 16px 24px;
+  border-top: 1px solid var(--border);
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1699,3 +1699,84 @@ textarea {
   height: 18px;
   flex-shrink: 0;
 }
+
+/* ── Audit Trail Timeline ────────────────────────────────────────────────────── */
+.audit-trail {
+  padding: 4px 0;
+}
+
+.audit-timeline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.audit-event {
+  display: grid;
+  grid-template-columns: 32px 1fr;
+  grid-template-rows: auto auto;
+  column-gap: 14px;
+  position: relative;
+  padding-bottom: 24px;
+}
+.audit-event:last-child { padding-bottom: 0; }
+
+.audit-line {
+  grid-column: 1;
+  grid-row: 2;
+  width: 2px;
+  background: var(--border);
+  margin: 4px auto 0;
+  min-height: 100%;
+  justify-self: center;
+}
+
+.audit-dot {
+  grid-column: 1;
+  grid-row: 1;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  flex-shrink: 0;
+  border: 2px solid transparent;
+}
+
+.audit-dot--issued   { background: var(--blue-subtle);   border-color: var(--blue);   }
+.audit-dot--attested { background: var(--green-subtle);  border-color: var(--green);  }
+.audit-dot--revoked  { background: var(--red-subtle);    border-color: var(--red);    }
+.audit-dot--expired  { background: var(--yellow-subtle); border-color: var(--yellow); }
+
+.audit-content {
+  grid-column: 2;
+  grid-row: 1;
+  padding-top: 4px;
+}
+
+.audit-event__label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 2px;
+}
+
+.audit-event__detail {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+
+.audit-event__timestamp {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.audit-empty {
+  font-size: 13px;
+  color: var(--text-muted);
+  padding: 12px 0;
+}


### PR DESCRIPTION
## Summary

This PR implements four medium/low priority frontend features for QuorumProof.

---

### 319 — Implement credential sharing UI

**Files changed:**
- `frontend/src/components/ShareCredentialDialog.tsx` *(new)*
  - Share dialog with public verification link + copy button
  - Add-by-Stellar-address form with validation (starts with G, ≥56 chars)
  - Permission levels: View / Verify / Full per shared address
  - Per-entry permission editing and removal
  - Accessible (aria roles, dialog semantics)
- `frontend/src/styles.css` — share dialog CSS
- `frontend/src/components/index.ts` — exports `ShareCredentialDialog`, `ShareEntry`, `SharePermission`
- `frontend/src/pages/CredentialDetail.tsx` — integrated Share button and dialog
- `frontend/src/__tests__/ShareCredentialDialog.test.tsx` *(new)* — 18 passing tests

---

### 320 — Add credential holder profile page

**Files changed:**
- `frontend/src/pages/Profile.tsx` *(new)*
  - Profile header with gradient avatar (initials) and truncated address
  - Stats bar: Total / Attested / Revoked credential counts
  - Credential list reusing `CredentialCard`, `CredentialCardSkeleton`, `EmptyState`
  - Handles no-wallet, loading, error, and empty states
- `frontend/src/styles.css` — profile page CSS
- `frontend/src/App.tsx` — lazy-loaded `/profile` route behind `WalletGuard`
- `frontend/src/components/AppLayout.tsx` — Profile nav link
- `frontend/src/pages/__tests__/Profile.test.tsx` *(new)* — 9 passing tests

---

### 322 — Add credential comparison tool

**Files changed:**
- `frontend/src/pages/CredentialCompare.tsx` *(new)*
  - Two credential ID inputs + Compare button
  - Side-by-side table with 6 fields: Type, Subject, Issuer, Expires, Revoked, Attestors
  - Difference highlighting: red-tinted row + `≠` badge on differing fields
  - Input validation (empty IDs, duplicate IDs)
- `frontend/src/styles.css` — comparison view CSS
- `frontend/src/App.tsx` — lazy-loaded public `/compare` route
- `frontend/src/components/AppLayout.tsx` — Compare nav link
- `frontend/src/pages/__tests__/CredentialCompare.test.tsx` *(new)* — 12 passing tests

---

### 321 — Implement credential audit trail UI

**Files changed:**
- `frontend/src/components/AuditTrail.tsx` *(new)*
  - `buildAuditEvents()` pure helper deriving events from credential state: issued, attested (one per attestor), revoked, expired
  - Vertical timeline with color-coded dots (blue/green/red/yellow) and connector lines
  - Label, detail text, and timestamp per event
- `frontend/src/styles.css` — audit trail CSS
- `frontend/src/components/index.ts` — exports `AuditTrail`, `buildAuditEvents`, types
- `frontend/src/pages/CredentialDetail.tsx` — Audit Trail card added after attestation section
- `frontend/src/__tests__/AuditTrail.test.tsx` *(new)* — 20 passing tests

---


Closes #319
Closes #320
Closes #321
Closes #322