### PR TITLE
feat: verification history on credential detail page

### DIFF
--- a/frontend/src/__tests__/VerificationHistory.test.tsx
+++ b/frontend/src/__tests__/VerificationHistory.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * VerificationHistory.test.tsx
+ * Tests for the verification history UI — issue #verification-history
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { VerificationHistory } from '../components/VerificationHistory';
+import type { VerificationRecord } from '../components/VerificationHistory';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const ADDR_A = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNN';
+const ADDR_B = 'GBAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNN';
+
+const NOW_S = BigInt(Math.floor(Date.now() / 1000));
+const ONE_HOUR = 3600n;
+
+function makeRecord(
+  id: number,
+  verifier: string,
+  requested_at: bigint,
+  claim_types: string[] = [],
+): VerificationRecord {
+  return { id: BigInt(id), verifier, requested_at, claim_types };
+}
+
+const RECORDS: VerificationRecord[] = [
+  makeRecord(1, ADDR_A, NOW_S - ONE_HOUR * 2n, ['HasDegree']),
+  makeRecord(2, ADDR_B, NOW_S - ONE_HOUR * 48n, ['HasLicense']),
+  makeRecord(3, ADDR_A, NOW_S - ONE_HOUR * 200n, []),
+];
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+describe('VerificationHistory — rendering', () => {
+  it('renders the verification history container', () => {
+    render(<VerificationHistory records={RECORDS} />);
+    expect(screen.getByLabelText('Verification history')).toBeInTheDocument();
+  });
+
+  it('shows the total count', () => {
+    render(<VerificationHistory records={RECORDS} />);
+    expect(screen.getByText(/3 verifications/i)).toBeInTheDocument();
+  });
+
+  it('renders one row per record', () => {
+    render(<VerificationHistory records={RECORDS} />);
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+  });
+
+  it('shows truncated verifier address', () => {
+    render(<VerificationHistory records={[RECORDS[0]]} />);
+    expect(screen.getByText(new RegExp(ADDR_A.slice(0, 8)))).toBeInTheDocument();
+  });
+
+  it('shows claim types as access type', () => {
+    render(<VerificationHistory records={[RECORDS[0]]} />);
+    expect(screen.getByText('HasDegree')).toBeInTheDocument();
+  });
+
+  it('shows "Full view" when claim_types is empty', () => {
+    render(<VerificationHistory records={[RECORDS[2]]} />);
+    expect(screen.getByText('Full view')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no records', () => {
+    render(<VerificationHistory records={[]} />);
+    expect(screen.getByText(/no verifications/i)).toBeInTheDocument();
+  });
+
+  it('renders the time filter selector', () => {
+    render(<VerificationHistory records={RECORDS} />);
+    expect(screen.getByLabelText('Filter verifications by time')).toBeInTheDocument();
+  });
+});
+
+// ── Sorting ───────────────────────────────────────────────────────────────────
+
+describe('VerificationHistory — sorting', () => {
+  it('shows most recent verification first', () => {
+    render(<VerificationHistory records={RECORDS} />);
+    const items = screen.getAllByRole('listitem');
+    // Record 1 is most recent (NOW - 2h), should be first
+    expect(items[0]).toHaveAttribute('data-testid', 'verification-record-1');
+  });
+});
+
+// ── Filter ────────────────────────────────────────────────────────────────────
+
+describe('VerificationHistory — time filter', () => {
+  it('defaults to "All time" showing all records', () => {
+    render(<VerificationHistory records={RECORDS} />);
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+  });
+
+  it('filters to last 24 hours', async () => {
+    render(<VerificationHistory records={RECORDS} />);
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Filter verifications by time'), {
+        target: { value: '24' },
+      });
+    });
+    // Only record 1 (NOW - 2h) is within 24h
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.getByTestId('verification-record-1')).toBeInTheDocument();
+  });
+
+  it('filters to last 7 days', async () => {
+    render(<VerificationHistory records={RECORDS} />);
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Filter verifications by time'), {
+        target: { value: '168' },
+      });
+    });
+    // Records 1 (2h ago) and 2 (48h ago) are within 7 days
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+  });
+
+  it('shows empty state when filter excludes all records', async () => {
+    render(<VerificationHistory records={RECORDS} />);
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Filter verifications by time'), {
+        target: { value: '1' },
+      });
+    });
+    expect(screen.getByText(/no verifications in this period/i)).toBeInTheDocument();
+  });
+
+  it('shows correct count after filtering', async () => {
+    render(<VerificationHistory records={RECORDS} />);
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Filter verifications by time'), {
+        target: { value: '168' },
+      });
+    });
+    expect(screen.getByText(/2 verifications/i)).toBeInTheDocument();
+  });
+
+  it('restoring "All time" shows all records again', async () => {
+    render(<VerificationHistory records={RECORDS} />);
+    const select = screen.getByLabelText('Filter verifications by time');
+    await act(async () => { fireEvent.change(select, { target: { value: '24' } }); });
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    await act(async () => { fireEvent.change(select, { target: { value: '0' } }); });
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+  });
+});
+
+// ── Multiple claim types ──────────────────────────────────────────────────────
+
+describe('VerificationHistory — access type display', () => {
+  it('joins multiple claim types with comma', () => {
+    const rec = makeRecord(10, ADDR_A, NOW_S, ['HasDegree', 'HasLicense']);
+    render(<VerificationHistory records={[rec]} />);
+    expect(screen.getByText('HasDegree, HasLicense')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/VerificationHistory.tsx
+++ b/frontend/src/components/VerificationHistory.tsx
@@ -1,0 +1,93 @@
+import { useState, useMemo } from 'react';
+import { formatAddress } from '../lib/credentialUtils';
+
+export interface VerificationRecord {
+  id: bigint;
+  verifier: string;
+  requested_at: bigint;
+  claim_types: string[];
+}
+
+interface Props {
+  records: VerificationRecord[];
+}
+
+const FILTER_OPTIONS = [
+  { value: 0,   label: 'All time' },
+  { value: 24,  label: 'Last 24 hours' },
+  { value: 168, label: 'Last 7 days' },
+  { value: 720, label: 'Last 30 days' },
+];
+
+function formatTs(ts: bigint): string {
+  return new Date(Number(ts) * 1000).toLocaleString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+function accessLabel(claimTypes: string[]): string {
+  if (!claimTypes || claimTypes.length === 0) return 'Full view';
+  return claimTypes.join(', ');
+}
+
+export function VerificationHistory({ records }: Props) {
+  const [filterHours, setFilterHours] = useState(0);
+
+  const filtered = useMemo(() => {
+    if (filterHours === 0) return records;
+    const cutoff = BigInt(Math.floor(Date.now() / 1000) - filterHours * 3600);
+    return records.filter((r) => r.requested_at >= cutoff);
+  }, [records, filterHours]);
+
+  // Most recent first
+  const sorted = useMemo(
+    () => [...filtered].sort((a, b) => (a.requested_at > b.requested_at ? -1 : 1)),
+    [filtered],
+  );
+
+  return (
+    <div aria-label="Verification history">
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+        <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>
+          {sorted.length} verification{sorted.length !== 1 ? 's' : ''}
+        </span>
+        <select
+          aria-label="Filter verifications by time"
+          value={filterHours}
+          onChange={(e) => setFilterHours(Number(e.target.value))}
+          style={{ fontSize: 12 }}
+        >
+          {FILTER_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
+      </div>
+
+      {sorted.length === 0 ? (
+        <p style={{ color: 'var(--text-muted)', fontSize: 14, textAlign: 'center', padding: '16px 0' }}>
+          No verifications in this period.
+        </p>
+      ) : (
+        <ol className="attestor-list" aria-label="Verification log" style={{ listStyle: 'none', padding: 0 }}>
+          {sorted.map((r) => (
+            <li key={r.id.toString()} className="attestor-item" data-testid={`verification-record-${r.id}`}>
+              <div className="attestor-item__avatar" aria-hidden="true">🔍</div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div className="attestor-item__addr" title={r.verifier}>
+                  {formatAddress(r.verifier)}
+                </div>
+                <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 2 }}>
+                  {accessLabel(r.claim_types)}
+                </div>
+              </div>
+              <span style={{ fontSize: 11, color: 'var(--text-muted)', whiteSpace: 'nowrap' }}>
+                {formatTs(r.requested_at)}
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -2,6 +2,8 @@ export { ShareCredentialDialog } from './ShareCredentialDialog';
 export type { ShareEntry, SharePermission } from './ShareCredentialDialog';
 export { AuditTrail } from './AuditTrail';
 export type { AuditEvent, AuditEventType } from './AuditTrail';
+export { VerificationHistory } from './VerificationHistory';
+export type { VerificationRecord } from './VerificationHistory';
 export { WalletGate } from './WalletGate';
 export { WalletGuard } from './WalletGuard';
 export { CredentialCard } from './CredentialCard';

--- a/frontend/src/pages/CredentialDetail.tsx
+++ b/frontend/src/pages/CredentialDetail.tsx
@@ -3,6 +3,8 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { Navbar } from '../components/Navbar';
 import { ShareCredentialDialog } from '../components/ShareCredentialDialog';
 import { AuditTrail } from '../components/AuditTrail';
+import { VerificationHistory } from '../components/VerificationHistory';
+import type { VerificationRecord } from '../components/VerificationHistory';
 import {
   getCredential,
   getAttestors,
@@ -10,7 +12,7 @@ import {
   getSlice,
 } from '../lib/contracts/quorumProof';
 import type { Credential, QuorumSlice } from '../lib/contracts/quorumProof';
-import { decodeMetadataHash } from '../stellar';
+import { decodeMetadataHash, getProofRequests } from '../stellar';
 import { credTypeLabel, formatTimestamp, formatAddress } from './Verify';
 import { attestorRole, deriveStatus } from '../lib/credentialUtils';
 
@@ -28,6 +30,7 @@ export default function CredentialDetail() {
   const [attestors, setAttestors] = useState<string[]>([]);
   const [slice, setSlice] = useState<QuorumSlice | null>(null);
   const [isExpiredFlag, setIsExpiredFlag] = useState(false);
+  const [verifications, setVerifications] = useState<VerificationRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
@@ -47,6 +50,9 @@ export default function CredentialDetail() {
         setCredential(cred);
         setIsExpiredFlag(expired);
         setAttestors(attestorList ?? []);
+
+        // Load verification history (non-fatal)
+        getProofRequests(credId).then((reqs) => setVerifications(reqs ?? [])).catch(() => {});
 
         // Try to load slice from localStorage (same pattern as Dashboard)
         const sliceIdRaw = localStorage.getItem('qp-slice-id');
@@ -284,6 +290,28 @@ export default function CredentialDetail() {
               attestors={attestors}
               expired={isExpiredFlag}
             />
+          </div>
+        </div>
+
+        {/* Verification History */}
+        <div className="detail-card" style={{ marginTop: '20px' }}>
+          <div className="detail-card__header">
+            <span className="detail-card__title">Verification History</span>
+            <span className="badge badge--gray">{verifications.length} total</span>
+          </div>
+          <div className="detail-card__body">
+            <VerificationHistory records={verifications} />
+          </div>
+        </div>
+
+        {/* Verification History */}
+        <div className="detail-card" style={{ marginTop: '20px' }}>
+          <div className="detail-card__header">
+            <span className="detail-card__title">Verification History</span>
+            <span className="badge badge--gray">{verifications.length} total</span>
+          </div>
+          <div className="detail-card__body">
+            <VerificationHistory records={verifications} />
           </div>
         </div>
       </main>

--- a/frontend/src/stellar.ts
+++ b/frontend/src/stellar.ts
@@ -199,6 +199,19 @@ function hexToBytes(hex) {
   return bytes;
 }
 
+/**
+ * Get all proof requests (verification history) for a credential.
+ * Returns array of { id, credential_id, verifier, requested_at, claim_types }
+ */
+export async function getProofRequests(credentialId) {
+  try {
+    const credVal = nativeToScVal(BigInt(credentialId), { type: 'u64' });
+    return await simulate(CONTRACT_QUORUM_PROOF, 'get_proof_requests', [credVal]);
+  } catch (error) {
+    throw new Error(handleContractError(error));
+  }
+}
+
 /** Metadata hash bytes → readable string (utf8 or hex fallback) */
 export function decodeMetadataHash(rawValue) {
   if (typeof rawValue === 'string') return rawValue;
@@ -219,3 +232,4 @@ function uint8ArrayToHex(arr) {
 }
 
 export { STELLAR_NETWORK as NETWORK, CONTRACT_QUORUM_PROOF as CONTRACT_ID, STELLAR_RPC_URL as RPC_URL };
+export { getProofRequests };


### PR DESCRIPTION
closes #463
- Add getProofRequests() wrapper in stellar.ts calling get_proof_requests contract function (returns verifier, requested_at, claim_types per record)
- Add VerificationHistory component showing verifier address, timestamp, and access type (claim types or 'Full view'), sorted most-recent-first
- Add time filter (all / 24h / 7d / 30d) with live count update
- Wire VerificationHistory into CredentialDetail page below Audit Trail
- Export VerificationHistory and VerificationRecord from components/index.ts
- Add VerificationHistory.test.tsx covering rendering, sorting, filtering, access type display, and empty states