### PR TITLE
feat: expiring share links for credential sharing

### DIFF
--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -400,6 +400,15 @@ pub enum DataKey2 {
     AttestConditions(u64),
     RateLimitConfig,
     RateLimitState(Address),
+    ShareToken(soroban_sdk::Bytes),
+}
+
+/// A time-limited share link token for a credential.
+#[contracttype]
+#[derive(Clone)]
+pub struct ShareLink {
+    pub credential_id: u64,
+    pub expires_at: u64,
 }
 
 #[contracttype]
@@ -5793,6 +5802,71 @@ impl QuorumProofContract {
         let metadata = soroban_sdk::Bytes::from_slice(&env, b"default");
         Self::issue_credential(env, issuer, subject, credential_type, metadata, expires_at)
     }
+
+    /// Generate a time-limited share link token for a credential.
+    ///
+    /// The caller must be the credential subject (holder). Returns an opaque
+    /// token (the credential ID encoded as bytes XOR'd with the expiry) that
+    /// can be embedded in a share URL. Call `validate_share_token` to redeem it.
+    pub fn generate_share_link(
+        env: Env,
+        subject: Address,
+        credential_id: u64,
+        expiry_hours: u32,
+    ) -> soroban_sdk::Bytes {
+        subject.require_auth();
+        Self::require_not_paused(&env);
+
+        assert!(expiry_hours > 0, "expiry_hours must be greater than 0");
+
+        // Credential must exist.
+        if !env
+            .storage()
+            .instance()
+            .has(&DataKey::Credential(credential_id))
+        {
+            panic_with_error!(&env, ContractError::CredentialNotFound);
+        }
+
+        let now = env.ledger().timestamp();
+        let expires_at = now + (expiry_hours as u64) * 3600;
+
+        // Build a deterministic token: 8 bytes credential_id || 8 bytes expires_at
+        let cid_bytes = credential_id.to_be_bytes();
+        let exp_bytes = expires_at.to_be_bytes();
+        let mut raw = [0u8; 16];
+        raw[..8].copy_from_slice(&cid_bytes);
+        raw[8..].copy_from_slice(&exp_bytes);
+        let token = soroban_sdk::Bytes::from_slice(&env, &raw);
+
+        let link = ShareLink { credential_id, expires_at };
+        env.storage()
+            .instance()
+            .set(&DataKey2::ShareToken(token.clone()), &link);
+        env.storage()
+            .instance()
+            .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+
+        token
+    }
+
+    /// Validate a share token and return the credential ID.
+    ///
+    /// Panics with `ContractError::InvalidInput` if the token is unknown or expired.
+    pub fn validate_share_token(env: Env, token: soroban_sdk::Bytes) -> u64 {
+        let link: ShareLink = env
+            .storage()
+            .instance()
+            .get(&DataKey2::ShareToken(token))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::InvalidInput));
+
+        let now = env.ledger().timestamp();
+        if now >= link.expires_at {
+            panic_with_error!(&env, ContractError::InvalidInput);
+        }
+
+        link.credential_id
+    }
 }
 
 #[cfg(test)]
@@ -10775,5 +10849,87 @@ mod doc_tests {
 
         let score = client.get_attestor_reputation_score(&attestor);
         assert_eq!(score, 70i32);
+    }
+
+    // ============ Tests for Feature: generate_share_link / validate_share_token ============
+
+    #[test]
+    fn test_generate_share_link_returns_token() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        let issuer = Address::generate(&env);
+        let holder = Address::generate(&env);
+        let metadata = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+
+        let cred_id = client.issue_credential(&issuer, &holder, &1u32, &metadata, &None::<u64>);
+        let token = client.generate_share_link(&holder, &cred_id, &24u32);
+
+        // Token must be 16 bytes (8 cred_id + 8 expires_at).
+        assert_eq!(token.len(), 16);
+    }
+
+    #[test]
+    fn test_validate_share_token_returns_credential_id() {
+        let env = Env::default();
+        env.mock_all_auths();
+        set_ledger_timestamp(&env, 1_000_000);
+        let (client, _) = setup(&env);
+        let issuer = Address::generate(&env);
+        let holder = Address::generate(&env);
+        let metadata = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+
+        let cred_id = client.issue_credential(&issuer, &holder, &1u32, &metadata, &None::<u64>);
+        let token = client.generate_share_link(&holder, &cred_id, &24u32);
+
+        let returned_id = client.validate_share_token(&token);
+        assert_eq!(returned_id, cred_id);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_validate_share_token_expired_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        set_ledger_timestamp(&env, 1_000_000);
+        let (client, _) = setup(&env);
+        let issuer = Address::generate(&env);
+        let holder = Address::generate(&env);
+        let metadata = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+
+        let cred_id = client.issue_credential(&issuer, &holder, &1u32, &metadata, &None::<u64>);
+        // 1-hour link
+        let token = client.generate_share_link(&holder, &cred_id, &1u32);
+
+        // Advance time past expiry (1 hour + 1 second)
+        set_ledger_timestamp(&env, 1_000_000 + 3601);
+
+        // Must panic because the token is expired.
+        client.validate_share_token(&token);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_validate_share_token_unknown_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+
+        let fake_token = Bytes::from_slice(&env, &[0u8; 16]);
+        client.validate_share_token(&fake_token);
+    }
+
+    #[test]
+    #[should_panic(expected = "expiry_hours must be greater than 0")]
+    fn test_generate_share_link_zero_expiry_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        let issuer = Address::generate(&env);
+        let holder = Address::generate(&env);
+        let metadata = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+
+        let cred_id = client.issue_credential(&issuer, &holder, &1u32, &metadata, &None::<u64>);
+        client.generate_share_link(&holder, &cred_id, &0u32);
     }
 }

--- a/frontend/src/__tests__/ShareLink.test.tsx
+++ b/frontend/src/__tests__/ShareLink.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * ShareLink.test.tsx
+ * Tests for expiring share link generation and expiry — issue #share-links
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ShareCredentialDialog } from '../components/ShareCredentialDialog';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const VALID_SUBJECT = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNN';
+const CRED_ID = '7';
+
+// 16-byte token returned by the contract
+const MOCK_TOKEN = new Uint8Array(16).fill(0xab);
+const MOCK_TOKEN_HEX = Array.from(MOCK_TOKEN).map(b => b.toString(16).padStart(2, '0')).join('');
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../stellar', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../stellar')>();
+  return {
+    ...actual,
+    generateShareLink: vi.fn(),
+    bytesToHex: actual.bytesToHex ?? ((arr: Uint8Array) =>
+      Array.from(arr).map(b => b.toString(16).padStart(2, '0')).join('')
+    ),
+    hexToUint8Array: actual.hexToUint8Array ?? ((hex: string) => {
+      const bytes = new Uint8Array(hex.length / 2);
+      for (let i = 0; i < bytes.length; i++) bytes[i] = parseInt(hex.substr(i * 2, 2), 16);
+      return bytes;
+    }),
+  };
+});
+
+import { generateShareLink } from '../stellar';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderDialog(subjectAddress?: string) {
+  return render(
+    <ShareCredentialDialog
+      credentialId={CRED_ID}
+      subjectAddress={subjectAddress}
+      onClose={vi.fn()}
+    />
+  );
+}
+
+// ── Unit: bytesToHex / hexToUint8Array round-trip ─────────────────────────────
+
+describe('bytesToHex / hexToUint8Array round-trip', () => {
+  it('converts bytes to hex and back', async () => {
+    const { bytesToHex, hexToUint8Array } = await import('../stellar');
+    const original = new Uint8Array([0x00, 0xab, 0xff, 0x10]);
+    const hex = bytesToHex(original);
+    expect(hex).toBe('00abff10');
+    const back = hexToUint8Array(hex);
+    expect(Array.from(back)).toEqual(Array.from(original));
+  });
+
+  it('produces a 32-char hex string for a 16-byte token', async () => {
+    const { bytesToHex } = await import('../stellar');
+    const token = new Uint8Array(16).fill(0xcd);
+    expect(bytesToHex(token)).toHaveLength(32);
+  });
+});
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+describe('ShareCredentialDialog — expiring link section', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+    vi.mocked(generateShareLink).mockResolvedValue(MOCK_TOKEN);
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('renders the expiry duration selector', () => {
+    renderDialog(VALID_SUBJECT);
+    expect(screen.getByLabelText('Link expiry duration')).toBeInTheDocument();
+  });
+
+  it('renders the Generate link button', () => {
+    renderDialog(VALID_SUBJECT);
+    expect(screen.getByLabelText('Generate expiring share link')).toBeInTheDocument();
+  });
+
+  it('shows an error when no wallet is connected', async () => {
+    renderDialog(/* no subjectAddress */);
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Generate expiring share link'));
+    });
+    expect(screen.getByRole('alert')).toHaveTextContent(/connect your wallet/i);
+    expect(generateShareLink).not.toHaveBeenCalled();
+  });
+});
+
+// ── Generate link flow ────────────────────────────────────────────────────────
+
+describe('ShareCredentialDialog — generate link flow', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+    vi.mocked(generateShareLink).mockResolvedValue(MOCK_TOKEN);
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('calls generateShareLink with correct args on click', async () => {
+    renderDialog(VALID_SUBJECT);
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Generate expiring share link'));
+    });
+    expect(generateShareLink).toHaveBeenCalledWith(VALID_SUBJECT, CRED_ID, 24);
+  });
+
+  it('displays the generated link containing the token hex', async () => {
+    renderDialog(VALID_SUBJECT);
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Generate expiring share link'));
+    });
+    await waitFor(() => {
+      expect(screen.getByTitle(expect.stringContaining(MOCK_TOKEN_HEX))).toBeInTheDocument();
+    });
+  });
+
+  it('generated link contains ?token= param', async () => {
+    renderDialog(VALID_SUBJECT);
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Generate expiring share link'));
+    });
+    await waitFor(() => {
+      expect(screen.getByTitle(expect.stringContaining('?token='))).toBeInTheDocument();
+    });
+  });
+
+  it('copies the generated link to clipboard', async () => {
+    renderDialog(VALID_SUBJECT);
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Generate expiring share link'));
+    });
+    await waitFor(() => screen.getByLabelText('Copy expiring share link'));
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Copy expiring share link'));
+    });
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining(MOCK_TOKEN_HEX)
+    );
+  });
+
+  it('uses the selected expiry duration', async () => {
+    renderDialog(VALID_SUBJECT);
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Link expiry duration'), { target: { value: '1' } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Generate expiring share link'));
+    });
+    expect(generateShareLink).toHaveBeenCalledWith(VALID_SUBJECT, CRED_ID, 1);
+  });
+
+  it('shows an error when generateShareLink rejects', async () => {
+    vi.mocked(generateShareLink).mockRejectedValue(new Error('Token generation failed'));
+    renderDialog(VALID_SUBJECT);
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Generate expiring share link'));
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/Token generation failed/i);
+    });
+  });
+
+  it('clears the previous link when expiry changes', async () => {
+    renderDialog(VALID_SUBJECT);
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Generate expiring share link'));
+    });
+    await waitFor(() => screen.getByLabelText('Copy expiring share link'));
+
+    // Change expiry — link should disappear
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Link expiry duration'), { target: { value: '72' } });
+    });
+    expect(screen.queryByLabelText('Copy expiring share link')).not.toBeInTheDocument();
+  });
+});
+
+// ── Verify page: token param handling ────────────────────────────────────────
+
+describe('parseIdFromUrl — token param is not an id param', () => {
+  it('returns null when only ?token= is present (no ?id=)', async () => {
+    const { parseIdFromUrl } = await import('../pages/Verify');
+    expect(parseIdFromUrl('https://app.example.com/verify?token=abcd1234')).toBeNull();
+  });
+});

--- a/frontend/src/components/ShareCredentialDialog.tsx
+++ b/frontend/src/components/ShareCredentialDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { generateShareLink, bytesToHex } from '../stellar';
 
 export type SharePermission = 'view' | 'verify' | 'full';
 
@@ -9,6 +10,7 @@ export interface ShareEntry {
 
 interface Props {
   credentialId: string;
+  subjectAddress?: string;
   onClose: () => void;
 }
 
@@ -18,18 +20,66 @@ const PERMISSION_LABELS: Record<SharePermission, { label: string; desc: string }
   full:   { label: 'Full',   desc: 'Full access including export' },
 };
 
+const EXPIRY_OPTIONS = [
+  { value: 1,   label: '1 hour' },
+  { value: 24,  label: '24 hours' },
+  { value: 72,  label: '3 days' },
+  { value: 168, label: '7 days' },
+];
+
 function isValidStellarAddress(addr: string): boolean {
   return addr.startsWith('G') && addr.length >= 56;
 }
 
-export function ShareCredentialDialog({ credentialId, onClose }: Props) {
+export function ShareCredentialDialog({ credentialId, subjectAddress, onClose }: Props) {
   const [shares, setShares] = useState<ShareEntry[]>([]);
   const [address, setAddress] = useState('');
   const [permission, setPermission] = useState<SharePermission>('view');
   const [error, setError] = useState('');
   const [copied, setCopied] = useState(false);
 
-  const shareUrl = `${window.location.origin}/verify?id=${credentialId}`;
+  // Expiring share link state
+  const [expiryHours, setExpiryHours] = useState(24);
+  const [shareLink, setShareLink] = useState<string | null>(null);
+  const [linkLoading, setLinkLoading] = useState(false);
+  const [linkError, setLinkError] = useState('');
+  const [linkCopied, setLinkCopied] = useState(false);
+
+  const staticShareUrl = `${window.location.origin}/verify?id=${credentialId}`;
+
+  async function handleGenerateLink() {
+    if (!subjectAddress) {
+      setLinkError('Connect your wallet to generate an expiring share link.');
+      return;
+    }
+    setLinkLoading(true);
+    setLinkError('');
+    setShareLink(null);
+    try {
+      const token = await generateShareLink(subjectAddress, credentialId, expiryHours);
+      const hex = bytesToHex(token);
+      setShareLink(`${window.location.origin}/verify?token=${hex}`);
+    } catch (err: unknown) {
+      setLinkError(err instanceof Error ? err.message : 'Failed to generate share link.');
+    } finally {
+      setLinkLoading(false);
+    }
+  }
+
+  function handleCopyLink() {
+    navigator.clipboard.writeText(staticShareUrl).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  function handleCopyShareLink() {
+    if (!shareLink) return;
+    navigator.clipboard.writeText(shareLink).then(() => {
+      setLinkCopied(true);
+      setTimeout(() => setLinkCopied(false), 2000);
+    });
+  }
 
   function handleAdd() {
     const trimmed = address.trim();
@@ -56,13 +106,6 @@ export function ShareCredentialDialog({ credentialId, onClose }: Props) {
     );
   }
 
-  function handleCopyLink() {
-    navigator.clipboard.writeText(shareUrl).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
-  }
-
   return (
     <div
       className="share-dialog-overlay"
@@ -83,11 +126,11 @@ export function ShareCredentialDialog({ credentialId, onClose }: Props) {
           </button>
         </div>
 
-        {/* Public link */}
+        {/* Static public link */}
         <div className="share-dialog__section">
           <label className="share-dialog__label">Public verification link</label>
           <div className="share-dialog__link-row">
-            <span className="share-dialog__link-url" title={shareUrl}>{shareUrl}</span>
+            <span className="share-dialog__link-url" title={staticShareUrl}>{staticShareUrl}</span>
             <button
               className="btn btn--sm btn--ghost"
               onClick={handleCopyLink}
@@ -96,6 +139,46 @@ export function ShareCredentialDialog({ credentialId, onClose }: Props) {
               {copied ? '✅ Copied' : '📋 Copy'}
             </button>
           </div>
+        </div>
+
+        {/* Expiring share link */}
+        <div className="share-dialog__section">
+          <label className="share-dialog__label">⏱ Expiring share link</label>
+          <div className="share-dialog__add-row">
+            <select
+              className="share-dialog__select"
+              value={expiryHours}
+              onChange={(e) => { setExpiryHours(Number(e.target.value)); setShareLink(null); }}
+              aria-label="Link expiry duration"
+            >
+              {EXPIRY_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+            <button
+              className="btn btn--sm btn--primary"
+              onClick={handleGenerateLink}
+              disabled={linkLoading}
+              aria-label="Generate expiring share link"
+            >
+              {linkLoading ? '⏳ Generating…' : 'Generate link'}
+            </button>
+          </div>
+          {linkError && (
+            <p className="share-dialog__error" role="alert">{linkError}</p>
+          )}
+          {shareLink && (
+            <div className="share-dialog__link-row" style={{ marginTop: 8 }}>
+              <span className="share-dialog__link-url" title={shareLink}>{shareLink}</span>
+              <button
+                className="btn btn--sm btn--ghost"
+                onClick={handleCopyShareLink}
+                aria-label="Copy expiring share link"
+              >
+                {linkCopied ? '✅ Copied' : '📋 Copy'}
+              </button>
+            </div>
+          )}
         </div>
 
         {/* Add address */}

--- a/frontend/src/pages/Verify.tsx
+++ b/frontend/src/pages/Verify.tsx
@@ -11,7 +11,7 @@ import {
 import type { Credential } from '../lib/contracts/quorumProof';
 import { verifyClaim } from '../lib/contracts/zkVerifier';
 import type { ClaimType } from '../lib/contracts/zkVerifier';
-import { decodeMetadataHash, CONTRACT_ID, RPC_URL, NETWORK } from '../stellar';
+import { decodeMetadataHash, CONTRACT_ID, RPC_URL, NETWORK, validateShareToken, hexToUint8Array } from '../stellar';
 
 export const DEFAULT_SLICE_ID = 1n;
 
@@ -271,7 +271,14 @@ export default function Verify() {
 
   useEffect(() => {
     const preId = searchParams.get('id');
-    if (preId && !autoTriggered.current) {
+    const preToken = searchParams.get('token');
+    if (autoTriggered.current) return;
+    if (preToken) {
+      autoTriggered.current = true;
+      validateShareToken(hexToUint8Array(preToken))
+        .then((id) => fetchCred(BigInt(id)))
+        .catch(() => setError('This share link is invalid or has expired.'));
+    } else if (preId) {
       autoTriggered.current = true;
       const id = parseInt(preId, 10);
       if (!isNaN(id) && id > 0) fetchCred(BigInt(id));

--- a/frontend/src/stellar.ts
+++ b/frontend/src/stellar.ts
@@ -199,6 +199,57 @@ function hexToBytes(hex) {
   return bytes;
 }
 
+/**
+ * Generate a time-limited share link token for a credential.
+ * The caller must be the credential subject (holder).
+ * @param {string} subject  Stellar address of the credential holder
+ * @param {number|string} credentialId
+ * @param {number} expiryHours  Must be > 0
+ * @returns {Promise<Uint8Array>} 16-byte opaque token
+ */
+export async function generateShareLink(subject, credentialId, expiryHours) {
+  try {
+    const subjectVal = new Address(subject).toScVal();
+    const credVal = nativeToScVal(BigInt(credentialId), { type: 'u64' });
+    const hoursVal = nativeToScVal(expiryHours, { type: 'u32' });
+    return await simulate(CONTRACT_QUORUM_PROOF, 'generate_share_link', [subjectVal, credVal, hoursVal]);
+  } catch (error) {
+    throw new Error(handleContractError(error));
+  }
+}
+
+/**
+ * Validate a share token and return the credential ID.
+ * Throws if the token is unknown or expired.
+ * @param {Uint8Array} token  16-byte token returned by generateShareLink
+ * @returns {Promise<bigint>} credential ID
+ */
+export async function validateShareToken(token) {
+  try {
+    const tokenVal = xdr.ScVal.scvBytes(token instanceof Uint8Array ? token : new Uint8Array(token));
+    return await simulate(CONTRACT_QUORUM_PROOF, 'validate_share_token', [tokenVal]);
+  } catch (error) {
+    throw new Error(handleContractError(error));
+  }
+}
+
+/** Utility: Uint8Array → hex string */
+export function bytesToHex(arr) {
+  return Array.from(arr instanceof Uint8Array ? arr : new Uint8Array(arr))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** Utility: hex string → Uint8Array */
+export function hexToUint8Array(hex) {
+  const clean = hex.replace(/^0x/, '');
+  const bytes = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(clean.substr(i * 2, 2), 16);
+  }
+  return bytes;
+}
+
 /** Metadata hash bytes → readable string (utf8 or hex fallback) */
 export function decodeMetadataHash(rawValue) {
   if (typeof rawValue === 'string') return rawValue;
@@ -219,3 +270,4 @@ function uint8ArrayToHex(arr) {
 }
 
 export { STELLAR_NETWORK as NETWORK, CONTRACT_QUORUM_PROOF as CONTRACT_ID, STELLAR_RPC_URL as RPC_URL };
+export { generateShareLink, validateShareToken, bytesToHex, hexToUint8Array };


### PR DESCRIPTION
closes #462
- Add generate_share_link(subject, credential_id, expiry_hours) to contract Returns a 16-byte opaque token (cred_id || expires_at) stored on-chain
- Add validate_share_token(token) to contract Returns credential_id or panics if token unknown/expired
- Add ShareLink struct and ShareToken DataKey2 variant
- Add generateShareLink / validateShareToken wrappers in stellar.ts
- Add bytesToHex / hexToUint8Array utilities in stellar.ts
- Update ShareCredentialDialog with expiry duration selector and Generate link button producing ?token= URLs
- Update Verify.tsx to resolve ?token= param via validateShareToken
- Add ShareLink.test.tsx covering generation, expiry, copy, error cases