### PR TITLE
perf: resolve #516 and #517 - credential cache and O(1) attestor lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,27 @@
 # Build artifacts
 target/
 *.wasm
+*.d
 
 # Node
 node_modules/
 frontend/node_modules/
 dashboard/node_modules/
+api-server/node_modules/
+
+# Lock files (generated)
+frontend/package-lock.json
+frontend/pnpm-lock.yaml
+api-server/package-lock.json
 
 # Coverage
 coverage/
 frontend/coverage/
 dashboard/coverage/
+api-server/coverage/
 *.lcov
 .nyc_output/
+lcov.info
 
 # Test snapshots
 **/test_snapshots/
@@ -23,18 +32,21 @@ dashboard/coverage/
 *.bak.*
 lib.rs.bak
 
-# Build artifacts
-*.wasm
-*.d
+# Fuzz artifacts
+fuzz/corpus/
+fuzz/artifacts/
 
 # IDE / OS
 .DS_Store
 *.swp
 *.swo
 .vscode/settings.json
+.idea/
 
 # Misc
 .env
 dist/
 dashboard/dist/
 frontend/dist/
+api-server/dist/
+

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -438,6 +438,8 @@ pub enum DataKey2 {
     RateLimitState(Address),
     CredentialAuditTrail(u64),
     CredentialMetadataStore(u64),
+    /// Issue #517: Set of attestor addresses for a slice, enabling O(1) membership lookup.
+    AttestorSet(u64),
 }
 
 #[contracttype]
@@ -1428,7 +1430,14 @@ impl QuorumProofContract {
             .instance()
             .get(&DataKey::Slice(slice_id))
             .unwrap_or_else(|| panic_with_error!(env, ContractError::SliceNotFound));
-        if !slice.attestors.contains(caller) {
+        // Issue #517: O(1) membership check via attestor set.
+        let in_slice = env
+            .storage()
+            .instance()
+            .get::<_, Map<Address, bool>>(&DataKey2::AttestorSet(slice_id))
+            .map(|set| set.contains_key(caller.clone()))
+            .unwrap_or_else(|| slice.attestors.contains(caller));
+        if !in_slice {
             panic_with_error!(env, ContractError::PermissionDenied);
         }
     }
@@ -3452,6 +3461,14 @@ impl QuorumProofContract {
         env.storage()
             .instance()
             .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+        // Issue #517: Build attestor set for O(1) membership lookup.
+        let mut attestor_set: Map<Address, bool> = Map::new(&env);
+        for a in slice.attestors.iter() {
+            attestor_set.set(a, true);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey2::AttestorSet(id), &attestor_set);
         // Post-condition: slice must be stored
         Self::postcondition(
             env.storage().instance().has(&DataKey::Slice(id)),
@@ -3549,6 +3566,16 @@ impl QuorumProofContract {
         env.storage()
             .instance()
             .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+        // Issue #517: Keep attestor set in sync.
+        let mut attestor_set: Map<Address, bool> = env
+            .storage()
+            .instance()
+            .get(&DataKey2::AttestorSet(slice_id))
+            .unwrap_or(Map::new(&env));
+        attestor_set.remove(attestor);
+        env.storage()
+            .instance()
+            .set(&DataKey2::AttestorSet(slice_id), &attestor_set);
     }
 
     /// Add a new attestor with a given weight to an existing quorum slice.
@@ -3580,7 +3607,7 @@ impl QuorumProofContract {
                 panic_with_error!(&env, ContractError::DuplicateAttestor);
             }
         }
-        slice.attestors.push_back(attestor);
+        slice.attestors.push_back(attestor.clone());
         slice.weights.push_back(weight);
         env.storage()
             .instance()
@@ -3588,6 +3615,16 @@ impl QuorumProofContract {
         env.storage()
             .instance()
             .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+        // Issue #517: Keep attestor set in sync.
+        let mut attestor_set: Map<Address, bool> = env
+            .storage()
+            .instance()
+            .get(&DataKey2::AttestorSet(slice_id))
+            .unwrap_or(Map::new(&env));
+        attestor_set.set(attestor, true);
+        env.storage()
+            .instance()
+            .set(&DataKey2::AttestorSet(slice_id), &attestor_set);
     }
 
     /// Update the threshold of an existing quorum slice.
@@ -4015,14 +4052,14 @@ impl QuorumProofContract {
             .instance()
             .get(&DataKey::Slice(slice_id))
             .unwrap_or_else(|| panic_with_error!(&env, ContractError::SliceNotFound));
-        let mut found = false;
-        for a in slice.attestors.iter() {
-            if a == attestor {
-                found = true;
-                break;
-            }
-        }
-        assert!(found, "attestor not in slice");
+        // Issue #517: O(1) attestor membership check via attestor set.
+        let in_slice = env
+            .storage()
+            .instance()
+            .get::<_, Map<Address, bool>>(&DataKey2::AttestorSet(slice_id))
+            .map(|set| set.contains_key(attestor.clone()))
+            .unwrap_or_else(|| slice.attestors.contains(&attestor));
+        assert!(in_slice, "attestor not in slice");
 
         // Check if attestor is suspended
         if Self::is_attestor_suspended(env.clone(), slice_id, attestor.clone()) {

--- a/contracts/sbt_registry/src/lib.rs
+++ b/contracts/sbt_registry/src/lib.rs
@@ -50,7 +50,24 @@ pub enum DataKey {
     CredentialAccessLog(u64),
     Blacklist(Address),
     SbtActivityLog(u64),
+    /// Issue #516: Cache entry for cross-contract credential revocation check.
+    CredentialCache(u64),
 }
+
+/// Issue #516: Cached result of a cross-contract is_revoked check.
+/// Stored in persistent storage keyed by credential_id.
+/// The cache is valid while `cached_at + CREDENTIAL_CACHE_TTL_LEDGERS > current_ledger`.
+#[contracttype]
+#[derive(Clone)]
+pub struct CredentialCacheEntry {
+    /// Whether the credential was revoked at the time of caching.
+    pub revoked: bool,
+    /// Ledger sequence number when this entry was written.
+    pub cached_at: u32,
+}
+
+/// Issue #516: Cache TTL in ledgers (~1 hour at 5s/ledger = 720 ledgers).
+const CREDENTIAL_CACHE_TTL_LEDGERS: u32 = 720;
 
 /// Weights used to compute a holder's reputation score.
 /// score = tokens_held * token_weight + notifications * activity_weight
@@ -214,12 +231,53 @@ impl SbtRegistryContract {
             .instance()
             .get(&DataKey::QuorumProofId)
             .expect("not initialized");
-        // is_revoked panics with CredentialNotFound if the credential doesn't exist.
-        let revoked: bool = env.invoke_contract(
-            &qp_id,
-            &Symbol::new(&env, "is_revoked"),
-            soroban_sdk::vec![&env, credential_id.into_val(&env)],
-        );
+        // Issue #516: Check credential cache before making a cross-contract call.
+        let current_ledger = env.ledger().sequence();
+        let revoked: bool = if let Some(entry) = env
+            .storage()
+            .persistent()
+            .get::<_, CredentialCacheEntry>(&DataKey::CredentialCache(credential_id))
+        {
+            if current_ledger.saturating_sub(entry.cached_at) < CREDENTIAL_CACHE_TTL_LEDGERS {
+                // Cache hit: use cached value, skip cross-contract call.
+                entry.revoked
+            } else {
+                // Cache expired: refresh via cross-contract call.
+                let r: bool = env.invoke_contract(
+                    &qp_id,
+                    &Symbol::new(&env, "is_revoked"),
+                    soroban_sdk::vec![&env, credential_id.into_val(&env)],
+                );
+                env.storage().persistent().set(
+                    &DataKey::CredentialCache(credential_id),
+                    &CredentialCacheEntry { revoked: r, cached_at: current_ledger },
+                );
+                env.storage().persistent().extend_ttl(
+                    &DataKey::CredentialCache(credential_id),
+                    STANDARD_TTL,
+                    EXTENDED_TTL,
+                );
+                r
+            }
+        } else {
+            // Cache miss: call cross-contract and populate cache.
+            // is_revoked panics with CredentialNotFound if the credential doesn't exist.
+            let r: bool = env.invoke_contract(
+                &qp_id,
+                &Symbol::new(&env, "is_revoked"),
+                soroban_sdk::vec![&env, credential_id.into_val(&env)],
+            );
+            env.storage().persistent().set(
+                &DataKey::CredentialCache(credential_id),
+                &CredentialCacheEntry { revoked: r, cached_at: current_ledger },
+            );
+            env.storage().persistent().extend_ttl(
+                &DataKey::CredentialCache(credential_id),
+                STANDARD_TTL,
+                EXTENDED_TTL,
+            );
+            r
+        };
         assert!(!revoked, "credential is revoked");
 
         // Check whitelist if enabled for this SBT


### PR DESCRIPTION
Issue #516: Add credential cache in sbt_registry mint
- Add CredentialCache(u64) DataKey and CredentialCacheEntry struct
- Cache TTL = 720 ledgers (~1 hour, matching credential TTL)
- mint() checks persistent cache before cross-contract is_revoked call
- Reduces cross-contract call overhead on repeated mints for same credential
Issue #517: Add attestor set for O(1) slice membership lookup
- Add AttestorSet(u64) to DataKey2 storing Map<Address, bool>
- create_slice, add_attestor, remove_attestor maintain the set
- attest() and require_slice_member() use set.contains_key() instead of Vec iteration
- Falls back to Vec scan if set not present (backward compatibility)
Closes #516 
Closes #517 