### PR TITLE
feat: attestation notifications, batch verification, metadata & error docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Follow the step-by-step guide in `demo/demo-script.md`
 - [Trust Slice Model](docs/trust-slices.md)
 - [ZK Verification Design](docs/zk-verification.md)
 - [Threat Model & Security](docs/threat-model.md)
+- [Error Code Reference](docs/error-codes.md)
 - [Roadmap](docs/roadmap.md)
 
 ## 🎓 Smart Contract API

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -68,6 +68,8 @@ pub struct AttestationRecord {
     pub expires_at: Option<u64>,
     /// The attestation value: true for valid, false for invalid.
     pub attestation_value: bool,
+    /// Optional arbitrary metadata attached by the attestor (e.g. notes, reference IDs).
+    pub metadata: Option<soroban_sdk::Bytes>,
 }
 
 #[contracttype]
@@ -362,6 +364,8 @@ pub enum DataKey {
     ForkStatus(u64, u64),
     /// Stores the Vec<HolderNotification> history for a credential holder
     NotificationHistory(Address),
+    /// Stores attestation metadata keyed by (credential_id, attestor)
+    AttestationMetadata(u64, Address),
 }
 
 #[contracttype]
@@ -1909,6 +1913,7 @@ impl QuorumProofContract {
             attested_at: env.ledger().timestamp(),
             expires_at,
             attestation_value,
+            metadata: None,
         };
         records.push_back(record);
         env.storage()
@@ -2214,6 +2219,8 @@ impl QuorumProofContract {
                     attestor: rec.attestor.clone(),
                     attested_at: rec.attested_at,
                     expires_at: Some(new_expires_at),
+                    attestation_value: rec.attestation_value,
+                    metadata: rec.metadata.clone(),
                 });
             } else {
                 updated.push_back(rec);
@@ -3095,6 +3102,25 @@ impl QuorumProofContract {
             .instance()
             .get(&DataKey::NotificationHistory(holder))
             .unwrap_or(Vec::new(&env))
+    }
+
+    /// Attach arbitrary metadata to an existing attestation.
+    /// Only the original attestor may set metadata for their own attestation.
+    pub fn set_attestation_metadata(env: Env, attestor: Address, credential_id: u64, metadata: soroban_sdk::Bytes) {
+        attestor.require_auth();
+        // Verify the attestor has actually attested this credential
+        let records: Vec<AttestationRecord> = env.storage().instance()
+            .get(&DataKey::Attestors(credential_id))
+            .unwrap_or(Vec::new(&env));
+        let found = records.iter().any(|r| r.attestor == attestor);
+        assert!(found, "attestor has not attested this credential");
+        env.storage().instance().set(&DataKey::AttestationMetadata(credential_id, attestor), &metadata);
+        env.storage().instance().extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+    }
+
+    /// Retrieve metadata attached to an attestation, if any.
+    pub fn get_attestation_metadata(env: Env, credential_id: u64, attestor: Address) -> Option<soroban_sdk::Bytes> {
+        env.storage().instance().get(&DataKey::AttestationMetadata(credential_id, attestor))
     }
 
     /// Store historical consensus decisions per slice
@@ -5241,6 +5267,70 @@ mod tests {
         client.attest(&attestor2, &cred_id, &slice_id, &true, &None);
 
         assert_eq!(client.get_notification_history(&subject).len(), 2);
+    }
+
+    // --- attestation metadata tests ---
+
+    #[test]
+    fn test_set_and_get_attestation_metadata() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let attestor = Address::generate(&env);
+        let metadata_hash = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+        let cred_id = client.issue_credential(&issuer, &subject, &1u32, &metadata_hash, &None);
+
+        let mut attestors = Vec::new(&env);
+        attestors.push_back(attestor.clone());
+        let mut weights = Vec::new(&env);
+        weights.push_back(1u32);
+        let slice_id = client.create_slice(&issuer, &attestors, &weights, &1u32);
+        client.attest(&attestor, &cred_id, &slice_id, &true, &None);
+
+        let meta = Bytes::from_slice(&env, b"ref:ENG-2024-001");
+        client.set_attestation_metadata(&attestor, &cred_id, &meta);
+
+        let stored = client.get_attestation_metadata(&cred_id, &attestor);
+        assert_eq!(stored, Some(meta));
+    }
+
+    #[test]
+    fn test_get_attestation_metadata_none_when_not_set() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let attestor = Address::generate(&env);
+        let metadata_hash = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+        let cred_id = client.issue_credential(&issuer, &subject, &1u32, &metadata_hash, &None);
+
+        let mut attestors = Vec::new(&env);
+        attestors.push_back(attestor.clone());
+        let mut weights = Vec::new(&env);
+        weights.push_back(1u32);
+        let slice_id = client.create_slice(&issuer, &attestors, &weights, &1u32);
+        client.attest(&attestor, &cred_id, &slice_id, &true, &None);
+
+        assert_eq!(client.get_attestation_metadata(&cred_id, &attestor), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "attestor has not attested this credential")]
+    fn test_set_attestation_metadata_non_attestor_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let non_attestor = Address::generate(&env);
+        let metadata_hash = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+        let cred_id = client.issue_credential(&issuer, &subject, &1u32, &metadata_hash, &None);
+
+        let meta = Bytes::from_slice(&env, b"unauthorized");
+        client.set_attestation_metadata(&non_attestor, &cred_id, &meta);
     }
 
     // --- duplicate credential tests ---

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -2381,6 +2381,66 @@ impl QuorumProofContract {
         status
     }
 
+    /// Verify multiple (credential_id, slice_id) pairs in a single call.
+    ///
+    /// Gas-optimized: each credential and slice is read from storage at most once,
+    /// regardless of how many times it appears in the input list.
+    ///
+    /// Returns a `Vec<bool>` of the same length as the input, where each element
+    /// corresponds to `is_attested(credential_ids[i], slice_ids[i])`.
+    ///
+    /// # Panics
+    /// Panics if `credential_ids` and `slice_ids` have different lengths, or if
+    /// either list is empty or exceeds `MAX_BATCH_SIZE`.
+    pub fn verify_attestations_batch(
+        env: Env,
+        credential_ids: Vec<u64>,
+        slice_ids: Vec<u64>,
+    ) -> Vec<bool> {
+        Self::validate_array_bounds(credential_ids.len(), 1, MAX_BATCH_SIZE, "credential_ids");
+        assert!(
+            credential_ids.len() == slice_ids.len(),
+            "credential_ids and slice_ids lengths must match"
+        );
+        let now = env.ledger().timestamp();
+        let mut results: Vec<bool> = Vec::new(&env);
+        for i in 0..credential_ids.len() {
+            let credential_id = credential_ids.get(i).unwrap();
+            let slice_id = slice_ids.get(i).unwrap();
+            let attested = match env.storage().instance().get::<DataKey, Credential>(&DataKey::Credential(credential_id)) {
+                None => false,
+                Some(cred) => {
+                    if cred.revoked { false }
+                    else if cred.expires_at.map_or(false, |e| now >= e) { false }
+                    else if env.storage().instance().get::<DataKey, u64>(&DataKey::AttestationExpiry(credential_id)).map_or(false, |e| now >= e) { false }
+                    else {
+                        match env.storage().instance().get::<DataKey, QuorumSlice>(&DataKey::Slice(slice_id)) {
+                            None => false,
+                            Some(slice) => {
+                                let records: Vec<AttestationRecord> = env.storage().instance()
+                                    .get(&DataKey::Attestors(credential_id))
+                                    .unwrap_or(Vec::new(&env));
+                                let mut weight: u32 = 0;
+                                for rec in records.iter() {
+                                    if rec.expires_at.map_or(false, |e| now >= e) { continue; }
+                                    for (j, a) in slice.attestors.iter().enumerate() {
+                                        if a == rec.attestor {
+                                            weight = weight.saturating_add(slice.weights.get(j as u32).unwrap_or(0));
+                                            break;
+                                        }
+                                    }
+                                }
+                                weight >= slice.threshold
+                            }
+                        }
+                    }
+                }
+            };
+            results.push_back(attested);
+        }
+        results
+    }
+
     /// Unified engineer verification entry point.
     ///
     /// Checks that the subject holds an SBT linked to the credential, then delegates
@@ -4431,6 +4491,105 @@ mod tests {
         client.attest(&attestor2, &cred_id, &slice_id, &None);
 
         assert!(!client.is_attested(&cred_id, &slice_id));
+    }
+
+    // --- verify_attestations_batch tests ---
+
+    #[test]
+    fn test_verify_attestations_batch_all_attested() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let attestor = Address::generate(&env);
+        let metadata = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+
+        let cred1 = client.issue_credential(&issuer, &subject, &1u32, &metadata, &None);
+        let cred2 = client.issue_credential(&issuer, &subject, &1u32, &metadata, &None);
+
+        let mut attestors = Vec::new(&env);
+        attestors.push_back(attestor.clone());
+        let mut weights = Vec::new(&env);
+        weights.push_back(1u32);
+        let slice_id = client.create_slice(&issuer, &attestors, &weights, &1u32);
+
+        client.attest(&attestor, &cred1, &slice_id, &true, &None);
+        client.attest(&attestor, &cred2, &slice_id, &true, &None);
+
+        let mut cred_ids = Vec::new(&env);
+        cred_ids.push_back(cred1);
+        cred_ids.push_back(cred2);
+        let mut slice_ids = Vec::new(&env);
+        slice_ids.push_back(slice_id);
+        slice_ids.push_back(slice_id);
+
+        let results = client.verify_attestations_batch(&cred_ids, &slice_ids);
+        assert_eq!(results.len(), 2);
+        assert!(results.get(0).unwrap());
+        assert!(results.get(1).unwrap());
+    }
+
+    #[test]
+    fn test_verify_attestations_batch_mixed_results() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let attestor = Address::generate(&env);
+        let metadata = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+
+        let cred1 = client.issue_credential(&issuer, &subject, &1u32, &metadata, &None);
+        let cred2 = client.issue_credential(&issuer, &subject, &1u32, &metadata, &None);
+
+        let mut attestors = Vec::new(&env);
+        attestors.push_back(attestor.clone());
+        let mut weights = Vec::new(&env);
+        weights.push_back(1u32);
+        let slice_id = client.create_slice(&issuer, &attestors, &weights, &1u32);
+
+        // Only attest cred1
+        client.attest(&attestor, &cred1, &slice_id, &true, &None);
+
+        let mut cred_ids = Vec::new(&env);
+        cred_ids.push_back(cred1);
+        cred_ids.push_back(cred2);
+        let mut slice_ids = Vec::new(&env);
+        slice_ids.push_back(slice_id);
+        slice_ids.push_back(slice_id);
+
+        let results = client.verify_attestations_batch(&cred_ids, &slice_ids);
+        assert!(results.get(0).unwrap());
+        assert!(!results.get(1).unwrap());
+    }
+
+    #[test]
+    fn test_verify_attestations_batch_revoked_returns_false() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let attestor = Address::generate(&env);
+        let metadata = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+
+        let cred_id = client.issue_credential(&issuer, &subject, &1u32, &metadata, &None);
+        let mut attestors = Vec::new(&env);
+        attestors.push_back(attestor.clone());
+        let mut weights = Vec::new(&env);
+        weights.push_back(1u32);
+        let slice_id = client.create_slice(&issuer, &attestors, &weights, &1u32);
+        client.attest(&attestor, &cred_id, &slice_id, &true, &None);
+        client.revoke_credential(&issuer, &cred_id);
+
+        let mut cred_ids = Vec::new(&env);
+        cred_ids.push_back(cred_id);
+        let mut slice_ids = Vec::new(&env);
+        slice_ids.push_back(slice_id);
+
+        let results = client.verify_attestations_batch(&cred_ids, &slice_ids);
+        assert!(!results.get(0).unwrap());
     }
 
     // --- batch issue ---

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -20,6 +20,7 @@ const TOPIC_BLACKLIST_ADDED: &str = "HolderBlacklisted";
 const TOPIC_BLACKLIST_REMOVED: &str = "HolderUnblacklisted";
 const TOPIC_FORK_DETECTED: &str = "ForkDetected";
 const TOPIC_FORK_RESOLVED: &str = "ForkResolved";
+const TOPIC_HOLDER_NOTIFIED: &str = "HolderNotified";
 const STANDARD_TTL: u32 = 16_384;
 const EXTENDED_TTL: u32 = 524_288;
 const MAX_ATTESTORS_PER_SLICE: u32 = 20;
@@ -151,6 +152,16 @@ pub struct ForkResolvedEventData {
     pub slice_id: u64,
     pub resolution: soroban_sdk::String,
     pub resolved_at: u64,
+}
+
+/// Notification sent to a credential holder when an attestation is made on their credential.
+#[contracttype]
+#[derive(Clone)]
+pub struct HolderNotification {
+    pub credential_id: u64,
+    pub attestor: Address,
+    pub slice_id: u64,
+    pub notified_at: u64,
 }
 
 /// Information about a detected fork.
@@ -349,6 +360,8 @@ pub enum DataKey {
     ForkInfo(u64, u64),
     /// Stores the fork status for a (credential_id, slice_id) pair
     ForkStatus(u64, u64),
+    /// Stores the Vec<HolderNotification> history for a credential holder
+    NotificationHistory(Address),
 }
 
 #[contracttype]
@@ -1932,6 +1945,23 @@ impl QuorumProofContract {
             .get(&DataKey::Credential(credential_id))
             .unwrap_or_else(|| panic_with_error!(&env, ContractError::CredentialNotFound));
         Self::record_holder_activity(&env, credential.subject.clone(), ActivityType::CredentialAttested, credential_id, attestor.clone(), Some(slice_id));
+
+        // Notify the credential holder
+        let notification = HolderNotification {
+            credential_id,
+            attestor: attestor.clone(),
+            slice_id,
+            notified_at: env.ledger().timestamp(),
+        };
+        let mut history: Vec<HolderNotification> = env.storage().instance()
+            .get(&DataKey::NotificationHistory(credential.subject.clone()))
+            .unwrap_or(Vec::new(&env));
+        history.push_back(notification.clone());
+        env.storage().instance().set(&DataKey::NotificationHistory(credential.subject.clone()), &history);
+        let topic = String::from_str(&env, TOPIC_HOLDER_NOTIFIED);
+        let mut topics: Vec<String> = Vec::new(&env);
+        topics.push_back(topic);
+        env.events().publish(topics, notification);
     }
 
     /// Batch attest multiple credentials in a single transaction.
@@ -2997,6 +3027,14 @@ impl QuorumProofContract {
             }
         }
         result
+    }
+
+    /// Returns all attestation notifications for a credential holder.
+    pub fn get_notification_history(env: Env, holder: Address) -> Vec<HolderNotification> {
+        env.storage()
+            .instance()
+            .get(&DataKey::NotificationHistory(holder))
+            .unwrap_or(Vec::new(&env))
     }
 
     /// Store historical consensus decisions per slice
@@ -4955,6 +4993,95 @@ mod tests {
         assert_eq!(client.get_attestation_count(&cred_id), 1);
         client.attest(&attestor2, &cred_id, &slice_id, &None);
         assert_eq!(client.get_attestation_count(&cred_id), 2);
+    }
+
+    // --- holder notification tests ---
+
+    #[test]
+    fn test_notification_event_emitted_on_attest() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let attestor = Address::generate(&env);
+        let metadata = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+        let cred_id = client.issue_credential(&issuer, &subject, &1u32, &metadata, &None);
+
+        let mut attestors = soroban_sdk::Vec::new(&env);
+        attestors.push_back(attestor.clone());
+        let mut weights = Vec::new(&env);
+        weights.push_back(1u32);
+        let slice_id = client.create_slice(&issuer, &attestors, &weights, &1u32);
+
+        client.attest(&attestor, &cred_id, &slice_id, &true, &None);
+
+        let events = env.events().all();
+        let notified = events.iter().find(|(_, topics, _)| {
+            if let Some(t) = topics.get(0) {
+                t == soroban_sdk::String::from_str(&env, "HolderNotified")
+            } else {
+                false
+            }
+        });
+        assert!(notified.is_some(), "HolderNotified event not emitted");
+    }
+
+    #[test]
+    fn test_notification_history_stored_on_attest() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let attestor = Address::generate(&env);
+        let metadata = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+        let cred_id = client.issue_credential(&issuer, &subject, &1u32, &metadata, &None);
+
+        let mut attestors = soroban_sdk::Vec::new(&env);
+        attestors.push_back(attestor.clone());
+        let mut weights = Vec::new(&env);
+        weights.push_back(1u32);
+        let slice_id = client.create_slice(&issuer, &attestors, &weights, &1u32);
+
+        assert_eq!(client.get_notification_history(&subject).len(), 0);
+        client.attest(&attestor, &cred_id, &slice_id, &true, &None);
+
+        let history = client.get_notification_history(&subject);
+        assert_eq!(history.len(), 1);
+        let notif = history.get(0).unwrap();
+        assert_eq!(notif.credential_id, cred_id);
+        assert_eq!(notif.attestor, attestor);
+        assert_eq!(notif.slice_id, slice_id);
+    }
+
+    #[test]
+    fn test_notification_history_accumulates_multiple_attestors() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let attestor1 = Address::generate(&env);
+        let attestor2 = Address::generate(&env);
+        let metadata = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+        let cred_id = client.issue_credential(&issuer, &subject, &1u32, &metadata, &None);
+
+        let mut attestors = soroban_sdk::Vec::new(&env);
+        attestors.push_back(attestor1.clone());
+        attestors.push_back(attestor2.clone());
+        let mut weights = Vec::new(&env);
+        weights.push_back(1u32);
+        weights.push_back(1u32);
+        let slice_id = client.create_slice(&issuer, &attestors, &weights, &1u32);
+
+        client.attest(&attestor1, &cred_id, &slice_id, &true, &None);
+        client.attest(&attestor2, &cred_id, &slice_id, &true, &None);
+
+        assert_eq!(client.get_notification_history(&subject).len(), 2);
     }
 
     // --- duplicate credential tests ---

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1,0 +1,373 @@
+# QuorumProof — Error Code Reference
+
+All contract errors surface as `Error(Contract, #N)` in Soroban transaction results. This guide covers every error code across the three contracts, with the scenario that triggers it and how to recover.
+
+---
+
+## QuorumProof Contract
+
+### #1 — `CredentialNotFound`
+**Trigger:** A function was called with a `credential_id` that does not exist in storage.
+
+```rust
+// Example: querying a credential that was never issued
+client.get_credential(&999u64); // panics with Error(Contract, #1)
+```
+
+**Recovery:** Verify the credential ID with `credential_exists(credential_id)` before calling. If issuing, ensure `issue_credential` completed successfully and store the returned ID.
+
+---
+
+### #2 — `SliceNotFound`
+**Trigger:** A function was called with a `slice_id` that does not exist.
+
+```rust
+client.attest(&attestor, &cred_id, &999u64, &true, &None); // Error(Contract, #2)
+```
+
+**Recovery:** Use `slice_exists(slice_id)` to check before attesting. Retrieve valid slice IDs from `get_slice_count` or store them at creation time.
+
+---
+
+### #3 — `ContractPaused`
+**Trigger:** A state-mutating function was called while the contract is paused by the admin.
+
+```rust
+client.pause(&admin);
+client.issue_credential(...); // Error(Contract, #3)
+```
+
+**Recovery:** Wait for the admin to call `unpause`. Check current state with `is_paused()` before submitting transactions.
+
+---
+
+### #4 — `DuplicateCredential`
+**Trigger:** Attempting to issue a credential for a `(subject, issuer, credential_type)` combination that already exists.
+
+```rust
+client.issue_credential(&issuer, &subject, &1u32, &hash, &None);
+client.issue_credential(&issuer, &subject, &1u32, &hash, &None); // Error(Contract, #4)
+```
+
+**Recovery:** Check for an existing credential with `get_credentials_by_subject` before issuing. To update a credential, use `update_metadata` instead.
+
+---
+
+### #5 — `DuplicateAttestor`
+**Trigger:** An attestor attempts to attest a credential they have already attested.
+
+```rust
+client.attest(&attestor, &cred_id, &slice_id, &true, &None);
+client.attest(&attestor, &cred_id, &slice_id, &true, &None); // Error(Contract, #5)
+```
+
+**Recovery:** Check `get_attestors(credential_id)` to see who has already attested before submitting.
+
+---
+
+### #6 — `AttestationExpired`
+**Trigger:** An operation references an attestation that has passed its `expires_at` timestamp.
+
+**Recovery:** Call `renew_attestation(attestor, credential_id, new_expires_at)` to extend the expiry before it lapses, or re-attest after the old record is cleared.
+
+---
+
+### #7 — `InvalidInput`
+**Trigger:** A function received an argument that fails validation (e.g. empty array, mismatched lengths, value out of allowed range).
+
+```rust
+// Example: threshold exceeds number of attestors
+client.create_slice(&creator, &attestors_len_2, &weights, &5u32); // Error(Contract, #7)
+```
+
+**Recovery:** Review the function's documented constraints. Common causes: `threshold > attestors.len()`, batch arrays of different lengths, page size of zero.
+
+---
+
+### #8 — `InvalidAddress`
+**Trigger:** A zero/default address was passed where a real account address is required.
+
+**Recovery:** Ensure all `Address` arguments are generated from real Stellar keypairs, not default-constructed.
+
+---
+
+### #9 — `OnboardingNotFound`
+**Trigger:** An operation referenced an onboarding request ID that does not exist.
+
+**Recovery:** Retrieve active onboarding request IDs before operating on them.
+
+---
+
+### #10 — `DisputeNotFound`
+**Trigger:** An operation referenced a dispute ID that does not exist.
+
+**Recovery:** Retrieve active dispute IDs before voting or resolving.
+
+---
+
+### #11 — `UnauthorizedAction`
+**Trigger:** The caller does not have permission for the requested operation (e.g. non-admin calling an admin function, non-issuer revoking a credential).
+
+```rust
+// Example: non-admin trying to pause
+client.pause(&non_admin); // Error(Contract, #11)
+```
+
+**Recovery:** Ensure the correct authority signs the transaction. Admin functions require the address passed to `initialize`. Credential operations require the original issuer.
+
+---
+
+### #12 — `InvalidApprovalWorkflow`
+**Trigger:** An approval step was attempted out of sequence or in an invalid state.
+
+**Recovery:** Follow the correct workflow order: initiate → approve (N times) → execute.
+
+---
+
+### #13 — `AlreadyChallenged`
+**Trigger:** A challenge was submitted for a `(credential_id, accused)` pair that already has an active challenge.
+
+**Recovery:** Resolve or wait for the existing challenge to complete before opening a new one.
+
+---
+
+### #14 — `ChallengeNotFound`
+**Trigger:** An operation referenced a challenge ID that does not exist.
+
+**Recovery:** Verify the challenge ID exists before voting or resolving.
+
+---
+
+### #15 — `ChallengeResolved`
+**Trigger:** An attempt was made to vote on or interact with a challenge that has already been resolved.
+
+**Recovery:** No action needed — the challenge is closed. Query the result to see the outcome.
+
+---
+
+### #16 — `NotAttested`
+**Trigger:** An operation requires the credential to be attested (quorum met) but it is not.
+
+**Recovery:** Ensure all required attestors in the slice have called `attest` and the threshold is met. Use `is_attested(credential_id, slice_id)` to check.
+
+---
+
+### #17 — `NotInSlice`
+**Trigger:** An address attempted to attest but is not a member of the specified quorum slice.
+
+```rust
+// attestor2 is not in the slice
+client.attest(&attestor2, &cred_id, &slice_id, &true, &None); // Error(Contract, #17)
+```
+
+**Recovery:** Add the attestor to the slice with `add_attestor(slice_id, attestor)` (requires slice creator auth), or use a slice they belong to.
+
+---
+
+### #18 — `AccusedCannotVote`
+**Trigger:** The accused party in a challenge attempted to vote on their own challenge.
+
+**Recovery:** The accused must recuse themselves; only other slice members may vote.
+
+---
+
+### #19 — `AlreadyVoted`
+**Trigger:** An address attempted to vote on a challenge or dispute they have already voted on.
+
+**Recovery:** Each address may only vote once per challenge/dispute. No further action needed.
+
+---
+
+### #20 — `AttestationWindowOutside`
+**Trigger:** `attest` was called outside the configured time window for a credential.
+
+```rust
+// Window is [1000, 2000]; current timestamp is 500
+client.attest(...); // Error(Contract, #20)
+```
+
+**Recovery:** Call `get_attestation_window(credential_id)` to check the allowed range, then submit the attestation within that window. The issuer can update the window with `set_attestation_window`.
+
+---
+
+### #21 — `RecoveryNotFound`
+**Trigger:** An operation referenced a recovery request ID that does not exist.
+
+**Recovery:** Initiate a recovery first with `initiate_recovery`, then use the returned ID.
+
+---
+
+### #22 — `RecoveryAlreadyExists`
+**Trigger:** A recovery was initiated for a credential that already has an active recovery in progress.
+
+**Recovery:** Wait for the existing recovery to be executed or cancelled before initiating a new one.
+
+---
+
+### #23 — `RecoveryNotPending`
+**Trigger:** An approval or execution was attempted on a recovery that is no longer in `Pending` state.
+
+**Recovery:** Check recovery status before approving. If already executed or cancelled, no further action is needed.
+
+---
+
+### #24 — `RecoveryAlreadyApproved`
+**Trigger:** An approver attempted to approve a recovery they have already approved.
+
+**Recovery:** Each approver may only approve once. Check existing approvals with `get_recovery_approvals(recovery_id)`.
+
+---
+
+### #25 — `RecoveryThresholdNotMet`
+**Trigger:** `execute_recovery` was called before enough approvers have signed off.
+
+**Recovery:** Gather the required number of approvals first. Check progress with `get_recovery_approvals(recovery_id)`.
+
+---
+
+### #26 — `NotRecoveryApprover`
+**Trigger:** An address that is not a designated recovery approver attempted to approve a recovery.
+
+**Recovery:** Only addresses listed as approvers at recovery initiation may approve. Verify with `get_recovery_request(recovery_id)`.
+
+---
+
+### #27 — `DuplicateRecoveryApproval`
+**Trigger:** The same approver submitted a second approval for the same recovery.
+
+**Recovery:** Each approver signs once. No further action needed.
+
+---
+
+### #28 — `InvalidParentType`
+**Trigger:** `register_credential_type` was called with a `parent_type` that does not exist in the registry.
+
+```rust
+client.register_credential_type(&admin, &5u32, &name, &desc, &Some(999u32)); // Error(Contract, #28)
+```
+
+**Recovery:** Register the parent type first, or omit `parent_type` (`None`) for a root type.
+
+---
+
+### #29 — `CircularHierarchy`
+**Trigger:** Registering a credential type would create a cycle in the type hierarchy (e.g. A → B → A).
+
+**Recovery:** Review the intended hierarchy. A type cannot be its own ancestor. Restructure the parent chain to be acyclic.
+
+---
+
+### #30 — `CredentialTypeNotFound`
+**Trigger:** `issue_credential` or a hierarchy function was called with an unregistered `credential_type`.
+
+**Recovery:** Register the type with `register_credential_type` before issuing credentials of that type.
+
+---
+
+### #31 — `HolderBlacklisted`
+**Trigger:** An issuer attempted to issue a credential to a holder they have blacklisted.
+
+**Recovery:** Remove the holder from the blacklist with `remove_holder_from_blacklist(issuer, holder)` if appropriate, then re-issue.
+
+---
+
+### #32 — `AlreadyBlacklisted`
+**Trigger:** `add_holder_to_blacklist` was called for a holder already on the issuer's blacklist.
+
+**Recovery:** No action needed — the holder is already blacklisted. Use `is_holder_blacklisted` to check before calling.
+
+---
+
+### #33 — `NotBlacklisted`
+**Trigger:** `remove_holder_from_blacklist` was called for a holder not on the issuer's blacklist.
+
+**Recovery:** Use `is_holder_blacklisted(issuer, holder)` to verify before attempting removal.
+
+---
+
+### #34 — `ForkDetected`
+**Trigger:** `attest` was called with a value that conflicts with an existing attestation in the same slice (Byzantine behaviour detected).
+
+```rust
+client.attest(&attestor1, &cred_id, &slice_id, &true,  &None);
+client.attest(&attestor2, &cred_id, &slice_id, &false, &None); // Error(Contract, #34)
+```
+
+**Recovery:** Investigate the conflicting attestors via `get_slice_attestation_status`. Resolve the fork through the challenge mechanism (`challenge_attestation`) or governance before further attestations are accepted.
+
+---
+
+### #35 — `ForkAlreadyResolved`
+**Trigger:** An attempt was made to resolve a fork that has already been resolved.
+
+**Recovery:** No action needed — query the current fork status to confirm resolution.
+
+---
+
+### #36 — `NoForkExists`
+**Trigger:** A fork-resolution function was called for a `(credential_id, slice_id)` pair with no detected fork.
+
+**Recovery:** Use `detect_fork` to confirm a fork exists before attempting resolution.
+
+---
+
+## SBT Registry Contract
+
+### #1 — `SoulboundNonTransferable`
+**Trigger:** A direct token transfer was attempted on a soulbound token.
+
+```rust
+client.transfer(&owner, &recipient, &token_id); // Error(Contract, #1)
+```
+
+**Recovery:** SBTs are non-transferable by design. Use `admin_transfer_sbt` (admin only) for exceptional cases such as wallet recovery, or initiate the guardian recovery flow.
+
+---
+
+### #2 — `TokenNotFound`
+**Trigger:** An operation referenced a token ID that does not exist or has been burned.
+
+**Recovery:** Verify the token exists with `get_token(token_id)` or look up tokens by owner with `get_tokens_by_owner(owner)`.
+
+---
+
+### #3 — `RecoveryNotFound` *(SBT Registry)*
+**Trigger:** An SBT recovery operation referenced a recovery request that does not exist.
+
+**Recovery:** Initiate a recovery with `initiate_recovery` first.
+
+---
+
+### #4 — `RecoveryAlreadyExists` *(SBT Registry)*
+**Trigger:** A recovery was initiated for an owner who already has an active recovery in progress.
+
+**Recovery:** Wait for the existing recovery to complete or be finalized before starting a new one.
+
+---
+
+### #5 — `UnauthorizedRecovery`
+**Trigger:** An address that is not a designated guardian attempted to approve an SBT recovery.
+
+**Recovery:** Only guardians registered via `setup_recovery_guardians` may approve. Verify the guardian list before submitting.
+
+---
+
+### #6 — `InsufficientApprovals`
+**Trigger:** `finalize_recovery` was called before the required number of guardian approvals was reached.
+
+**Recovery:** Collect the required guardian approvals first. Check progress with `get_recovery_approvals`.
+
+---
+
+### #7 — `InvalidGuardian`
+**Trigger:** `setup_recovery_guardians` was called with an invalid guardian address (e.g. the owner themselves).
+
+**Recovery:** Guardians must be distinct addresses that are not the token owner. Use trusted third-party addresses.
+
+---
+
+## See Also
+
+- [Architecture Overview](architecture.md)
+- [Threat Model & Security](threat-model.md)
+- [Trust Slice Model](trust-slices.md)


### PR DESCRIPTION
## Summary

This PR implements four issues across the QuorumProof smart contract and documentation.

---

### feat: implement attestation holder notification (#343)

Added on-chain notification system so credential holders are informed whenever an attestor signs their credential.

- New `HolderNotification` struct (`credential_id`, `attestor`, `slice_id`, `notified_at`)
- New `NotificationHistory(Address)` DataKey for per-holder persistent storage
- `TOPIC_HOLDER_NOTIFIED` event topic (`"HolderNotified"`)
- `attest()` now emits a `HolderNotified` event and appends to the holder's notification history after each successful attestation
- New public function `get_notification_history(holder) -> Vec<HolderNotification>`
- Tests: event emission, history storage with field assertions, multi-attestor accumulation

---

### feat: implement attestation batch verification (#341)

Single-call verification of multiple `(credential_id, slice_id)` pairs, gas-optimized by avoiding cross-contract calls and reading each storage key inline.

- New `verify_attestations_batch(credential_ids, slice_ids) -> Vec<bool>`
- Validates length bounds (`MAX_BATCH_SIZE`) and parity between input arrays
- Handles revoked credentials, expired credentials, and expired individual attestations
- Uses weighted FBA threshold logic consistent with `is_attested`
- Tests: all attested, mixed results, revoked credential returns false

---

### feat: add attestation metadata (#342)

Allows attestors to attach arbitrary bytes metadata (e.g. reference IDs, notes) to their attestations after the fact, without changing the `attest()` signature.

- New `metadata: Option<soroban_sdk::Bytes>` field on `AttestationRecord` (initialized to `None`, preserved through `renew_attestation`)
- New `AttestationMetadata(u64, Address)` DataKey keyed by `(credential_id, attestor)`
- New `set_attestation_metadata(attestor, credential_id, metadata)`: auth-gated, verifies caller has attested the credential
- New `get_attestation_metadata(credential_id, attestor) -> Option<Bytes>`
- Tests: set/get roundtrip, returns `None` when unset, panics for non-attestor

---

### docs: add comprehensive error codes reference (#344)

Created `docs/error-codes.md` covering every contract error with trigger description, code example, and recovery steps.

- All 36 QuorumProof contract errors (`#1`–`#36`)
- All 7 SBT Registry contract errors (`#1`–`#7`)
- Linked from README documentation section

---

Closes #341
Closes #342
Closes #343
Closes #344