### PR TITLE
feat: add credential suspension support to dashboard TS client

### DIFF
--- a/dashboard/src/lib/contracts/quorumProof.ts
+++ b/dashboard/src/lib/contracts/quorumProof.ts
@@ -56,6 +56,40 @@ export async function revokeCredential(caller: string, credentialId: bigint): Pr
   })
 }
 
+/**
+ * Temporarily suspend a credential. Only the original issuer may call this.
+ * Unlike revocation, suspension is reversible via `resumeCredential`.
+ */
+export async function suspendCredential(issuer: string, credentialId: bigint): Promise<void> {
+  return invokeContract<void>({
+    contractId: CONTRACT_ID,
+    method: 'suspend_credential',
+    args: [issuer, credentialId],
+    source: issuer,
+  })
+}
+
+/**
+ * Resume a previously suspended credential. Only the original issuer may call this.
+ */
+export async function resumeCredential(issuer: string, credentialId: bigint): Promise<void> {
+  return invokeContract<void>({
+    contractId: CONTRACT_ID,
+    method: 'resume_credential',
+    args: [issuer, credentialId],
+    source: issuer,
+  })
+}
+
+/** Returns true if the credential is currently suspended. */
+export async function isSuspended(credentialId: bigint): Promise<boolean> {
+  return invokeContract<boolean>({
+    contractId: CONTRACT_ID,
+    method: 'is_suspended',
+    args: [credentialId],
+  })
+}
+
 // ── Quorum slices ────────────────────────────────────────────────────────────
 
 /**

--- a/dashboard/src/lib/contracts/types.ts
+++ b/dashboard/src/lib/contracts/types.ts
@@ -12,6 +12,7 @@ export interface Credential {
   credential_type: number
   metadata_hash: string
   revoked: boolean
+  suspended: boolean
   expires_at: bigint | null
 }
 


### PR DESCRIPTION
Closes #540

Closes #541 

---

## Summary

The Soroban `quorum_proof` contract already implements `suspend_credential`, `resume_credential`, and `is_suspended`, but the dashboard TypeScript client had no bindings for them — only permanent revocation was exposed.

## Changes

**`dashboard/src/lib/contracts/types.ts`**
- Added `suspended: boolean` to the `Credential` interface to match the on-chain struct

**`dashboard/src/lib/contracts/quorumProof.ts`**
- Added `suspendCredential(issuer, credentialId)` — temporarily suspends a credential (reversible)
- Added `resumeCredential(issuer, credentialId)` — lifts a suspension
- Added `isSuspended(credentialId)` — query whether a credential is currently suspended

## Why

Revocation is permanent and irreversible. Suspension allows issuers to temporarily block attestation (e.g. during a dispute or review) without destroying the credential. The contract enforces this distinction; the client now exposes it.

## Testing

Contract-level tests already cover this behaviour:
- `test_suspend_and_resume_credential`
- `test_suspended_credential_blocks_attestation`
- Integration tests: `test_suspended_credential_blocks_attestation`, `test_resume_credential_allows_attestation`