### PR TITLE
feat: CI/CD pipeline, disaster recovery docs, credential versioning & consent transfer (#327 #328 #329 #330)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  contracts:
+    name: Build & Test Contracts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build contracts
+        run: ./scripts/build.sh
+
+      - name: Test contracts
+        run: ./scripts/test.sh
+
+  frontend:
+    name: Build & Test Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy Testnet
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy to Testnet
+    runs-on: ubuntu-latest
+    environment: testnet
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install Stellar CLI
+        run: cargo install stellar-cli --locked
+
+      - name: Build contracts
+        run: ./scripts/build.sh
+
+      - name: Deploy to testnet
+        env:
+          STELLAR_NETWORK: testnet
+          STELLAR_RPC_URL: ${{ secrets.STELLAR_RPC_URL }}
+          STELLAR_SECRET_KEY: ${{ secrets.STELLAR_SECRET_KEY }}
+        run: |
+          stellar keys add deployer --secret-key "$STELLAR_SECRET_KEY"
+          ./scripts/deploy_testnet.sh

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -122,6 +122,7 @@ pub struct Credential {
     pub metadata_hash: soroban_sdk::Bytes,
     pub revoked: bool,
     pub expires_at: Option<u64>,
+    pub version: u32,
 }
 
 /// A single proof request record, capturing who requested proof of a credential and when.
@@ -363,7 +364,7 @@ impl QuorumProofContract {
         }
         
         let id: u64 = env.storage().instance().get(&DataKey::CredentialCount).unwrap_or(0u64) + 1;
-        let credential = Credential { id, subject: subject.clone(), issuer: issuer.clone(), credential_type, metadata_hash, revoked: false, expires_at };
+        let credential = Credential { id, subject: subject.clone(), issuer: issuer.clone(), credential_type, metadata_hash, revoked: false, expires_at, version: 1 };
         env.storage().instance().set(&DataKey::Credential(id), &credential);
         env.storage().instance().extend_ttl(STANDARD_TTL, EXTENDED_TTL);
         env.storage().instance().set(&DataKey::CredentialCount, &id);
@@ -465,6 +466,7 @@ impl QuorumProofContract {
             metadata_hash,
             revoked: false,
             expires_at,
+            version: 1,
         };
         env.storage()
             .instance()
@@ -519,6 +521,41 @@ impl QuorumProofContract {
             );
         }
         credential
+    }
+
+    /// Update the metadata hash of a credential and increment its version.
+    ///
+    /// Only the original issuer may call this function.
+    ///
+    /// # Parameters
+    /// - `issuer`: The address that originally issued the credential; must authorize.
+    /// - `credential_id`: The ID of the credential to update.
+    /// - `new_metadata_hash`: The new metadata hash to store.
+    ///
+    /// # Panics
+    /// Panics with `ContractError::CredentialNotFound` if the credential does not exist.
+    /// Panics if the caller is not the original issuer.
+    pub fn update_metadata(
+        env: Env,
+        issuer: Address,
+        credential_id: u64,
+        new_metadata_hash: soroban_sdk::Bytes,
+    ) {
+        issuer.require_auth();
+        Self::require_not_paused(&env);
+        assert!(!new_metadata_hash.is_empty(), "metadata_hash cannot be empty");
+        let mut credential: Credential = env
+            .storage()
+            .instance()
+            .get(&DataKey::Credential(credential_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::CredentialNotFound));
+        assert!(credential.issuer == issuer, "only the issuer may update metadata");
+        credential.metadata_hash = new_metadata_hash;
+        credential.version += 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::Credential(credential_id), &credential);
+        env.storage().instance().extend_ttl(STANDARD_TTL, EXTENDED_TTL);
     }
 
     /// Return all credential IDs issued to a subject.
@@ -2512,6 +2549,30 @@ mod tests {
         let id = client.issue_credential(&issuer, &subject, &1u32, &metadata, &Some(2_000u64));
         set_ledger_timestamp(&env, 3_000);
         client.get_credential(&id);
+    }
+
+    #[test]
+    fn test_version_increments_on_update_metadata() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let metadata = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+        let id = client.issue_credential(&issuer, &subject, &1u32, &metadata, &None);
+
+        let cred_v1 = client.get_credential(&id);
+        assert_eq!(cred_v1.version, 1);
+
+        let new_metadata = Bytes::from_slice(&env, b"QmUpdatedHash0000000000000000000000");
+        client.update_metadata(&issuer, &id, &new_metadata);
+        let cred_v2 = client.get_credential(&id);
+        assert_eq!(cred_v2.version, 2);
+        assert_eq!(cred_v2.metadata_hash, new_metadata);
+
+        client.update_metadata(&issuer, &id, &metadata);
+        let cred_v3 = client.get_credential(&id);
+        assert_eq!(cred_v3.version, 3);
     }
 
     #[test]

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -80,6 +80,7 @@ pub enum ContractError {
     AttestationExpired = 6,
     InvalidInput = 7,
     InvalidAddress = 8,
+    UnauthorizedTransfer = 9,
 }
 
 #[contracttype]
@@ -102,6 +103,8 @@ pub enum DataKey {
     ProofRequestCount,
     /// Stores the ReputationRecovery record for an attestor
     ReputationRecovery(Address),
+    /// Pending transfer request for a credential
+    TransferRequest(u64),
 }
 
 #[contracttype]
@@ -151,6 +154,18 @@ pub struct ReputationRecovery {
     pub initiated_at: u64,
     /// Whether the recovery has been completed.
     pub completed: bool,
+}
+
+/// A pending consent-based credential transfer request.
+#[contracttype]
+#[derive(Clone)]
+pub struct TransferRequest {
+    /// The credential being transferred.
+    pub credential_id: u64,
+    /// The current subject initiating the transfer.
+    pub from: Address,
+    /// The intended recipient who must accept.
+    pub to: Address,
 }
 
 /// QuorumSlice represents a federated Byzantine agreement (FBA) trust slice.
@@ -555,6 +570,97 @@ impl QuorumProofContract {
         env.storage()
             .instance()
             .set(&DataKey::Credential(credential_id), &credential);
+        env.storage().instance().extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+    }
+
+    /// Initiate a consent-based transfer of a credential to a new subject.
+    ///
+    /// The current credential subject calls this to propose a transfer to `to`.
+    /// The transfer is not final until `accept_transfer` is called by `to`.
+    ///
+    /// # Panics
+    /// Panics with `ContractError::CredentialNotFound` if the credential does not exist.
+    /// Panics with `ContractError::UnauthorizedTransfer` if the caller is not the current subject.
+    pub fn initiate_transfer(env: Env, from: Address, credential_id: u64, to: Address) {
+        from.require_auth();
+        Self::require_not_paused(&env);
+        let credential: Credential = env
+            .storage()
+            .instance()
+            .get(&DataKey::Credential(credential_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::CredentialNotFound));
+        if credential.subject != from {
+            panic_with_error!(&env, ContractError::UnauthorizedTransfer);
+        }
+        let request = TransferRequest { credential_id, from, to };
+        env.storage()
+            .instance()
+            .set(&DataKey::TransferRequest(credential_id), &request);
+        env.storage().instance().extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+    }
+
+    /// Accept a pending transfer request, reassigning the credential to the caller.
+    ///
+    /// Only the address named as `to` in the pending `TransferRequest` may call this.
+    ///
+    /// # Panics
+    /// Panics with `ContractError::CredentialNotFound` if the credential does not exist.
+    /// Panics with `ContractError::UnauthorizedTransfer` if no pending request exists or
+    /// the caller is not the intended recipient.
+    pub fn accept_transfer(env: Env, to: Address, credential_id: u64) {
+        to.require_auth();
+        Self::require_not_paused(&env);
+        let request: TransferRequest = env
+            .storage()
+            .instance()
+            .get(&DataKey::TransferRequest(credential_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::UnauthorizedTransfer));
+        if request.to != to {
+            panic_with_error!(&env, ContractError::UnauthorizedTransfer);
+        }
+        let mut credential: Credential = env
+            .storage()
+            .instance()
+            .get(&DataKey::Credential(credential_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::CredentialNotFound));
+
+        // Remove credential from old subject's list
+        let mut old_creds: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::SubjectCredentials(credential.subject.clone()))
+            .unwrap_or(Vec::new(&env));
+        let mut retained: Vec<u64> = Vec::new(&env);
+        for id in old_creds.iter() {
+            if id != credential_id {
+                retained.push_back(id);
+            }
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::SubjectCredentials(credential.subject.clone()), &retained);
+
+        // Add to new subject's list
+        let mut new_creds: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::SubjectCredentials(to.clone()))
+            .unwrap_or(Vec::new(&env));
+        new_creds.push_back(credential_id);
+        env.storage()
+            .instance()
+            .set(&DataKey::SubjectCredentials(to.clone()), &new_creds);
+
+        // Update credential subject
+        credential.subject = to;
+        env.storage()
+            .instance()
+            .set(&DataKey::Credential(credential_id), &credential);
+
+        // Clear the pending request
+        env.storage()
+            .instance()
+            .remove(&DataKey::TransferRequest(credential_id));
         env.storage().instance().extend_ttl(STANDARD_TTL, EXTENDED_TTL);
     }
 
@@ -2573,6 +2679,79 @@ mod tests {
         client.update_metadata(&issuer, &id, &metadata);
         let cred_v3 = client.get_credential(&id);
         assert_eq!(cred_v3.version, 3);
+    }
+
+    #[test]
+    fn test_transfer_full_flow() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let metadata = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+        let id = client.issue_credential(&issuer, &subject, &1u32, &metadata, &None);
+
+        client.initiate_transfer(&subject, &id, &recipient);
+        client.accept_transfer(&recipient, &id);
+
+        let cred = client.get_credential(&id);
+        assert_eq!(cred.subject, recipient);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_initiate_transfer_unauthorized() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let metadata = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+        let id = client.issue_credential(&issuer, &subject, &1u32, &metadata, &None);
+
+        // attacker is not the subject — should panic with UnauthorizedTransfer
+        client.initiate_transfer(&attacker, &id, &recipient);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_accept_transfer_wrong_recipient() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let other = Address::generate(&env);
+        let metadata = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+        let id = client.issue_credential(&issuer, &subject, &1u32, &metadata, &None);
+
+        client.initiate_transfer(&subject, &id, &recipient);
+        // `other` is not the intended recipient — should panic
+        client.accept_transfer(&other, &id);
+    }
+
+    #[test]
+    fn test_transfer_updates_subject_credential_lists() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let metadata = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+        let id = client.issue_credential(&issuer, &subject, &1u32, &metadata, &None);
+
+        client.initiate_transfer(&subject, &id, &recipient);
+        client.accept_transfer(&recipient, &id);
+
+        let old_list = client.get_credentials_by_subject(&subject, &1u32, &50u32);
+        let new_list = client.get_credentials_by_subject(&recipient, &1u32, &50u32);
+        assert!(!old_list.contains(&id));
+        assert!(new_list.contains(&id));
     }
 
     #[test]

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -1,0 +1,96 @@
+# Disaster Recovery Procedures
+
+## Overview
+
+This document covers recovery procedures, backup strategy, and recovery testing for QuorumProof. Because core credential data lives on the Stellar blockchain, recovery focuses on restoring contract access, operator keys, and off-chain supporting infrastructure.
+
+---
+
+## 1. Recovery Procedures
+
+### 1.1 Lost Deployer / Admin Key
+
+1. If a backup key was pre-registered as a secondary admin via the contract's admin management, invoke `set_admin(new_admin)` from the backup key.
+2. If no backup key exists, the contract is unrecoverable — redeploy all three contracts and re-issue credentials from source institutions.
+3. Update `.env` and GitHub secrets (`STELLAR_SECRET_KEY`) with the new key immediately.
+
+### 1.2 Contract Redeployment
+
+Use this procedure when a contract must be redeployed (e.g. critical bug, key compromise):
+
+```bash
+# 1. Build fresh WASM artifacts
+./scripts/build.sh
+
+# 2. Deploy to the target network
+./scripts/deploy_testnet.sh   # or deploy_mainnet.sh for production
+
+# 3. Update contract addresses in .env
+CONTRACT_QUORUM_PROOF=<new-id>
+CONTRACT_SBT_REGISTRY=<new-id>
+CONTRACT_ZK_VERIFIER=<new-id>
+
+# 4. Update frontend/dashboard env files and redeploy frontend
+```
+
+> Existing on-chain SBTs issued under the old contract address are not migrated automatically. Coordinate with attestors to re-attest affected credentials.
+
+### 1.3 RPC / Network Outage
+
+- Switch `STELLAR_RPC_URL` to an alternate RPC endpoint (e.g. Horizon public API or a self-hosted Stellar node).
+- Testnet: `https://soroban-testnet.stellar.org`
+- Mainnet fallback: `https://horizon.stellar.org`
+- No contract redeployment is needed; only the client configuration changes.
+
+### 1.4 Frontend / Dashboard Outage
+
+1. Redeploy from the latest tagged release on the `main` branch via the CI/CD pipeline (`workflow_dispatch` on `deploy.yml`).
+2. If the hosting provider is unavailable, deploy to an alternate static host using `npm run build` output from `frontend/` or `dashboard/`.
+
+---
+
+## 2. Backup Strategy
+
+| Asset | What to Back Up | Where | Frequency |
+|---|---|---|---|
+| Deployer secret key | Stellar secret key (`S...`) | Encrypted cold storage + GitHub secret | On creation / rotation |
+| Contract IDs | `CONTRACT_QUORUM_PROOF`, `CONTRACT_SBT_REGISTRY`, `CONTRACT_ZK_VERIFIER` | `.env`, repo wiki, team password manager | After every deployment |
+| Environment config | `.env` values (non-secret portions) | `.env.example` kept up to date in repo | On every config change |
+| WASM artifacts | Built `.wasm` files | GitHub Actions artifacts (retained 90 days) | Every CI run on `main` |
+| On-chain state | Credential and attestation records | Inherently replicated by Stellar network | Continuous (blockchain) |
+
+**Key rotation policy**: Rotate the deployer key every 90 days or immediately after any suspected compromise.
+
+---
+
+## 3. Recovery Testing
+
+Run recovery drills on testnet. Do **not** use mainnet for drills.
+
+### 3.1 Key Recovery Drill (quarterly)
+
+1. Generate a temporary test key: `stellar keys generate dr-test --network testnet`
+2. Register it as a secondary admin on the testnet contract.
+3. Revoke the primary test key and confirm `dr-test` can call admin-gated functions.
+4. Clean up: remove `dr-test` and restore primary key.
+
+### 3.2 Contract Redeployment Drill (per release)
+
+1. On testnet, run `./scripts/deploy_testnet.sh` from a clean environment (no cached `.env`).
+2. Verify all three contract IDs are returned and functional via `cargo test`.
+3. Confirm the CI deploy workflow (`deploy.yml`) completes successfully end-to-end.
+
+### 3.3 RPC Failover Drill (quarterly)
+
+1. Point `STELLAR_RPC_URL` at the fallback endpoint in `.env`.
+2. Run `cargo test` and confirm all contract interactions succeed.
+3. Restore the primary RPC URL.
+
+### 3.4 Checklist
+
+- [ ] Deployer key backup verified in cold storage
+- [ ] Contract IDs recorded and accessible to the team
+- [ ] Secondary admin key registered on-chain
+- [ ] CI deploy workflow tested via `workflow_dispatch`
+- [ ] RPC failover endpoint confirmed reachable
+- [ ] Recovery drill results logged with date and outcome


### PR DESCRIPTION
## Summary

This PR resolves four issues in a single branch: **#327**, **#328**, **#329**, and **#330**.

---

## #327 — Implement Continuous Integration

**Files:** `.github/workflows/ci.yml`, `.github/workflows/deploy.yml`

### CI (`ci.yml`)
- Triggers on push/PR to `main` and `develop`
- **Contracts job**: installs Rust + `wasm32-unknown-unknown` target, caches Cargo registry, runs `./scripts/build.sh` and `./scripts/test.sh`
- **Frontend job**: sets up Node 20, runs `npm ci`, `npm run lint`, `npm test` (vitest), and `npm run build`

### Deploy (`deploy.yml`)
- Triggers on push to `main` or manual `workflow_dispatch`
- Builds contracts, installs Stellar CLI, deploys all three contracts to testnet
- Uses `STELLAR_SECRET_KEY` and `STELLAR_RPC_URL` GitHub secrets under the `testnet` environment

---

## #328 — Add Disaster Recovery Procedures

**File:** `docs/disaster-recovery.md`

Covers all three acceptance criteria:

- **Recovery procedures**: lost/compromised admin key (backup key promotion or full redeploy), contract redeployment steps, RPC/network failover, frontend/dashboard outage recovery
- **Backup strategy**: table covering deployer secret key, contract IDs, env config, WASM artifacts (CI artifacts), and on-chain state — with a 90-day key rotation policy
- **Recovery testing**: quarterly and per-release drills for key recovery, contract redeployment, and RPC failover — plus a verification checklist

---

## #329 — Implement Credential Metadata Versioning

**File:** `contracts/quorum_proof/src/lib.rs`

- Added `pub version: u32` field to the `Credential` struct
- Both `issue_credential` and `issue_inner` initialize `version: 1`
- New `update_metadata(issuer, credential_id, new_metadata_hash)` function:
  - Requires issuer authorization
  - Validates caller is the original issuer
  - Updates `metadata_hash` and increments `version`
- `get_credential` returns the full `Credential` struct including `version` (no change needed)
- New test `test_version_increments_on_update_metadata`: issues credential (asserts `version == 1`), calls `update_metadata` twice, asserts `version == 2` then `version == 3` with correct hash

---

## #330 — Add Credential Transfer with Consent

**File:** `contracts/quorum_proof/src/lib.rs`

- Added `ContractError::UnauthorizedTransfer = 9`
- Added `DataKey::TransferRequest(u64)` for storing pending requests
- Added `TransferRequest` struct (`credential_id`, `from`, `to`)
- New `initiate_transfer(from, credential_id, to)`:
  - Requires `from` authorization
  - Panics with `UnauthorizedTransfer` if `from != credential.subject`
  - Stores a `TransferRequest` on-chain
- New `accept_transfer(to, credential_id)`:
  - Requires `to` authorization
  - Panics with `UnauthorizedTransfer` if no pending request or `to` is not the intended recipient
  - Reassigns `credential.subject` to `to`
  - Removes credential ID from old subject's `SubjectCredentials` list
  - Adds credential ID to new subject's `SubjectCredentials` list
  - Clears the pending `TransferRequest`
- 4 new tests:
  - `test_transfer_full_flow` — happy path, subject changes to recipient
  - `test_initiate_transfer_unauthorized` — non-subject initiating panics
  - `test_accept_transfer_wrong_recipient` — wrong address accepting panics
  - `test_transfer_updates_subject_credential_lists` — verifies old list no longer contains ID, new list does

---

## Checklist

- [x] CI configuration (`ci.yml`)
- [x] Automated testing in CI (contracts + frontend)
- [x] Deployment automation (`deploy.yml`)
- [x] Disaster recovery procedures documented
- [x] Backup strategy documented
- [x] Recovery testing procedures documented
- [x] `version` field on `Credential` struct
- [x] `get_credential` returns version info
- [x] Tests verify version increments on update
- [x] `initiate_transfer` function implemented
- [x] `accept_transfer` function implemented
- [x] Unauthorized transfers prevented with structured error

Closes #327, Closes #328, Closes #329, Closes #330