### PR TITLE
feat(import): credential import from JSON/CSV (#363)

### DIFF
--- a/frontend/src/__tests__/ImportCredentials.test.tsx
+++ b/frontend/src/__tests__/ImportCredentials.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { parseJSON, parseCSV, parseImportFile } from '../lib/importUtils';
+import { ImportCredentialsDialog } from '../components/ImportCredentialsDialog';
+import type { Credential } from '../lib/contracts/quorumProof';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const SUBJECT = 'GBUQWP3BOUZX34ULNQG23RQ6F4YUSXHTQSXUSMIQSTBE2EURIDVXL6B';
+const ISSUER  = 'GCZXWX4J3CKPF35VQ4XYVNIS7QQ5QEPL7SZLW5QJSTW2QC4QFSXZJWF';
+
+const validJSON = JSON.stringify([
+  {
+    id: '1',
+    subject: SUBJECT,
+    issuer: ISSUER,
+    credential_type: 1,
+    metadataHash: '0102030405',
+    revoked: false,
+    expiresAt: '1704067200',
+  },
+]);
+
+const validCSV = [
+  'ID,Subject,Issuer,Credential_Type,Metadata Hash,Revoked,Expires At',
+  `"1","${SUBJECT}","${ISSUER}","1","0102030405","No","1704067200"`,
+].join('\n');
+
+// ── parseJSON ─────────────────────────────────────────────────────────────────
+
+describe('parseJSON', () => {
+  it('parses a valid JSON array', () => {
+    const { credentials, errors } = parseJSON(validJSON);
+    expect(errors).toHaveLength(0);
+    expect(credentials).toHaveLength(1);
+    expect(credentials[0].id).toBe(BigInt(1));
+    expect(credentials[0].subject).toBe(SUBJECT);
+    expect(credentials[0].revoked).toBe(false);
+  });
+
+  it('returns error for invalid JSON', () => {
+    const { credentials, errors } = parseJSON('not json');
+    expect(credentials).toHaveLength(0);
+    expect(errors[0]).toMatch(/Invalid JSON/);
+  });
+
+  it('returns error when root is not an array', () => {
+    const { credentials, errors } = parseJSON('{"id":"1"}');
+    expect(credentials).toHaveLength(0);
+    expect(errors[0]).toMatch(/expected an array/);
+  });
+
+  it('collects per-row errors and still returns valid rows', () => {
+    const mixed = JSON.stringify([
+      { id: '1', subject: SUBJECT, issuer: ISSUER, credential_type: 1, metadataHash: '0102' },
+      { subject: SUBJECT, issuer: ISSUER, credential_type: 1 }, // missing id
+    ]);
+    const { credentials, errors } = parseJSON(mixed);
+    expect(credentials).toHaveLength(1);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/missing "id"/);
+  });
+
+  it('handles null expires_at', () => {
+    const json = JSON.stringify([
+      { id: '2', subject: SUBJECT, issuer: ISSUER, credential_type: 2, metadataHash: '', expiresAt: null },
+    ]);
+    const { credentials } = parseJSON(json);
+    expect(credentials[0].expires_at).toBeNull();
+  });
+
+  it('returns error for invalid metadataHash hex', () => {
+    const json = JSON.stringify([
+      { id: '1', subject: SUBJECT, issuer: ISSUER, credential_type: 1, metadataHash: 'xyz' },
+    ]);
+    const { errors } = parseJSON(json);
+    expect(errors[0]).toMatch(/invalid "metadataHash"/i);
+  });
+});
+
+// ── parseCSV ──────────────────────────────────────────────────────────────────
+
+describe('parseCSV', () => {
+  it('parses a valid CSV', () => {
+    const { credentials, errors } = parseCSV(validCSV);
+    expect(errors).toHaveLength(0);
+    expect(credentials).toHaveLength(1);
+    expect(credentials[0].id).toBe(BigInt(1));
+    expect(credentials[0].issuer).toBe(ISSUER);
+  });
+
+  it('returns error for header-only CSV', () => {
+    const { credentials, errors } = parseCSV('ID,Subject,Issuer');
+    expect(credentials).toHaveLength(0);
+    expect(errors[0]).toMatch(/header row/);
+  });
+
+  it('marks revoked=true for "Yes"', () => {
+    const csv = [
+      'ID,Subject,Issuer,Credential_Type,Metadata Hash,Revoked,Expires At',
+      `"1","${SUBJECT}","${ISSUER}","1","","Yes","Never"`,
+    ].join('\n');
+    const { credentials } = parseCSV(csv);
+    expect(credentials[0].revoked).toBe(true);
+  });
+
+  it('sets expires_at to null for "Never"', () => {
+    const csv = [
+      'ID,Subject,Issuer,Credential_Type,Metadata Hash,Revoked,Expires At',
+      `"1","${SUBJECT}","${ISSUER}","1","","No","Never"`,
+    ].join('\n');
+    const { credentials } = parseCSV(csv);
+    expect(credentials[0].expires_at).toBeNull();
+  });
+});
+
+// ── parseImportFile ───────────────────────────────────────────────────────────
+
+describe('parseImportFile', () => {
+  it('delegates to parseJSON for json format', () => {
+    const { credentials } = parseImportFile(validJSON, 'json');
+    expect(credentials).toHaveLength(1);
+  });
+
+  it('delegates to parseCSV for csv format', () => {
+    const { credentials } = parseImportFile(validCSV, 'csv');
+    expect(credentials).toHaveLength(1);
+  });
+});
+
+// ── ImportCredentialsDialog ───────────────────────────────────────────────────
+
+function makeFile(content: string, name: string): File {
+  return new File([content], name, { type: 'text/plain' });
+}
+
+describe('ImportCredentialsDialog', () => {
+  const onImport = vi.fn();
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the dialog', () => {
+    render(<ImportCredentialsDialog onImport={onImport} onClose={onClose} />);
+    expect(screen.getByText('Import Credentials')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /import/i })).toBeDisabled();
+  });
+
+  it('calls onClose when Cancel is clicked', () => {
+    render(<ImportCredentialsDialog onImport={onImport} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when overlay is clicked', () => {
+    render(<ImportCredentialsDialog onImport={onImport} onClose={onClose} />);
+    fireEvent.click(document.querySelector('.modal-overlay')!);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('enables Import button after a valid JSON file is loaded', async () => {
+    render(<ImportCredentialsDialog onImport={onImport} onClose={onClose} />);
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makeFile(validJSON, 'creds.json')] } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^import$/i })).not.toBeDisabled();
+    });
+    expect(screen.getByText(/1 credential\(s\) ready/)).toBeInTheDocument();
+  });
+
+  it('calls onImport with parsed credentials on confirm', async () => {
+    render(<ImportCredentialsDialog onImport={onImport} onClose={onClose} />);
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makeFile(validJSON, 'creds.json')] } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^import$/i })).not.toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^import$/i }));
+    expect(onImport).toHaveBeenCalledOnce();
+    const imported = onImport.mock.calls[0][0] as Credential[];
+    expect(imported).toHaveLength(1);
+    expect(imported[0].id).toBe(BigInt(1));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('shows validation errors for a bad JSON file', async () => {
+    render(<ImportCredentialsDialog onImport={onImport} onClose={onClose} />);
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makeFile('not json', 'bad.json')] } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Validation errors/)).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /^import$/i })).toBeDisabled();
+  });
+
+  it('auto-detects CSV format from file extension', async () => {
+    render(<ImportCredentialsDialog onImport={onImport} onClose={onClose} />);
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makeFile(validCSV, 'creds.csv')] } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^import$/i })).not.toBeDisabled();
+    });
+    expect(screen.getByText(/1 credential\(s\) ready/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ImportCredentialsDialog.tsx
+++ b/frontend/src/components/ImportCredentialsDialog.tsx
@@ -1,0 +1,110 @@
+import { useState, useRef } from 'react';
+import type { Credential } from '../lib/contracts/quorumProof';
+import { parseImportFile } from '../lib/importUtils';
+
+interface ImportCredentialsDialogProps {
+  onImport: (credentials: Credential[]) => void;
+  onClose: () => void;
+}
+
+export function ImportCredentialsDialog({ onImport, onClose }: ImportCredentialsDialogProps) {
+  const [format, setFormat] = useState<'json' | 'csv'>('json');
+  const [errors, setErrors] = useState<string[]>([]);
+  const [preview, setPreview] = useState<Credential[] | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const handleFile = (file: File) => {
+    setErrors([]);
+    setPreview(null);
+    setFileName(file.name);
+
+    const detectedFormat = file.name.endsWith('.csv') ? 'csv' : 'json';
+    setFormat(detectedFormat);
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const content = e.target?.result as string;
+      const result = parseImportFile(content, detectedFormat);
+      setErrors(result.errors);
+      if (result.credentials.length > 0) setPreview(result.credentials);
+    };
+    reader.readAsText(file);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (file) handleFile(file);
+  };
+
+  const handleConfirm = () => {
+    if (preview && preview.length > 0) {
+      onImport(preview);
+      onClose();
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <h2 className="modal-title">Import Credentials</h2>
+          <button className="modal-close" onClick={onClose} aria-label="Close">×</button>
+        </div>
+
+        <div className="modal-body">
+          <div
+            className="import-dropzone"
+            onDrop={handleDrop}
+            onDragOver={(e) => e.preventDefault()}
+            onClick={() => fileRef.current?.click()}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => e.key === 'Enter' && fileRef.current?.click()}
+            aria-label="Drop a JSON or CSV file here, or click to browse"
+          >
+            <input
+              ref={fileRef}
+              type="file"
+              accept=".json,.csv"
+              style={{ display: 'none' }}
+              onChange={(e) => { const f = e.target.files?.[0]; if (f) handleFile(f); }}
+            />
+            {fileName
+              ? <p>{fileName}</p>
+              : <p>Drop a <strong>JSON</strong> or <strong>CSV</strong> file here, or click to browse</p>
+            }
+          </div>
+
+          {errors.length > 0 && (
+            <div className="error-card" style={{ marginTop: '12px' }}>
+              <div className="error-card__title">Validation errors ({errors.length})</div>
+              <ul style={{ margin: '4px 0 0', paddingLeft: '16px', fontSize: '13px' }}>
+                {errors.map((err, i) => <li key={i}>{err}</li>)}
+              </ul>
+            </div>
+          )}
+
+          {preview && (
+            <p style={{ marginTop: '12px', fontSize: '14px' }}>
+              ✅ {preview.length} credential(s) ready to import
+              {errors.length > 0 && ` (${errors.length} row(s) skipped)`}
+            </p>
+          )}
+        </div>
+
+        <div className="modal-footer">
+          <button className="btn btn--ghost" onClick={onClose}>Cancel</button>
+          <button
+            className="btn btn--primary"
+            onClick={handleConfirm}
+            disabled={!preview || preview.length === 0}
+          >
+            Import
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -10,3 +10,4 @@ export { Navbar } from './Navbar';
 export { AppLayout } from './AppLayout';
 export { ToastContainer } from './ToastContainer';
 export { FeedbackForm } from './FeedbackForm';
+export { ImportCredentialsDialog } from './ImportCredentialsDialog';

--- a/frontend/src/lib/importUtils.ts
+++ b/frontend/src/lib/importUtils.ts
@@ -1,0 +1,112 @@
+import type { Credential } from './contracts/quorumProof';
+
+export interface ImportResult {
+  credentials: Credential[];
+  errors: string[];
+}
+
+function hexToUint8Array(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) throw new Error('Invalid hex string');
+  const arr = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < arr.length; i++) {
+    arr[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return arr;
+}
+
+function parseCredentialFromObject(raw: Record<string, unknown>, index: number): Credential {
+  const id = raw.id !== undefined ? BigInt(raw.id as string) : undefined;
+  const subject = raw.subject as string | undefined;
+  const issuer = raw.issuer as string | undefined;
+  const credential_type = raw.credential_type !== undefined
+    ? Number(raw.credential_type)
+    : raw.type !== undefined ? Number(raw.type) : undefined;
+  const metadataHex = (raw.metadataHash ?? raw.metadata_hash ?? '') as string;
+  const revoked = raw.revoked === true || raw.revoked === 'Yes';
+  const expires_at = raw.expiresAt != null && raw.expiresAt !== 'Never' && raw.expiresAt !== ''
+    ? BigInt(raw.expiresAt as string)
+    : raw.expires_at != null && raw.expires_at !== 'Never' && raw.expires_at !== ''
+    ? BigInt(raw.expires_at as string)
+    : null;
+
+  if (id === undefined) throw new Error(`Row ${index + 1}: missing "id"`);
+  if (!subject) throw new Error(`Row ${index + 1}: missing "subject"`);
+  if (!issuer) throw new Error(`Row ${index + 1}: missing "issuer"`);
+  if (credential_type === undefined || isNaN(credential_type)) throw new Error(`Row ${index + 1}: missing or invalid "credential_type"`);
+
+  let metadata_hash: Uint8Array;
+  try {
+    metadata_hash = metadataHex ? hexToUint8Array(metadataHex) : new Uint8Array();
+  } catch {
+    throw new Error(`Row ${index + 1}: invalid "metadataHash"`);
+  }
+
+  return { id, subject, issuer, credential_type, metadata_hash, revoked, expires_at };
+}
+
+export function parseJSON(content: string): ImportResult {
+  const errors: string[] = [];
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return { credentials: [], errors: ['Invalid JSON: could not parse file'] };
+  }
+
+  if (!Array.isArray(parsed)) {
+    return { credentials: [], errors: ['Invalid JSON: expected an array of credentials'] };
+  }
+
+  const credentials: Credential[] = [];
+  for (let i = 0; i < parsed.length; i++) {
+    try {
+      credentials.push(parseCredentialFromObject(parsed[i] as Record<string, unknown>, i));
+    } catch (e) {
+      errors.push((e as Error).message);
+    }
+  }
+
+  return { credentials, errors };
+}
+
+export function parseCSV(content: string): ImportResult {
+  const errors: string[] = [];
+  const lines = content.trim().split('\n');
+
+  if (lines.length < 2) {
+    return { credentials: [], errors: ['CSV file must have a header row and at least one data row'] };
+  }
+
+  const headers = lines[0].split(',').map(h => h.replace(/^"|"$/g, '').trim().toLowerCase());
+  const credentials: Credential[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const values = lines[i].split(',').map(v => v.replace(/^"|"$/g, '').trim());
+    const row: Record<string, unknown> = {};
+    headers.forEach((h, idx) => { row[h] = values[idx] ?? ''; });
+
+    // Map CSV column names to object keys
+    const mapped: Record<string, unknown> = {
+      id: row['id'],
+      subject: row['subject'],
+      issuer: row['issuer'],
+      credential_type: row['credential_type'] ?? row['type'],
+      metadataHash: row['metadata hash'] ?? row['metadatahash'] ?? row['metadata_hash'],
+      revoked: row['revoked'],
+      expiresAt: row['expires at'] ?? row['expiresat'] ?? row['expires_at'],
+    };
+
+    try {
+      credentials.push(parseCredentialFromObject(mapped, i - 1));
+    } catch (e) {
+      errors.push((e as Error).message);
+    }
+  }
+
+  return { credentials, errors };
+}
+
+export function parseImportFile(content: string, format: 'json' | 'csv'): ImportResult {
+  return format === 'json' ? parseJSON(content) : parseCSV(content);
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import { CredentialCard } from '../components/CredentialCard';
 import { CredentialCardSkeleton } from '../components/CredentialCardSkeleton';
 import { EmptyState } from '../components/EmptyState';
 import { ExportCredentialsDialog } from '../components/ExportCredentialsDialog';
+import { ImportCredentialsDialog } from '../components/ImportCredentialsDialog';
 import { useWallet } from '../hooks';
 import {
   getCredentialsBySubject,
@@ -22,6 +23,7 @@ export default function Dashboard() {
   const [error, setError] = useState<string | null>(null);
   const [retryKey, setRetryKey] = useState(0);
   const [showExportDialog, setShowExportDialog] = useState(false);
+  const [showImportDialog, setShowImportDialog] = useState(false);
 
   const fetchCredentials = useCallback(async (walletAddress: string) => {
     setLoading(true);
@@ -125,6 +127,12 @@ export default function Dashboard() {
                 📥 Export
               </button>
             )}
+            <button
+              className="btn btn--ghost btn--sm"
+              onClick={() => setShowImportDialog(true)}
+            >
+              📤 Import
+            </button>
             {address && (
               <div className="wallet-sim-card">
                 <div className="wallet-sim__label">Connected Address</div>
@@ -212,6 +220,25 @@ export default function Dashboard() {
         <ExportCredentialsDialog
           credentials={cards.map(c => c.credential)}
           onClose={() => setShowExportDialog(false)}
+        />
+      )}
+
+      {showImportDialog && (
+        <ImportCredentialsDialog
+          onImport={(imported) => {
+            setCards(prev => [
+              ...prev,
+              ...imported.map(credential => ({
+                credential,
+                attested: false,
+                slice: null,
+                expired: false,
+                sliceError: false,
+                credError: null,
+              })),
+            ]);
+          }}
+          onClose={() => setShowImportDialog(false)}
         />
       )}
     </>


### PR DESCRIPTION
## Summary

Implements credential import functionality as specified in issue #363.

Users can now import credentials from external sources directly into the Dashboard via a file picker or drag-and-drop zone.

## Changes

### New files
- `frontend/src/lib/importUtils.ts` — format parsing and validation
  - `parseJSON`: validates root array, collects per-row errors without aborting the full import
  - `parseCSV`: parses header row, maps column names case-insensitively, handles quoted values
  - Both validate required fields, hex-decode `metadataHash`, handle `null`/`"Never"` for `expires_at`
- `frontend/src/components/ImportCredentialsDialog.tsx` — import dialog
  - Drag-and-drop zone + file picker (`accept=".json,.csv"`)
  - Auto-detects format from file extension
  - Shows inline per-row validation errors; Import button disabled until at least one valid credential is parsed
- `frontend/src/__tests__/ImportCredentials.test.tsx` — 19 tests

### Modified files
- `frontend/src/pages/Dashboard.tsx` — Import button in header, imported credentials appended to the grid
- `frontend/src/components/index.ts` — exports `ImportCredentialsDialog`

## Acceptance Criteria

- [x] Import dialog
- [x] Format validation (JSON + CSV, per-row error collection)
- [x] Tests for import (19 passing)

## Testing

```
cd frontend && npm test src/__tests__/ImportCredentials.test.tsx
# Test Files  1 passed (1)
# Tests       19 passed (19)
```

Closes #363