### PR TITLE
Add disaster recovery integration tests and contract state snapshot testing

### DIFF
--- a/contracts/integration_tests/src/lib.rs
+++ b/contracts/integration_tests/src/lib.rs
@@ -607,6 +607,137 @@ mod integration {
         assert_eq!(req.credential_id, cred_id);
     }
 
+    // ── Disaster recovery integration tests (#557) ───────────────────────────
+
+    /// Simulates a key loss scenario: a holder pre-configures guardians, then
+    /// loses access to their key. Guardians approve recovery to a new address,
+    /// and all SBTs transfer to the new owner with no credential data loss.
+    #[test]
+    fn test_disaster_recovery_key_loss_scenario() {
+        let env = Env::default();
+        let c = setup(&env);
+
+        let issuer = soroban_sdk::Address::generate(&env);
+        // Holder pre-configures recovery guardians while they still have key access
+        let holder = soroban_sdk::Address::generate(&env);
+        let new_owner = soroban_sdk::Address::generate(&env);
+        let guardian1 = soroban_sdk::Address::generate(&env);
+        let guardian2 = soroban_sdk::Address::generate(&env);
+
+        // Issue credentials and mint SBTs before key loss
+        let cred_id1 = c.qp.issue_credential(&issuer, &holder, &1u32, &metadata(&env), &None, &0u64);
+        let cred_id2 = c.qp.issue_credential(&issuer, &holder, &2u32, &metadata(&env), &None, &0u64);
+        let uri = Bytes::from_slice(&env, b"ipfs://QmSBT");
+        let token_id1 = c.sbt.mint(&holder, &cred_id1, &uri);
+        let token_id2 = c.sbt.mint(&holder, &cred_id2, &uri);
+
+        assert_eq!(c.sbt.get_tokens_by_owner(&holder).len(), 2);
+
+        // Pre-configure guardians (2-of-2 threshold) while key is still accessible
+        let mut guardians = Vec::new(&env);
+        guardians.push_back(guardian1.clone());
+        guardians.push_back(guardian2.clone());
+        c.sbt.setup_recovery_guardians(&c.admin, &guardians, &2u32);
+
+        // --- Key loss occurs here ---
+        // Holder (or a trusted party with knowledge of old address) initiates recovery
+        let recovery_id = c.sbt.initiate_recovery(&holder, &new_owner);
+
+        // Verify recovery request is pending and not yet completed
+        let recovery = c.sbt.get_recovery_request(&recovery_id);
+        assert_eq!(recovery.initiator, holder);
+        assert_eq!(recovery.new_owner, new_owner);
+        assert!(!recovery.completed);
+        assert_eq!(recovery.approvals_count, 0);
+
+        // Both guardians independently approve the recovery
+        c.sbt.approve_recovery(&guardian1, &recovery_id);
+        let after_g1 = c.sbt.get_recovery_request(&recovery_id);
+        assert_eq!(after_g1.approvals_count, 1);
+
+        c.sbt.approve_recovery(&guardian2, &recovery_id);
+        let after_g2 = c.sbt.get_recovery_request(&recovery_id);
+        assert_eq!(after_g2.approvals_count, 2);
+
+        // Finalize recovery — all SBTs transfer to new_owner
+        c.sbt.finalize_recovery(&holder, &recovery_id);
+
+        // Verify recovery procedure worked: old owner has no tokens
+        assert_eq!(c.sbt.get_tokens_by_owner(&holder).len(), 0);
+
+        // New owner has all recovered tokens
+        assert_eq!(c.sbt.get_tokens_by_owner(&new_owner).len(), 2);
+        assert_eq!(c.sbt.owner_of(&token_id1), new_owner);
+        assert_eq!(c.sbt.owner_of(&token_id2), new_owner);
+
+        // Recovery request is marked completed
+        let completed = c.sbt.get_recovery_request(&recovery_id);
+        assert!(completed.completed);
+
+        // Credential validity is unaffected by the key change
+        assert!(c.qp.credential_exists(&cred_id1));
+        assert!(c.qp.credential_exists(&cred_id2));
+    }
+
+    /// Recovery must fail when approval threshold is not met.
+    #[test]
+    #[should_panic]
+    fn test_disaster_recovery_insufficient_approvals_blocked() {
+        let env = Env::default();
+        let c = setup(&env);
+
+        let issuer = soroban_sdk::Address::generate(&env);
+        let holder = soroban_sdk::Address::generate(&env);
+        let new_owner = soroban_sdk::Address::generate(&env);
+        let guardian1 = soroban_sdk::Address::generate(&env);
+        let guardian2 = soroban_sdk::Address::generate(&env);
+
+        let cred_id = c.qp.issue_credential(&issuer, &holder, &1u32, &metadata(&env), &None, &0u64);
+        let uri = Bytes::from_slice(&env, b"ipfs://QmSBT");
+        c.sbt.mint(&holder, &cred_id, &uri);
+
+        // Require 2-of-2 approvals
+        let mut guardians = Vec::new(&env);
+        guardians.push_back(guardian1.clone());
+        guardians.push_back(guardian2.clone());
+        c.sbt.setup_recovery_guardians(&c.admin, &guardians, &2u32);
+
+        let recovery_id = c.sbt.initiate_recovery(&holder, &new_owner);
+
+        // Only one guardian approves — threshold not met
+        c.sbt.approve_recovery(&guardian1, &recovery_id);
+
+        // Finalize must panic — insufficient approvals
+        c.sbt.finalize_recovery(&holder, &recovery_id);
+    }
+
+    /// An unauthorized address cannot approve a recovery request.
+    #[test]
+    #[should_panic]
+    fn test_disaster_recovery_unauthorized_approver_rejected() {
+        let env = Env::default();
+        let c = setup(&env);
+
+        let issuer = soroban_sdk::Address::generate(&env);
+        let holder = soroban_sdk::Address::generate(&env);
+        let new_owner = soroban_sdk::Address::generate(&env);
+        let guardian = soroban_sdk::Address::generate(&env);
+        let attacker = soroban_sdk::Address::generate(&env);
+
+        let cred_id = c.qp.issue_credential(&issuer, &holder, &1u32, &metadata(&env), &None, &0u64);
+        let uri = Bytes::from_slice(&env, b"ipfs://QmSBT");
+        c.sbt.mint(&holder, &cred_id, &uri);
+
+        let mut guardians = Vec::new(&env);
+        guardians.push_back(guardian.clone());
+        c.sbt.setup_recovery_guardians(&c.admin, &guardians, &1u32);
+
+        let recovery_id = c.sbt.initiate_recovery(&holder, &new_owner);
+
+        // Non-guardian attempts to approve — must panic
+        c.sbt.approve_recovery(&attacker, &recovery_id);
+    }
+
     // ── E2E: SBT burn removes token from owner ────────────────────────────────
 
     #[test]

--- a/contracts/sbt_registry/src/lib.rs
+++ b/contracts/sbt_registry/src/lib.rs
@@ -1896,6 +1896,117 @@ mod tests {
         assert_eq!(env.ledger().timestamp(), env2.ledger().timestamp());
     }
 
+    // ── Snapshot upgrade state tests (#556) ──────────────────────────────────
+
+    /// Snapshots contract state before a simulated upgrade, reloads the snapshot,
+    /// re-registers the contract code at the same address (upgrade), and verifies
+    /// all state is preserved with no data loss.
+    #[test]
+    fn test_snapshot_upgrade_preserves_state() {
+        let snap_path = "test_snapshots/tests/snapshot_upgrade_state.json";
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, qp_client, _qp_id) = setup_with_qp(&env);
+
+        let issuer = Address::generate(&env);
+        let holder1 = Address::generate(&env);
+        let holder2 = Address::generate(&env);
+        let meta = soroban_sdk::Bytes::from_slice(&env, b"ipfs://meta");
+
+        // Build non-trivial pre-upgrade state: two holders, three tokens
+        let cred_id1 = qp_client.issue_credential(&issuer, &holder1, &1u32, &meta, &None, &0u64);
+        let cred_id2 = qp_client.issue_credential(&issuer, &holder1, &2u32, &meta, &None, &0u64);
+        let cred_id3 = qp_client.issue_credential(&issuer, &holder2, &3u32, &meta, &None, &0u64);
+        let uri = Bytes::from_slice(&env, b"ipfs://QmSBT");
+        let token_id1 = client.mint(&holder1, &cred_id1, &uri);
+        let token_id2 = client.mint(&holder1, &cred_id2, &uri);
+        let token_id3 = client.mint(&holder2, &cred_id3, &uri);
+
+        // Configure recovery guardians so that state is present
+        let guardian = Address::generate(&env);
+        let guardians = soroban_sdk::vec![&env, guardian];
+        client.setup_recovery_guardians(&admin, &guardians, &1u32);
+
+        // Record all pre-upgrade state values
+        let pre_sbt_count = client.sbt_count();
+        let pre_owner1 = client.owner_of(&token_id1);
+        let pre_owner2 = client.owner_of(&token_id2);
+        let pre_owner3 = client.owner_of(&token_id3);
+        let pre_holder1_count = client.get_tokens_by_owner(&holder1).len();
+        let pre_holder2_count = client.get_tokens_by_owner(&holder2).len();
+        let pre_threshold = client.get_recovery_threshold();
+
+        // Capture contract address and take pre-upgrade snapshot
+        let sbt_address = client.address.clone();
+        env.to_snapshot_file(snap_path);
+
+        // Restore snapshot and re-register contract code (simulates WASM upgrade)
+        let env2 = Env::from_snapshot_file(snap_path);
+        env2.mock_all_auths();
+        env2.register_contract(Some(&sbt_address), SbtRegistryContract);
+        let client2 = SbtRegistryContractClient::new(&env2, &sbt_address);
+
+        // Ledger metadata must be identical
+        assert_eq!(env.ledger().sequence(), env2.ledger().sequence());
+        assert_eq!(env.ledger().timestamp(), env2.ledger().timestamp());
+
+        // All contract state must be intact — no data loss after upgrade
+        assert_eq!(client2.sbt_count(), pre_sbt_count, "token count changed after upgrade");
+        assert_eq!(client2.owner_of(&token_id1), pre_owner1, "token 1 owner changed");
+        assert_eq!(client2.owner_of(&token_id2), pre_owner2, "token 2 owner changed");
+        assert_eq!(client2.owner_of(&token_id3), pre_owner3, "token 3 owner changed");
+        assert_eq!(
+            client2.get_tokens_by_owner(&holder1).len(),
+            pre_holder1_count,
+            "holder1 token count changed after upgrade"
+        );
+        assert_eq!(
+            client2.get_tokens_by_owner(&holder2).len(),
+            pre_holder2_count,
+            "holder2 token count changed after upgrade"
+        );
+        assert_eq!(
+            client2.get_recovery_threshold(),
+            pre_threshold,
+            "recovery threshold changed after upgrade"
+        );
+    }
+
+    /// Detects data loss: burning a token before snapshot must not silently restore it.
+    #[test]
+    fn test_snapshot_upgrade_detects_data_loss() {
+        let snap_path = "test_snapshots/tests/snapshot_upgrade_dataloss.json";
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, qp_client, _qp_id) = setup_with_qp(&env);
+
+        let issuer = Address::generate(&env);
+        let holder = Address::generate(&env);
+        let meta = soroban_sdk::Bytes::from_slice(&env, b"ipfs://meta");
+        let cred_id = qp_client.issue_credential(&issuer, &holder, &1u32, &meta, &None, &0u64);
+        let uri = Bytes::from_slice(&env, b"ipfs://QmSBT");
+        let token_id = client.mint(&holder, &cred_id, &uri);
+        client.burn_sbt(&holder, &token_id);
+
+        // Record state after burn (token no longer owned)
+        let pre_tokens = client.get_tokens_by_owner(&holder).len();
+
+        let sbt_address = client.address.clone();
+        env.to_snapshot_file(snap_path);
+
+        let env2 = Env::from_snapshot_file(snap_path);
+        env2.mock_all_auths();
+        env2.register_contract(Some(&sbt_address), SbtRegistryContract);
+        let client2 = SbtRegistryContractClient::new(&env2, &sbt_address);
+
+        // Burn must not be reversed by the upgrade — no phantom token reappearance
+        assert_eq!(
+            client2.get_tokens_by_owner(&holder).len(),
+            pre_tokens,
+            "burned token reappeared after upgrade (data loss)"
+        );
+    }
+
     // ── Property-based fuzz tests ─────────────────────────────────────────────
 
     /// Property: minting N SBTs for distinct credentials always increments


### PR DESCRIPTION
## Summary

- **#557 (High):** Added 3 integration tests covering the full disaster recovery lifecycle — key loss simulation, guardian threshold enforcement, and unauthorized approver rejection.
- **#556 (Medium):** Added 2 snapshot-based upgrade tests — one verifying all contract state is preserved after a simulated WASM upgrade, and one detecting phantom token reappearance from burned tokens.

## Changes

### `contracts/integration_tests/src/lib.rs`
- `test_disaster_recovery_key_loss_scenario` — End-to-end test: issues credentials, mints SBTs, configures 2-of-2 recovery guardians, initiates recovery from the original (lost) key address to a new owner, verifies both guardians approve independently, finalizes recovery, and asserts all SBTs transferred to new owner while credentials remain valid.
- `test_disaster_recovery_insufficient_approvals_blocked` — Verifies `finalize_recovery` panics when the approval threshold (2-of-2) is not met (only 1 guardian approved).
- `test_disaster_recovery_unauthorized_approver_rejected` — Verifies a non-guardian address cannot approve a recovery request.

### `contracts/sbt_registry/src/lib.rs`
- `test_snapshot_upgrade_preserves_state` — Builds non-trivial pre-upgrade state (3 tokens across 2 holders, recovery guardians configured), takes a snapshot, reloads it in a fresh env, re-registers the contract code at the same address (simulating a WASM upgrade), then asserts all state values — token count, ownership, per-holder token lists, and recovery threshold — are identical to pre-upgrade values.
- `test_snapshot_upgrade_detects_data_loss` — Burns a token before snapshotting, restores the snapshot with a re-registered contract, and asserts the burned token does not reappear in the owner's token list (guards against phantom-token data loss across upgrades).

## Closes

Closes #557
Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)