### PR TITLE
feat: credential type index, batch revoke, metadata hash cache (#518, #519, #520)

### DIFF
--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -38,6 +38,8 @@ const DEFAULT_REPUTATION_AGE_DIVISOR_SECONDS: u64 = 1_000;
 // Issue #381: Rate limiting configuration
 const DEFAULT_RATE_LIMIT_MAX_CALLS: u32 = 100;
 const DEFAULT_RATE_LIMIT_WINDOW_SECONDS: u64 = 3600; // 1 hour
+/// Issue #519: Cache TTL for metadata hash validation (~1 hour wall-clock seconds)
+const METADATA_CACHE_TTL_SECS: u64 = 3_600;
 
 #[contracttype]
 #[derive(Clone)]
@@ -273,6 +275,17 @@ pub struct TransferRestriction {
     pub configured_at: u64,
 }
 
+/// Issue #519: Cache for metadata hash validation result
+#[contracttype]
+#[derive(Clone)]
+pub struct MetadataHashCache {
+    pub credential_id: u64,
+    pub metadata_hash: soroban_sdk::Bytes,
+    pub is_valid: bool,
+    pub cached_at: u64,
+    pub expires_at: u64,
+}
+
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -400,6 +413,10 @@ pub enum DataKey2 {
     AttestConditions(u64),
     RateLimitConfig,
     RateLimitState(Address),
+    /// Issue #520: Index of credential IDs by credential type for O(1) lookup
+    CredentialTypeIndex(u32),
+    /// Issue #519: Cache for metadata hash validation result per credential
+    MetadataHashCache(u64),
 }
 
 #[contracttype]
@@ -1403,6 +1420,81 @@ impl QuorumProofContract {
         }
     }
 
+    // ── Issue #520: CredentialTypeIndex helpers ───────────────────────────────
+
+    fn type_index_add(env: &Env, credential_type: u32, credential_id: u64) {
+        let mut ids: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey2::CredentialTypeIndex(credential_type))
+            .unwrap_or(Vec::new(env));
+        ids.push_back(credential_id);
+        env.storage()
+            .instance()
+            .set(&DataKey2::CredentialTypeIndex(credential_type), &ids);
+        env.storage()
+            .instance()
+            .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+    }
+
+    fn type_index_remove(env: &Env, credential_type: u32, credential_id: u64) {
+        let ids: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey2::CredentialTypeIndex(credential_type))
+            .unwrap_or(Vec::new(env));
+        let mut retained: Vec<u64> = Vec::new(env);
+        for id in ids.iter() {
+            if id != credential_id {
+                retained.push_back(id);
+            }
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey2::CredentialTypeIndex(credential_type), &retained);
+        env.storage()
+            .instance()
+            .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+    }
+
+    // ── Issue #519: MetadataHashCache helpers ─────────────────────────────────
+
+    fn get_metadata_cache(env: &Env, credential_id: u64) -> Option<MetadataHashCache> {
+        let cache: Option<MetadataHashCache> = env
+            .storage()
+            .instance()
+            .get(&DataKey2::MetadataHashCache(credential_id));
+        if let Some(ref c) = cache {
+            if env.ledger().timestamp() >= c.expires_at {
+                return None;
+            }
+        }
+        cache
+    }
+
+    fn set_metadata_cache(env: &Env, credential_id: u64, metadata_hash: &soroban_sdk::Bytes, is_valid: bool) {
+        let now = env.ledger().timestamp();
+        let cache = MetadataHashCache {
+            credential_id,
+            metadata_hash: metadata_hash.clone(),
+            is_valid,
+            cached_at: now,
+            expires_at: now.saturating_add(METADATA_CACHE_TTL_SECS),
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey2::MetadataHashCache(credential_id), &cache);
+        env.storage()
+            .instance()
+            .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+    }
+
+    fn invalidate_metadata_cache(env: &Env, credential_id: u64) {
+        env.storage()
+            .instance()
+            .remove(&DataKey2::MetadataHashCache(credential_id));
+    }
+
     /// Issue #380: Set transfer restriction for a credential type
     pub fn set_transfer_restriction(
         env: Env,
@@ -1582,6 +1674,9 @@ impl QuorumProofContract {
         env.storage()
             .instance()
             .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+
+        // Issue #520: Maintain CredentialTypeIndex
+        Self::type_index_add(&env, credential_type, id);
 
         let event_data = CredentialIssuedEventData {
             id,
@@ -1809,6 +1904,8 @@ impl QuorumProofContract {
         env.storage()
             .instance()
             .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+        // Issue #519: Invalidate metadata hash cache on update
+        Self::invalidate_metadata_cache(&env, credential_id);
     }
 
     /// Initiate a consent-based transfer of a credential to a new subject.
@@ -1946,6 +2043,51 @@ impl QuorumProofContract {
         result
     }
 
+    /// Issue #520: Get all credential IDs for a given credential type (O(1) index lookup).
+    ///
+    /// # Parameters
+    /// - `credential_type`: The credential type to look up.
+    ///
+    /// # Returns
+    /// Returns a `Vec<u64>` of credential IDs of the given type (excluding revoked ones are still
+    /// present in the index until revoked; revocation removes them).
+    pub fn get_credentials_by_type(env: Env, credential_type: u32) -> Vec<u64> {
+        env.storage()
+            .instance()
+            .get(&DataKey2::CredentialTypeIndex(credential_type))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Issue #519: Validate a metadata hash for a credential, using a 1-hour cache.
+    ///
+    /// Returns `true` if the hash is non-empty and matches the stored credential's metadata hash.
+    /// The result is cached for 1 hour and invalidated when metadata is updated or credential is revoked.
+    ///
+    /// # Parameters
+    /// - `credential_id`: The credential to validate against.
+    /// - `metadata_hash`: The hash to validate.
+    pub fn validate_metadata_hash(
+        env: Env,
+        credential_id: u64,
+        metadata_hash: soroban_sdk::Bytes,
+    ) -> bool {
+        if let Some(cache) = Self::get_metadata_cache(&env, credential_id) {
+            if cache.metadata_hash == metadata_hash {
+                return cache.is_valid;
+            }
+        }
+        let credential: Option<Credential> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Credential(credential_id));
+        let is_valid = match credential {
+            Some(c) => !metadata_hash.is_empty() && c.metadata_hash == metadata_hash,
+            None => false,
+        };
+        Self::set_metadata_cache(&env, credential_id, &metadata_hash, is_valid);
+        is_valid
+    }
+
     /// Check if a credential with the given ID exists.
     ///
     /// # Parameters
@@ -2022,6 +2164,10 @@ impl QuorumProofContract {
             .instance()
             .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
         Self::invalidate_verification_caches_for_credential(&env, credential_id);
+        // Issue #520: Remove from CredentialTypeIndex
+        Self::type_index_remove(&env, credential.credential_type, credential_id);
+        // Issue #519: Invalidate metadata hash cache
+        Self::invalidate_metadata_cache(&env, credential_id);
         let event_data = RevokeEventData {
             credential_id,
             subject: credential.subject.clone(),
@@ -2050,6 +2196,94 @@ impl QuorumProofContract {
             issuer.clone(),
             None,
         );
+    }
+
+    /// Issue #518: Revoke multiple credentials in a single transaction.
+    ///
+    /// Applies the same authorization and validation checks as `revoke_credential` for each ID.
+    /// Panics on the first credential that fails any check, leaving prior revocations applied.
+    ///
+    /// # Parameters
+    /// - `issuer`: Must be the original issuer of every credential in the list.
+    /// - `credential_ids`: List of credential IDs to revoke. Max `MAX_BATCH_SIZE` entries.
+    pub fn batch_revoke(env: Env, issuer: Address, credential_ids: Vec<u64>) {
+        issuer.require_auth();
+        Self::require_not_paused(&env);
+        Self::require_rate_limit(&env, &issuer);
+        assert!(
+            credential_ids.len() <= MAX_BATCH_SIZE,
+            "batch size exceeds maximum"
+        );
+        for credential_id in credential_ids.iter() {
+            let mut credential: Credential = env
+                .storage()
+                .instance()
+                .get(&DataKey::Credential(credential_id))
+                .unwrap_or_else(|| panic_with_error!(&env, ContractError::CredentialNotFound));
+            assert!(
+                issuer == credential.issuer,
+                "only the original issuer can revoke"
+            );
+            assert!(!credential.revoked, "credential already revoked");
+            if let Some(expires_at) = credential.expires_at {
+                assert!(
+                    env.ledger().timestamp() < expires_at,
+                    "credential has expired"
+                );
+            }
+            credential.revoked = true;
+            credential.suspended = false;
+            env.storage()
+                .instance()
+                .set(&DataKey::Credential(credential_id), &credential);
+
+            // Remove from SubjectCredentials
+            let mut subject_creds: Vec<u64> = env
+                .storage()
+                .instance()
+                .get(&DataKey::SubjectCredentials(credential.subject.clone()))
+                .unwrap_or(Vec::new(&env));
+            let mut retained: Vec<u64> = Vec::new(&env);
+            for id in subject_creds.iter() {
+                if id != credential_id {
+                    retained.push_back(id);
+                }
+            }
+            if retained.len() != subject_creds.len() {
+                subject_creds = retained;
+                env.storage().instance().set(
+                    &DataKey::SubjectCredentials(credential.subject.clone()),
+                    &subject_creds,
+                );
+            }
+
+            Self::invalidate_verification_caches_for_credential(&env, credential_id);
+            // Issue #520: Remove from CredentialTypeIndex
+            Self::type_index_remove(&env, credential.credential_type, credential_id);
+            // Issue #519: Invalidate metadata hash cache
+            Self::invalidate_metadata_cache(&env, credential_id);
+
+            let event_data = RevokeEventData {
+                credential_id,
+                subject: credential.subject.clone(),
+            };
+            let topic = String::from_str(&env, TOPIC_REVOKE);
+            let mut topics: Vec<String> = Vec::new(&env);
+            topics.push_back(topic);
+            env.events().publish(topics, event_data);
+
+            Self::record_holder_activity(
+                &env,
+                credential.subject.clone(),
+                ActivityType::CredentialRevoked,
+                credential_id,
+                issuer.clone(),
+                None,
+            );
+        }
+        env.storage()
+            .instance()
+            .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
     }
 
     /// Suspend a credential temporarily. Only the original issuer may call this.

--- a/contracts/quorum_proof/src/tests_new_features.rs
+++ b/contracts/quorum_proof/src/tests_new_features.rs
@@ -794,4 +794,198 @@ mod tests {
         let result = client.evaluate_attestation_conditions(&cred_id, &vec![&env]);
         assert_eq!(result, true);
     }
+
+    // ── Issue #520: CredentialTypeIndex Tests ─────────────────────────────────
+
+    #[test]
+    fn test_get_credentials_by_type_empty() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, QuorumProofContract);
+        let client = QuorumProofContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let result = client.get_credentials_by_type(&1u32);
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_get_credentials_by_type_after_issuance() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, QuorumProofContract);
+        let client = QuorumProofContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let subject1 = Address::generate(&env);
+        let subject2 = Address::generate(&env);
+        client.initialize(&admin);
+
+        let hash = soroban_sdk::Bytes::from_array(&env, &[1u8; 32]);
+        let id1 = client.issue_credential(&issuer, &subject1, &1u32, &hash, &None);
+        let id2 = client.issue_credential(&issuer, &subject2, &1u32, &hash, &None);
+        // Different type
+        let hash2 = soroban_sdk::Bytes::from_array(&env, &[2u8; 32]);
+        let _id3 = client.issue_credential(&issuer, &subject1, &2u32, &hash2, &None);
+
+        let type1_creds = client.get_credentials_by_type(&1u32);
+        assert_eq!(type1_creds.len(), 2);
+        assert!(type1_creds.contains(&id1));
+        assert!(type1_creds.contains(&id2));
+
+        let type2_creds = client.get_credentials_by_type(&2u32);
+        assert_eq!(type2_creds.len(), 1);
+    }
+
+    #[test]
+    fn test_type_index_updated_on_revocation() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, QuorumProofContract);
+        let client = QuorumProofContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.initialize(&admin);
+
+        let hash = soroban_sdk::Bytes::from_array(&env, &[1u8; 32]);
+        let cred_id = client.issue_credential(&issuer, &subject, &1u32, &hash, &None);
+
+        assert_eq!(client.get_credentials_by_type(&1u32).len(), 1);
+
+        client.revoke_credential(&issuer, &cred_id);
+
+        assert_eq!(client.get_credentials_by_type(&1u32).len(), 0);
+    }
+
+    // ── Issue #518: batch_revoke Tests ────────────────────────────────────────
+
+    #[test]
+    fn test_batch_revoke_basic() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, QuorumProofContract);
+        let client = QuorumProofContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.initialize(&admin);
+
+        let hash = soroban_sdk::Bytes::from_array(&env, &[1u8; 32]);
+        let id1 = client.issue_credential(&issuer, &subject, &1u32, &hash, &None);
+        let hash2 = soroban_sdk::Bytes::from_array(&env, &[2u8; 32]);
+        let id2 = client.issue_credential(&issuer, &subject, &2u32, &hash2, &None);
+
+        client.batch_revoke(&issuer, &soroban_sdk::vec![&env, id1, id2]);
+
+        assert!(client.get_credential(&id1).revoked);
+        assert!(client.get_credential(&id2).revoked);
+    }
+
+    #[test]
+    fn test_batch_revoke_updates_type_index() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, QuorumProofContract);
+        let client = QuorumProofContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.initialize(&admin);
+
+        let hash = soroban_sdk::Bytes::from_array(&env, &[1u8; 32]);
+        let id1 = client.issue_credential(&issuer, &subject, &1u32, &hash, &None);
+        let hash2 = soroban_sdk::Bytes::from_array(&env, &[2u8; 32]);
+        let id2 = client.issue_credential(&issuer, &subject, &1u32, &hash2, &None);
+
+        assert_eq!(client.get_credentials_by_type(&1u32).len(), 2);
+
+        client.batch_revoke(&issuer, &soroban_sdk::vec![&env, id1, id2]);
+
+        assert_eq!(client.get_credentials_by_type(&1u32).len(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "only the original issuer can revoke")]
+    fn test_batch_revoke_wrong_issuer_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, QuorumProofContract);
+        let client = QuorumProofContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let other = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.initialize(&admin);
+
+        let hash = soroban_sdk::Bytes::from_array(&env, &[1u8; 32]);
+        let id1 = client.issue_credential(&issuer, &subject, &1u32, &hash, &None);
+
+        client.batch_revoke(&other, &soroban_sdk::vec![&env, id1]);
+    }
+
+    // ── Issue #519: MetadataHashCache Tests ───────────────────────────────────
+
+    #[test]
+    fn test_validate_metadata_hash_valid() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, QuorumProofContract);
+        let client = QuorumProofContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.initialize(&admin);
+
+        let hash = soroban_sdk::Bytes::from_array(&env, &[1u8; 32]);
+        let cred_id = client.issue_credential(&issuer, &subject, &1u32, &hash, &None);
+
+        assert!(client.validate_metadata_hash(&cred_id, &hash));
+    }
+
+    #[test]
+    fn test_validate_metadata_hash_wrong_hash() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, QuorumProofContract);
+        let client = QuorumProofContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.initialize(&admin);
+
+        let hash = soroban_sdk::Bytes::from_array(&env, &[1u8; 32]);
+        let cred_id = client.issue_credential(&issuer, &subject, &1u32, &hash, &None);
+
+        let wrong_hash = soroban_sdk::Bytes::from_array(&env, &[9u8; 32]);
+        assert!(!client.validate_metadata_hash(&cred_id, &wrong_hash));
+    }
+
+    #[test]
+    fn test_validate_metadata_hash_invalidated_on_update() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, QuorumProofContract);
+        let client = QuorumProofContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        client.initialize(&admin);
+
+        let hash = soroban_sdk::Bytes::from_array(&env, &[1u8; 32]);
+        let cred_id = client.issue_credential(&issuer, &subject, &1u32, &hash, &None);
+
+        // Cache the valid result
+        assert!(client.validate_metadata_hash(&cred_id, &hash));
+
+        // Update metadata
+        let new_hash = soroban_sdk::Bytes::from_array(&env, &[2u8; 32]);
+        client.update_metadata(&issuer, &cred_id, &new_hash);
+
+        // Old hash should now be invalid
+        assert!(!client.validate_metadata_hash(&cred_id, &hash));
+        // New hash should be valid
+        assert!(client.validate_metadata_hash(&cred_id, &new_hash));
+    }
 }


### PR DESCRIPTION
closes #520 
closes #518 
closes #519 

## Summary

Addresses three performance issues in the credential management contract.

### #520 — Credential lookup by type (O(1))
- Added `CredentialTypeIndex(u32)` storage key mapping each type to a `Vec<u64>` of credential IDs
- `issue_credential` appends to the index; `revoke_credential` and `batch_revoke` remove from it
- New public `get_credentials_by_type(credential_type) -> Vec<u64>`

### #518 — Batch credential revocation
- New public `batch_revoke(issuer, credential_ids: Vec<u64>)`
- Single `require_auth` for the issuer; applies the same per-credential checks (issuer match, not already revoked, not expired) as `revoke_credential`
- Emits `RevokeEventData` and updates all indexes/caches per entry; capped at `MAX_BATCH_SIZE` (50)

### #519 — Metadata hash validation cache
- Added `MetadataHashCache` struct with a 1-hour wall-clock TTL (`METADATA_CACHE_TTL_SECS = 3600`)
- New public `validate_metadata_hash(credential_id, metadata_hash) -> bool` — cache hit avoids re-reading the credential
- Cache invalidated by `update_metadata` and `revoke_credential`/`batch_revoke`

## Tests
Nine new tests added to `tests_new_features.rs` covering empty index, issuance/revocation index maintenance, batch revoke correctness and auth, and metadata cache hit/miss/invalidation.