### PR TITLE
Feat/issues 464 465 466 467

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,8 +28,7 @@
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitest/coverage-v8": "^3.2.4",
-    "@vitejs/plugin-react": "^4.7.0",
+    "@vitejs/plugin-react": "^4.4.1",
     "@vitest/coverage-v8": "^4.1.1",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
@@ -39,7 +38,7 @@
     "jsdom": "^29.0.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "^5.4.10",
+    "vite": "^6.4.2",
     "vite-plugin-node-polyfills": "^0.25.0",
     "vitest": "^4.1.1"
   }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -52,11 +52,11 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
-        specifier: ^4.7.0
-        version: 4.7.0(vite@5.4.21(@types/node@24.12.0))
+        specifier: ^4.4.1
+        version: 4.7.0(vite@6.4.2(@types/node@24.12.0))
       '@vitest/coverage-v8':
         specifier: ^4.1.1
-        version: 4.1.2(vitest@4.1.2(@types/node@24.12.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@5.4.21(@types/node@24.12.0)))
+        version: 4.1.2(vitest@4.1.2(@types/node@24.12.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@6.4.2(@types/node@24.12.0)))
       eslint:
         specifier: ^9.39.4
         version: 9.39.4
@@ -82,14 +82,14 @@ importers:
         specifier: ^8.57.0
         version: 8.57.2(eslint@9.39.4)(typescript@5.9.3)
       vite:
-        specifier: ^5.4.10
-        version: 5.4.21(@types/node@24.12.0)
+        specifier: ^6.4.2
+        version: 6.4.2(@types/node@24.12.0)
       vite-plugin-node-polyfills:
         specifier: ^0.25.0
-        version: 0.25.0(rollup@4.60.0)(vite@5.4.21(@types/node@24.12.0))
+        version: 0.25.0(rollup@4.60.0)(vite@6.4.2(@types/node@24.12.0))
       vitest:
         specifier: ^4.1.1
-        version: 4.1.2(@types/node@24.12.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@5.4.21(@types/node@24.12.0))
+        version: 4.1.2(@types/node@24.12.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@6.4.2(@types/node@24.12.0))
 
 packages:
 
@@ -238,141 +238,159 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@esbuild/aix-ppc64@0.21.5':
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
-    engines: {node: '>=12'}
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.21.5':
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.21.5':
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.21.5':
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
-    engines: {node: '>=12'}
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.21.5':
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.21.5':
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.21.5':
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.21.5':
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.21.5':
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.21.5':
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.21.5':
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.21.5':
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.21.5':
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.21.5':
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.21.5':
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.21.5':
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-x64@0.21.5':
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-x64@0.21.5':
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
-    engines: {node: '>=12'}
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/sunos-x64@0.21.5':
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.21.5':
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.21.5':
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.21.5':
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -518,66 +536,79 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -1116,9 +1147,9 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
-    engines: {node: '>=12'}
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escalade@3.2.0:
@@ -2003,21 +2034,26 @@ packages:
     peerDependencies:
       vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  vite@5.4.21:
-    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
       sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
-      terser: ^5.4.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
     peerDependenciesMeta:
       '@types/node':
+        optional: true
+      jiti:
         optional: true
       less:
         optional: true
@@ -2032,6 +2068,10 @@ packages:
       sugarss:
         optional: true
       terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   vitest@4.1.2:
@@ -2299,73 +2339,82 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@esbuild/aix-ppc64@0.21.5':
+  '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/android-arm64@0.21.5':
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
-  '@esbuild/android-arm@0.21.5':
+  '@esbuild/android-arm@0.25.12':
     optional: true
 
-  '@esbuild/android-x64@0.21.5':
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-arm64@0.21.5':
+  '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-x64@0.21.5':
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.21.5':
+  '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-x64@0.21.5':
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm64@0.21.5':
+  '@esbuild/linux-arm64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm@0.21.5':
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
-  '@esbuild/linux-ia32@0.21.5':
+  '@esbuild/linux-ia32@0.25.12':
     optional: true
 
-  '@esbuild/linux-loong64@0.21.5':
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
-  '@esbuild/linux-mips64el@0.21.5':
+  '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
-  '@esbuild/linux-ppc64@0.21.5':
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/linux-riscv64@0.21.5':
+  '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
-  '@esbuild/linux-s390x@0.21.5':
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
-  '@esbuild/linux-x64@0.21.5':
+  '@esbuild/linux-x64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-x64@0.21.5':
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-x64@0.21.5':
+  '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/sunos-x64@0.21.5':
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/win32-arm64@0.21.5':
+  '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/win32-ia32@0.21.5':
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
-  '@esbuild/win32-x64@0.21.5':
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
@@ -2746,7 +2795,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.2
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@24.12.0))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@24.12.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -2754,11 +2803,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 5.4.21(@types/node@24.12.0)
+      vite: 6.4.2(@types/node@24.12.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@24.12.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@5.4.21(@types/node@24.12.0)))':
+  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@24.12.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@6.4.2(@types/node@24.12.0)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.2
@@ -2770,7 +2819,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@24.12.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@5.4.21(@types/node@24.12.0))
+      vitest: 4.1.2(@types/node@24.12.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@6.4.2(@types/node@24.12.0))
 
   '@vitest/expect@4.1.2':
     dependencies:
@@ -2781,13 +2830,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@5.4.21(@types/node@24.12.0))':
+  '@vitest/mocker@4.1.2(vite@6.4.2(@types/node@24.12.0))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21(@types/node@24.12.0)
+      vite: 6.4.2(@types/node@24.12.0)
 
   '@vitest/pretty-format@4.1.2':
     dependencies:
@@ -3185,31 +3234,34 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  esbuild@0.21.5:
+  esbuild@0.25.12:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   escalade@3.2.0: {}
 
@@ -4140,27 +4192,30 @@ snapshots:
       is-typed-array: 1.1.15
       which-typed-array: 1.1.20
 
-  vite-plugin-node-polyfills@0.25.0(rollup@4.60.0)(vite@5.4.21(@types/node@24.12.0)):
+  vite-plugin-node-polyfills@0.25.0(rollup@4.60.0)(vite@6.4.2(@types/node@24.12.0)):
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.60.0)
       node-stdlib-browser: 1.3.1
-      vite: 5.4.21(@types/node@24.12.0)
+      vite: 6.4.2(@types/node@24.12.0)
     transitivePeerDependencies:
       - rollup
 
-  vite@5.4.21(@types/node@24.12.0):
+  vite@6.4.2(@types/node@24.12.0):
     dependencies:
-      esbuild: 0.21.5
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.8
       rollup: 4.60.0
+      tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.12.0
       fsevents: 2.3.3
 
-  vitest@4.1.2(@types/node@24.12.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@5.4.21(@types/node@24.12.0)):
+  vitest@4.1.2(@types/node@24.12.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@6.4.2(@types/node@24.12.0)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@5.4.21(@types/node@24.12.0))
+      '@vitest/mocker': 4.1.2(vite@6.4.2(@types/node@24.12.0))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -4177,7 +4232,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 5.4.21(@types/node@24.12.0)
+      vite: 6.4.2(@types/node@24.12.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.0

--- a/frontend/src/components/NotificationPreferences.tsx
+++ b/frontend/src/components/NotificationPreferences.tsx
@@ -1,0 +1,34 @@
+import { useNotification, type CredentialEventType } from '../context/NotificationContext';
+
+const EVENT_LABELS: Record<CredentialEventType, string> = {
+  issued: 'Credential Issued',
+  revoked: 'Credential Revoked',
+  verified: 'Credential Verified',
+  disputed: 'Credential Disputed',
+};
+
+export function NotificationPreferences() {
+  const { preferences, updatePreferences } = useNotification();
+
+  return (
+    <div className="notification-preferences" data-testid="notification-preferences">
+      <h4 className="notification-preferences__title">Notification Preferences</h4>
+      <p className="notification-preferences__desc">Choose which events you want to be notified about.</p>
+      <ul className="notification-preferences__list">
+        {(Object.keys(EVENT_LABELS) as CredentialEventType[]).map((event) => (
+          <li key={event} className="notification-preferences__item">
+            <label className="notification-preferences__label">
+              <input
+                type="checkbox"
+                checked={preferences[event]}
+                onChange={(e) => updatePreferences({ [event]: e.target.checked })}
+                aria-label={`Enable ${EVENT_LABELS[event]} notifications`}
+              />
+              <span>{EVENT_LABELS[event]}</span>
+            </label>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/SliceMemberManager.tsx
+++ b/frontend/src/components/SliceMemberManager.tsx
@@ -1,0 +1,187 @@
+import { useState } from 'react';
+import type { ChangeEvent, FormEvent } from 'react';
+
+export interface SliceMember {
+  id: string;
+  address: string;
+  role: string;
+  reputationScore: number; // 0–100
+  available: boolean;
+}
+
+interface SliceMemberManagerProps {
+  members: SliceMember[];
+  threshold: number;
+  onAddMember: (member: Omit<SliceMember, 'id'>) => void;
+  onRemoveMember: (id: string) => void;
+  onThresholdChange: (threshold: number) => void;
+}
+
+const ROLES = ['University', 'Licensing Body', 'Employer', 'Other'] as const;
+
+function isValidStellarAddress(addr: string) {
+  return /^G[A-Z2-7]{55}$/.test(addr.trim());
+}
+
+function reputationLabel(score: number): string {
+  if (score >= 80) return 'High';
+  if (score >= 50) return 'Medium';
+  return 'Low';
+}
+
+function reputationColor(score: number): string {
+  if (score >= 80) return '#10b981';
+  if (score >= 50) return '#f59e0b';
+  return '#ef4444';
+}
+
+export function SliceMemberManager({
+  members,
+  threshold,
+  onAddMember,
+  onRemoveMember,
+  onThresholdChange,
+}: SliceMemberManagerProps) {
+  const [addr, setAddr] = useState('');
+  const [role, setRole] = useState<string>('University');
+  const [reputation, setReputation] = useState(75);
+  const [addrError, setAddrError] = useState('');
+
+  function handleAdd(e: FormEvent) {
+    e.preventDefault();
+    const trimmed = addr.trim();
+    if (!trimmed) { setAddrError('Address is required.'); return; }
+    if (!isValidStellarAddress(trimmed)) { setAddrError('Must be a valid Stellar address (G…, 56 chars).'); return; }
+    if (members.some((m) => m.address === trimmed)) { setAddrError('Address already in slice.'); return; }
+    setAddrError('');
+    onAddMember({ address: trimmed, role, reputationScore: reputation, available: true });
+    setAddr('');
+    setReputation(75);
+  }
+
+  const requiredSignatures = threshold;
+  const totalMembers = members.length;
+
+  return (
+    <div className="slice-member-manager" data-testid="slice-member-manager">
+      {/* ── Add Member Form ── */}
+      <section aria-label="Add attestor">
+        <h4 className="smm__section-title">Add Attestor</h4>
+        <form onSubmit={handleAdd} noValidate aria-label="Add attestor form">
+          <div className="form-row">
+            <label htmlFor="smm-addr" className="form-label">Stellar Address</label>
+            <input
+              id="smm-addr"
+              type="text"
+              placeholder="GABC…XYZ"
+              value={addr}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => { setAddr(e.target.value); setAddrError(''); }}
+              aria-invalid={!!addrError}
+              aria-describedby={addrError ? 'smm-addr-err' : undefined}
+              autoComplete="off"
+            />
+            {addrError && <p id="smm-addr-err" className="issue-form__field-error" role="alert">{addrError}</p>}
+          </div>
+          <div className="form-row">
+            <label htmlFor="smm-role" className="form-label">Role</label>
+            <select id="smm-role" value={role} onChange={(e) => setRole(e.target.value)} aria-label="Attestor role">
+              {ROLES.map((r) => <option key={r} value={r}>{r}</option>)}
+            </select>
+          </div>
+          <div className="form-row">
+            <label htmlFor="smm-rep" className="form-label">
+              Reputation Score: <strong style={{ color: reputationColor(reputation) }}>{reputation} ({reputationLabel(reputation)})</strong>
+            </label>
+            <input
+              id="smm-rep"
+              type="range"
+              min={0}
+              max={100}
+              value={reputation}
+              onChange={(e) => setReputation(Number(e.target.value))}
+              aria-label="Reputation score"
+            />
+          </div>
+          <button type="submit" className="btn btn--ghost btn--sm" style={{ width: '100%', marginTop: 8 }}>
+            + Add to Slice
+          </button>
+        </form>
+      </section>
+
+      <div className="divider" />
+
+      {/* ── Member List ── */}
+      <section aria-label="Attestor list">
+        <h4 className="smm__section-title">Attestors ({totalMembers})</h4>
+        {totalMembers === 0 ? (
+          <p className="qsb__empty">No attestors added yet.</p>
+        ) : (
+          <ul className="smm__member-list" aria-label="Slice members">
+            {members.map((m) => (
+              <li key={m.id} className="smm__member-item" data-testid={`member-${m.id}`}>
+                <div className="smm__member-info">
+                  <span className="smm__member-addr mono" title={m.address}>
+                    {m.address.slice(0, 8)}…{m.address.slice(-6)}
+                  </span>
+                  <span className="smm__member-role">{m.role}</span>
+                </div>
+                <div className="smm__member-rep" title={`Reputation: ${m.reputationScore}`}>
+                  <span
+                    className="smm__rep-badge"
+                    style={{ color: reputationColor(m.reputationScore) }}
+                    aria-label={`Reputation score ${m.reputationScore}`}
+                  >
+                    ★ {m.reputationScore}
+                  </span>
+                  <span className="smm__rep-label" style={{ color: reputationColor(m.reputationScore) }}>
+                    {reputationLabel(m.reputationScore)}
+                  </span>
+                </div>
+                <button
+                  className="qsb__remove-btn"
+                  onClick={() => onRemoveMember(m.id)}
+                  aria-label={`Remove ${m.role} ${m.address.slice(0, 8)}`}
+                >
+                  ✕
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <div className="divider" />
+
+      {/* ── Threshold / Required Signatures ── */}
+      <section aria-label="Threshold settings">
+        <h4 className="smm__section-title">Required Signatures</h4>
+        <div className="smm__threshold-info">
+          <div className="meta-row">
+            <span className="meta-label">Threshold</span>
+            <span className="meta-value" data-testid="threshold-display">
+              {requiredSignatures} / {totalMembers || '—'}
+            </span>
+          </div>
+          <div className="meta-row">
+            <span className="meta-label">Required signatures</span>
+            <span className="meta-value">{requiredSignatures}</span>
+          </div>
+        </div>
+        {totalMembers > 0 && (
+          <div className="form-row" style={{ marginTop: 8 }}>
+            <label htmlFor="smm-threshold" className="form-label">Minimum signatures required</label>
+            <input
+              id="smm-threshold"
+              type="number"
+              min={1}
+              max={totalMembers}
+              value={threshold}
+              onChange={(e) => onThresholdChange(parseInt(e.target.value, 10) || 1)}
+              aria-label="Attestation threshold"
+            />
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/SliceRecommendationPanel.tsx
+++ b/frontend/src/components/SliceRecommendationPanel.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { recommendSlice, type AttestorCandidate, type SliceRecommendation } from '../lib/sliceRecommendation';
+
+interface SliceRecommendationPanelProps {
+  candidates: AttestorCandidate[];
+  onAccept: (recommendation: SliceRecommendation) => void;
+}
+
+export function SliceRecommendationPanel({ candidates, onAccept }: SliceRecommendationPanelProps) {
+  const [recommendation] = useState<SliceRecommendation | null>(() => recommendSlice(candidates));
+  const [customized, setCustomized] = useState<SliceRecommendation | null>(null);
+  const [accepted, setAccepted] = useState(false);
+
+  const active = customized ?? recommendation;
+
+  if (!active) {
+    return (
+      <div className="srp srp--empty" data-testid="srp-empty">
+        <p>No candidates available for recommendation.</p>
+      </div>
+    );
+  }
+
+  if (accepted) {
+    return (
+      <div className="srp srp--accepted" data-testid="srp-accepted">
+        <span>✅ Recommended slice applied ({active.attestors.length} attestors, threshold {active.threshold})</span>
+      </div>
+    );
+  }
+
+  function handleRemove(address: string) {
+    if (!active) return;
+    const next = active.attestors.filter((a) => a.address !== address);
+    if (next.length === 0) return;
+    setCustomized({
+      attestors: next,
+      threshold: Math.min(active.threshold, next.length),
+      score: Math.round(next.reduce((s, a) => s + a.reputationScore, 0) / next.length),
+    });
+  }
+
+  function handleAccept() {
+    onAccept(active!);
+    setAccepted(true);
+  }
+
+  return (
+    <div className="srp" data-testid="slice-recommendation-panel">
+      <div className="srp__header">
+        <h4 className="srp__title">Recommended Slice</h4>
+        <span className="srp__score" data-testid="recommendation-score">
+          Score: {active.score}/100
+        </span>
+      </div>
+      <p className="srp__desc">
+        Based on reputation and availability. You can remove attestors to customize.
+      </p>
+
+      <ul className="srp__list" aria-label="Recommended attestors">
+        {active.attestors.map((a) => (
+          <li key={a.address} className="srp__item" data-testid={`rec-attestor-${a.address.slice(0, 8)}`}>
+            <div className="srp__item-info">
+              <span className="mono srp__addr" title={a.address}>{a.address.slice(0, 8)}…</span>
+              <span className="srp__role">{a.role}</span>
+              <span className="srp__rep">★ {a.reputationScore}</span>
+              {!a.available && <span className="srp__unavailable">Unavailable</span>}
+            </div>
+            <button
+              className="qsb__remove-btn"
+              onClick={() => handleRemove(a.address)}
+              aria-label={`Remove ${a.role} from recommendation`}
+              disabled={active.attestors.length <= 1}
+            >
+              ✕
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <div className="srp__threshold">
+        Suggested threshold: <strong data-testid="rec-threshold">{active.threshold}</strong> of {active.attestors.length}
+      </div>
+
+      <div className="srp__actions">
+        <button className="btn btn--primary btn--sm" onClick={handleAccept} data-testid="accept-recommendation">
+          Accept Recommendation
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SliceThresholdVisualizer.tsx
+++ b/frontend/src/components/SliceThresholdVisualizer.tsx
@@ -1,0 +1,77 @@
+export type SliceHealth = 'healthy' | 'degraded' | 'critical';
+
+export interface SliceThresholdVisualizerProps {
+  attestations: number;   // current attestations received
+  threshold: number;      // minimum required
+  totalAttestors: number; // total attestors in slice
+  availableAttestors: number; // attestors currently available
+}
+
+export function getSliceHealth(availableAttestors: number, threshold: number): SliceHealth {
+  if (availableAttestors >= threshold) return 'healthy';
+  if (availableAttestors > 0) return 'degraded';
+  return 'critical';
+}
+
+const HEALTH_CONFIG: Record<SliceHealth, { color: string; label: string; icon: string }> = {
+  healthy:  { color: '#10b981', label: 'All attestors available', icon: '✅' },
+  degraded: { color: '#f59e0b', label: 'Some attestors unavailable', icon: '⚠️' },
+  critical: { color: '#ef4444', label: 'No attestors available', icon: '🔴' },
+};
+
+export function SliceThresholdVisualizer({
+  attestations,
+  threshold,
+  totalAttestors,
+  availableAttestors,
+}: SliceThresholdVisualizerProps) {
+  const progress = totalAttestors > 0 ? Math.min((attestations / threshold) * 100, 100) : 0;
+  const health = getSliceHealth(availableAttestors, threshold);
+  const { color, label, icon } = HEALTH_CONFIG[health];
+
+  return (
+    <div className="slice-threshold-viz" data-testid="slice-threshold-viz">
+      {/* Progress bar */}
+      <div className="stv__progress-section">
+        <div className="stv__labels">
+          <span className="stv__label">Attestations</span>
+          <span className="stv__count" data-testid="attestation-count">
+            {attestations} / {threshold} required
+          </span>
+        </div>
+        <div
+          className="stv__track"
+          role="progressbar"
+          aria-valuenow={attestations}
+          aria-valuemin={0}
+          aria-valuemax={threshold}
+          aria-label="Attestation progress"
+        >
+          <div
+            className="stv__fill"
+            style={{ width: `${progress}%`, backgroundColor: color }}
+            data-testid="progress-fill"
+          />
+        </div>
+        <div className="stv__pct" style={{ color }}>
+          {Math.round(progress)}%
+        </div>
+      </div>
+
+      {/* Health indicator */}
+      <div
+        className="stv__health"
+        data-testid="health-indicator"
+        data-health={health}
+        style={{ color }}
+        aria-label={`Slice health: ${label}`}
+      >
+        <span className="stv__health-icon" aria-hidden="true">{icon}</span>
+        <span className="stv__health-label">{label}</span>
+        <span className="stv__health-detail">
+          {availableAttestors} of {totalAttestors} attestors available
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/NotificationPreferences.test.tsx
+++ b/frontend/src/components/__tests__/NotificationPreferences.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { NotificationProvider, useNotification } from '../../context/NotificationContext';
+import { NotificationPreferences } from '../NotificationPreferences';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <NotificationProvider>{children}</NotificationProvider>
+);
+
+describe('NotificationContext — credential event helpers (#464)', () => {
+  it('notifyCredentialIssued adds a success notification', () => {
+    const { result } = renderHook(() => useNotification(), { wrapper });
+    act(() => { result.current.notifyCredentialIssued('cred-1', 'Engineering Degree'); });
+    expect(result.current.notifications).toHaveLength(1);
+    expect(result.current.notifications[0].type).toBe('success');
+    expect(result.current.notifications[0].eventType).toBe('issued');
+    expect(result.current.notifications[0].title).toBe('Credential Issued');
+    expect(result.current.notifications[0].message).toContain('Engineering Degree');
+  });
+
+  it('notifyCredentialRevoked adds an error notification', () => {
+    const { result } = renderHook(() => useNotification(), { wrapper });
+    act(() => { result.current.notifyCredentialRevoked('cred-2'); });
+    expect(result.current.notifications[0].type).toBe('error');
+    expect(result.current.notifications[0].eventType).toBe('revoked');
+    expect(result.current.notifications[0].credentialId).toBe('cred-2');
+  });
+
+  it('notifyCredentialVerified adds a success notification', () => {
+    const { result } = renderHook(() => useNotification(), { wrapper });
+    act(() => { result.current.notifyCredentialVerified('cred-3'); });
+    expect(result.current.notifications[0].type).toBe('success');
+    expect(result.current.notifications[0].eventType).toBe('verified');
+  });
+
+  it('notifyCredentialDisputed adds a warning notification', () => {
+    const { result } = renderHook(() => useNotification(), { wrapper });
+    act(() => { result.current.notifyCredentialDisputed('cred-4'); });
+    expect(result.current.notifications[0].type).toBe('warning');
+    expect(result.current.notifications[0].eventType).toBe('disputed');
+  });
+
+  it('does not add notification when preference is disabled', () => {
+    const { result } = renderHook(() => useNotification(), { wrapper });
+    act(() => { result.current.updatePreferences({ issued: false }); });
+    act(() => { result.current.notifyCredentialIssued('cred-5'); });
+    expect(result.current.notifications).toHaveLength(0);
+  });
+
+  it('notifyCredentialIssued without credentialType uses fallback message', () => {
+    const { result } = renderHook(() => useNotification(), { wrapper });
+    act(() => { result.current.notifyCredentialIssued('cred-6'); });
+    expect(result.current.notifications[0].message).toContain('cred-6');
+  });
+});
+
+describe('NotificationPreferences component (#464)', () => {
+  it('renders all four event type checkboxes', () => {
+    render(
+      <NotificationProvider>
+        <NotificationPreferences />
+      </NotificationProvider>
+    );
+    expect(screen.getByLabelText(/Enable Credential Issued/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Enable Credential Revoked/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Enable Credential Verified/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Enable Credential Disputed/i)).toBeInTheDocument();
+  });
+
+  it('all checkboxes are checked by default', () => {
+    render(
+      <NotificationProvider>
+        <NotificationPreferences />
+      </NotificationProvider>
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    checkboxes.forEach((cb) => expect(cb).toBeChecked());
+  });
+
+  it('unchecking a preference updates the checkbox state', () => {
+    render(
+      <NotificationProvider>
+        <NotificationPreferences />
+      </NotificationProvider>
+    );
+    const revokedCheckbox = screen.getByLabelText(/Enable Credential Revoked/i);
+    fireEvent.click(revokedCheckbox);
+    expect(revokedCheckbox).not.toBeChecked();
+  });
+});

--- a/frontend/src/components/__tests__/SliceMemberManager.test.tsx
+++ b/frontend/src/components/__tests__/SliceMemberManager.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { SliceMemberManager, type SliceMember } from '../SliceMemberManager';
+
+const VALID_ADDR = 'GW674PTN7IWEZ6AE6OWW3NBULKVCCJUZOGMUSG6HFG6ZOLSL56XCAMBX';
+
+const mockMember: SliceMember = {
+  id: 'member-1',
+  address: 'GW674PTN7IWEZ6AE6OWW3NBULKVCCJUZOGMUSG6HFG6ZOLSL56XCAMBX',
+  role: 'University',
+  reputationScore: 85,
+  available: true,
+};
+
+function renderManager(overrides: Partial<Parameters<typeof SliceMemberManager>[0]> = {}) {
+  const props = {
+    members: [],
+    threshold: 1,
+    onAddMember: vi.fn(),
+    onRemoveMember: vi.fn(),
+    onThresholdChange: vi.fn(),
+    ...overrides,
+  };
+  render(<SliceMemberManager {...props} />);
+  return props;
+}
+
+describe('SliceMemberManager (#465)', () => {
+  it('renders the add attestor form', () => {
+    renderManager();
+    expect(screen.getByLabelText(/Stellar Address/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Attestor role/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Reputation score/i)).toBeInTheDocument();
+  });
+
+  it('shows validation error for empty address', () => {
+    render(<SliceMemberManager members={[]} threshold={1} onAddMember={vi.fn()} onRemoveMember={vi.fn()} onThresholdChange={vi.fn()} />);
+    fireEvent.submit(screen.getByRole('form', { name: 'Add attestor form' }));
+    expect(screen.getByText('Address is required.')).toBeInTheDocument();
+  });
+
+  it('shows validation error for invalid Stellar address', () => {
+    render(<SliceMemberManager members={[]} threshold={1} onAddMember={vi.fn()} onRemoveMember={vi.fn()} onThresholdChange={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/Stellar Address/i), { target: { value: 'invalid' } });
+    fireEvent.submit(screen.getByRole('form', { name: 'Add attestor form' }));
+    expect(screen.getByText(/valid Stellar address/i)).toBeInTheDocument();
+  });
+
+  it('accepts valid Stellar address without showing error', () => {
+    render(<SliceMemberManager members={[]} threshold={1} onAddMember={vi.fn()} onRemoveMember={vi.fn()} onThresholdChange={vi.fn()} />);
+    const addrInput = screen.getByLabelText(/Stellar Address/i) as HTMLInputElement;
+    fireEvent.change(addrInput, { target: { value: VALID_ADDR } });
+    // Trigger validation by submitting
+    fireEvent.submit(screen.getByRole('form', { name: 'Add attestor form' }));
+    // No validation error should appear for a valid address
+    expect(screen.queryByText(/valid Stellar address/i)).not.toBeInTheDocument();
+    expect(screen.queryByText('Address is required.')).not.toBeInTheDocument();
+  });
+
+  it('displays existing members with reputation scores', () => {
+    renderManager({ members: [mockMember] });
+    expect(screen.getByText(/GW674PTN/)).toBeInTheDocument();
+    expect(screen.getAllByText('University').length).toBeGreaterThan(0);
+    expect(screen.getByLabelText(/Reputation score 85/i)).toBeInTheDocument();
+  });
+
+  it('calls onRemoveMember when remove button clicked', () => {
+    const { onRemoveMember } = renderManager({ members: [mockMember] });
+    fireEvent.click(screen.getByLabelText(/Remove University/i));
+    expect(onRemoveMember).toHaveBeenCalledWith('member-1');
+  });
+
+  it('shows threshold and required signatures', () => {
+    renderManager({ members: [mockMember], threshold: 1 });
+    expect(screen.getByTestId('threshold-display')).toHaveTextContent('1 / 1');
+  });
+
+  it('calls onThresholdChange when threshold input changes', () => {
+    const onThresholdChange = vi.fn();
+    render(<SliceMemberManager members={[mockMember, { ...mockMember, id: 'm2', address: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZQE3GGQMJYQMVAMLEGO' }]} threshold={1} onAddMember={vi.fn()} onRemoveMember={vi.fn()} onThresholdChange={onThresholdChange} />);
+    const input = screen.getByLabelText(/Attestation threshold/i);
+    fireEvent.change(input, { target: { value: '2' } });
+    expect(onThresholdChange).toHaveBeenCalledWith(2);
+  });
+
+  it('shows empty state when no members', () => {
+    renderManager();
+    expect(screen.getByText(/No attestors added yet/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/SliceRecommendationPanel.test.tsx
+++ b/frontend/src/components/__tests__/SliceRecommendationPanel.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { recommendSlice, type AttestorCandidate } from '../../lib/sliceRecommendation';
+import { SliceRecommendationPanel } from '../SliceRecommendationPanel';
+
+const candidates: AttestorCandidate[] = [
+  { address: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN', role: 'University', reputationScore: 90, available: true },
+  { address: 'GBCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC', role: 'Employer', reputationScore: 70, available: true },
+  { address: 'GDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD', role: 'Licensing Body', reputationScore: 50, available: false },
+  { address: 'GEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE', role: 'Other', reputationScore: 80, available: true },
+];
+
+describe('recommendSlice algorithm (#467)', () => {
+  it('returns null for empty candidates', () => {
+    expect(recommendSlice([])).toBeNull();
+  });
+
+  it('selects up to maxSize candidates', () => {
+    const rec = recommendSlice(candidates, 3);
+    expect(rec!.attestors).toHaveLength(3);
+  });
+
+  it('prioritizes available attestors over unavailable', () => {
+    const rec = recommendSlice(candidates, 3);
+    const unavailable = rec!.attestors.filter((a) => !a.available);
+    expect(unavailable.length).toBeLessThan(rec!.attestors.length);
+  });
+
+  it('sorts available attestors by reputation descending', () => {
+    const rec = recommendSlice(candidates, 3);
+    const available = rec!.attestors.filter((a) => a.available);
+    for (let i = 1; i < available.length; i++) {
+      expect(available[i - 1].reputationScore).toBeGreaterThanOrEqual(available[i].reputationScore);
+    }
+  });
+
+  it('sets threshold to ceil(n/2)', () => {
+    expect(recommendSlice(candidates, 3)!.threshold).toBe(2); // ceil(3/2)
+    expect(recommendSlice(candidates, 2)!.threshold).toBe(1); // ceil(2/2)
+  });
+
+  it('computes score as average reputation', () => {
+    const rec = recommendSlice([candidates[0]], 1);
+    expect(rec!.score).toBe(90);
+  });
+});
+
+describe('SliceRecommendationPanel (#467)', () => {
+  it('shows empty state when no candidates', () => {
+    render(<SliceRecommendationPanel candidates={[]} onAccept={vi.fn()} />);
+    expect(screen.getByTestId('srp-empty')).toBeInTheDocument();
+  });
+
+  it('renders recommended attestors', () => {
+    render(<SliceRecommendationPanel candidates={candidates} onAccept={vi.fn()} />);
+    expect(screen.getByTestId('slice-recommendation-panel')).toBeInTheDocument();
+    expect(screen.getByTestId('recommendation-score')).toBeInTheDocument();
+    expect(screen.getByTestId('rec-threshold')).toBeInTheDocument();
+  });
+
+  it('shows accept button', () => {
+    render(<SliceRecommendationPanel candidates={candidates} onAccept={vi.fn()} />);
+    expect(screen.getByTestId('accept-recommendation')).toBeInTheDocument();
+  });
+
+  it('calls onAccept and shows accepted state when accepted', () => {
+    const onAccept = vi.fn();
+    render(<SliceRecommendationPanel candidates={candidates} onAccept={onAccept} />);
+    fireEvent.click(screen.getByTestId('accept-recommendation'));
+    expect(onAccept).toHaveBeenCalled();
+    expect(screen.getByTestId('srp-accepted')).toBeInTheDocument();
+  });
+
+  it('allows removing an attestor to customize', () => {
+    render(<SliceRecommendationPanel candidates={candidates} onAccept={vi.fn()} />);
+    const removeButtons = screen.getAllByLabelText(/Remove .* from recommendation/i);
+    const initialCount = screen.getAllByRole('listitem').length;
+    fireEvent.click(removeButtons[0]);
+    expect(screen.getAllByRole('listitem').length).toBe(initialCount - 1);
+  });
+});

--- a/frontend/src/components/__tests__/SliceThresholdVisualizer.test.tsx
+++ b/frontend/src/components/__tests__/SliceThresholdVisualizer.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SliceThresholdVisualizer, getSliceHealth } from '../SliceThresholdVisualizer';
+
+describe('getSliceHealth (#466)', () => {
+  it('returns healthy when available >= threshold', () => {
+    expect(getSliceHealth(3, 3)).toBe('healthy');
+    expect(getSliceHealth(5, 3)).toBe('healthy');
+  });
+
+  it('returns degraded when available > 0 but < threshold', () => {
+    expect(getSliceHealth(1, 3)).toBe('degraded');
+    expect(getSliceHealth(2, 3)).toBe('degraded');
+  });
+
+  it('returns critical when no attestors available', () => {
+    expect(getSliceHealth(0, 3)).toBe('critical');
+  });
+});
+
+describe('SliceThresholdVisualizer (#466)', () => {
+  it('renders progress bar with correct aria attributes', () => {
+    render(<SliceThresholdVisualizer attestations={2} threshold={3} totalAttestors={4} availableAttestors={4} />);
+    const bar = screen.getByRole('progressbar', { name: /Attestation progress/i });
+    expect(bar).toHaveAttribute('aria-valuenow', '2');
+    expect(bar).toHaveAttribute('aria-valuemax', '3');
+  });
+
+  it('shows attestation count', () => {
+    render(<SliceThresholdVisualizer attestations={1} threshold={3} totalAttestors={3} availableAttestors={3} />);
+    expect(screen.getByTestId('attestation-count')).toHaveTextContent('1 / 3 required');
+  });
+
+  it('shows healthy indicator when all attestors available', () => {
+    render(<SliceThresholdVisualizer attestations={3} threshold={3} totalAttestors={3} availableAttestors={3} />);
+    const indicator = screen.getByTestId('health-indicator');
+    expect(indicator).toHaveAttribute('data-health', 'healthy');
+    expect(indicator).toHaveTextContent(/All attestors available/i);
+  });
+
+  it('shows degraded indicator when some attestors unavailable', () => {
+    render(<SliceThresholdVisualizer attestations={1} threshold={3} totalAttestors={3} availableAttestors={1} />);
+    const indicator = screen.getByTestId('health-indicator');
+    expect(indicator).toHaveAttribute('data-health', 'degraded');
+    expect(indicator).toHaveTextContent(/Some attestors unavailable/i);
+  });
+
+  it('shows critical indicator when no attestors available', () => {
+    render(<SliceThresholdVisualizer attestations={0} threshold={3} totalAttestors={3} availableAttestors={0} />);
+    const indicator = screen.getByTestId('health-indicator');
+    expect(indicator).toHaveAttribute('data-health', 'critical');
+    expect(indicator).toHaveTextContent(/No attestors available/i);
+  });
+
+  it('caps progress at 100% when attestations exceed threshold', () => {
+    render(<SliceThresholdVisualizer attestations={5} threshold={3} totalAttestors={5} availableAttestors={5} />);
+    const fill = screen.getByTestId('progress-fill');
+    expect(fill).toHaveStyle({ width: '100%' });
+  });
+
+  it('shows 0% progress when no attestations', () => {
+    render(<SliceThresholdVisualizer attestations={0} threshold={3} totalAttestors={3} availableAttestors={3} />);
+    const fill = screen.getByTestId('progress-fill');
+    expect(fill).toHaveStyle({ width: '0%' });
+  });
+});

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -11,3 +11,4 @@ export { AppLayout } from './AppLayout';
 export { ToastContainer } from './ToastContainer';
 export { FeedbackForm } from './FeedbackForm';
 export { ImportCredentialsDialog } from './ImportCredentialsDialog';
+export { NotificationPreferences } from './NotificationPreferences';

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -12,3 +12,8 @@ export { ToastContainer } from './ToastContainer';
 export { FeedbackForm } from './FeedbackForm';
 export { ImportCredentialsDialog } from './ImportCredentialsDialog';
 export { NotificationPreferences } from './NotificationPreferences';
+export { SliceMemberManager } from './SliceMemberManager';
+export type { SliceMember } from './SliceMemberManager';
+export { SliceThresholdVisualizer, getSliceHealth } from './SliceThresholdVisualizer';
+export type { SliceHealth, SliceThresholdVisualizerProps } from './SliceThresholdVisualizer';
+export { SliceRecommendationPanel } from './SliceRecommendationPanel';

--- a/frontend/src/context/NotificationContext.tsx
+++ b/frontend/src/context/NotificationContext.tsx
@@ -1,5 +1,7 @@
 import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
 
+export type CredentialEventType = 'issued' | 'revoked' | 'verified' | 'disputed';
+
 export interface Notification {
   id: string;
   title: string;
@@ -8,15 +10,31 @@ export interface Notification {
   timestamp: Date;
   read: boolean;
   credentialId?: string;
+  eventType?: CredentialEventType;
 }
+
+export type NotificationPreferences = Record<CredentialEventType, boolean>;
+
+const DEFAULT_PREFERENCES: NotificationPreferences = {
+  issued: true,
+  revoked: true,
+  verified: true,
+  disputed: true,
+};
 
 interface NotificationContextValue {
   notifications: Notification[];
+  preferences: NotificationPreferences;
   addNotification: (notification: Omit<Notification, 'id' | 'timestamp' | 'read'>) => string;
+  notifyCredentialIssued: (credentialId: string, credentialType?: string) => void;
+  notifyCredentialRevoked: (credentialId: string) => void;
+  notifyCredentialVerified: (credentialId: string) => void;
+  notifyCredentialDisputed: (credentialId: string) => void;
   markAsRead: (id: string) => void;
   markAllAsRead: () => void;
   removeNotification: (id: string) => void;
   clearAll: () => void;
+  updatePreferences: (prefs: Partial<NotificationPreferences>) => void;
   unreadCount: number;
 }
 
@@ -24,6 +42,7 @@ const NotificationContext = createContext<NotificationContextValue | undefined>(
 
 export function NotificationProvider({ children }: { children: ReactNode }) {
   const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [preferences, setPreferences] = useState<NotificationPreferences>(DEFAULT_PREFERENCES);
 
   const addNotification = useCallback((notification: Omit<Notification, 'id' | 'timestamp' | 'read'>): string => {
     const id = crypto.randomUUID();
@@ -36,6 +55,52 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
     setNotifications((prev) => [newNotification, ...prev]);
     return id;
   }, []);
+
+  const notifyCredentialIssued = useCallback((credentialId: string, credentialType?: string) => {
+    if (!preferences.issued) return;
+    addNotification({
+      title: 'Credential Issued',
+      message: credentialType
+        ? `Your ${credentialType} credential has been issued.`
+        : `Credential #${credentialId} has been issued.`,
+      type: 'success',
+      credentialId,
+      eventType: 'issued',
+    });
+  }, [preferences.issued, addNotification]);
+
+  const notifyCredentialRevoked = useCallback((credentialId: string) => {
+    if (!preferences.revoked) return;
+    addNotification({
+      title: 'Credential Revoked',
+      message: `Credential #${credentialId} has been revoked.`,
+      type: 'error',
+      credentialId,
+      eventType: 'revoked',
+    });
+  }, [preferences.revoked, addNotification]);
+
+  const notifyCredentialVerified = useCallback((credentialId: string) => {
+    if (!preferences.verified) return;
+    addNotification({
+      title: 'Credential Verified',
+      message: `Credential #${credentialId} has been successfully verified.`,
+      type: 'success',
+      credentialId,
+      eventType: 'verified',
+    });
+  }, [preferences.verified, addNotification]);
+
+  const notifyCredentialDisputed = useCallback((credentialId: string) => {
+    if (!preferences.disputed) return;
+    addNotification({
+      title: 'Credential Disputed',
+      message: `Credential #${credentialId} has been disputed and is under review.`,
+      type: 'warning',
+      credentialId,
+      eventType: 'disputed',
+    });
+  }, [preferences.disputed, addNotification]);
 
   const markAsRead = useCallback((id: string) => {
     setNotifications((prev) =>
@@ -55,17 +120,27 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
     setNotifications([]);
   }, []);
 
+  const updatePreferences = useCallback((prefs: Partial<NotificationPreferences>) => {
+    setPreferences((prev) => ({ ...prev, ...prefs }));
+  }, []);
+
   const unreadCount = notifications.filter((n) => !n.read).length;
 
   return (
     <NotificationContext.Provider
       value={{
         notifications,
+        preferences,
         addNotification,
+        notifyCredentialIssued,
+        notifyCredentialRevoked,
+        notifyCredentialVerified,
+        notifyCredentialDisputed,
         markAsRead,
         markAllAsRead,
         removeNotification,
         clearAll,
+        updatePreferences,
         unreadCount,
       }}
     >

--- a/frontend/src/lib/sliceRecommendation.ts
+++ b/frontend/src/lib/sliceRecommendation.ts
@@ -1,0 +1,38 @@
+export interface AttestorCandidate {
+  address: string;
+  role: string;
+  reputationScore: number; // 0–100
+  available: boolean;
+}
+
+export interface SliceRecommendation {
+  attestors: AttestorCandidate[];
+  threshold: number;
+  score: number; // overall recommendation score 0–100
+}
+
+/**
+ * Recommends a quorum slice from a pool of candidates.
+ * Ranks by: availability first, then reputation score.
+ * Selects top N candidates and sets threshold to majority (ceil(N/2)).
+ */
+export function recommendSlice(
+  candidates: AttestorCandidate[],
+  maxSize = 3,
+): SliceRecommendation | null {
+  if (candidates.length === 0) return null;
+
+  const ranked = [...candidates]
+    .sort((a, b) => {
+      if (a.available !== b.available) return a.available ? -1 : 1;
+      return b.reputationScore - a.reputationScore;
+    })
+    .slice(0, maxSize);
+
+  const threshold = Math.ceil(ranked.length / 2);
+  const score = Math.round(
+    ranked.reduce((sum, c) => sum + c.reputationScore, 0) / ranked.length
+  );
+
+  return { attestors: ranked, threshold, score };
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
-    setupFiles: [],
+    setupFiles: ['./src/setupTests.ts'],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html", "lcov"],


### PR DESCRIPTION
Closes #464 
Closes #465 
Closes #466
Closes #467 

 Here's a summary of everything implemented on branch

  feat/issues-464-465-466-467:
  
  #464 — Credential Holder Notifications
  
  - NotificationContext.tsx — added
  notifyCredentialIssued/Revoked/Verified/Disputed helpers +
  NotificationPreferences type + updatePreferences
  - NotificationPreferences.tsx — UI with per-event-type toggles (issued,
  revoked, verified, disputed)
  - 9 tests
  
  #465 — Slice Member Management UI
  
  - SliceMemberManager.tsx — add/remove attestors with reputation scores
  (0–100, color-coded High/Medium/Low), threshold + required signatures display
  - 9 tests
  
  #466 — Slice Threshold Visualization
  
  - SliceThresholdVisualizer.tsx — progress bar (attestations vs threshold) +
  health indicator (healthy/degraded/critical) based on attestor availability
  - 10 tests
  
  #467 — Slice Recommendation Engine
  
  - sliceRecommendation.ts — recommendSlice() algorithm: ranks by availability
  then reputation, selects top N, threshold = ceil(N/2)
  - SliceRecommendationPanel.tsx — shows recommended slice on creation page,
  accept or customize (remove attestors)
  - 11 tests
  