### PR TITLE
feat(contracts): add credential revocation registry with time-lock

### DIFF
--- a/contracts/quorum_proof/API.md
+++ b/contracts/quorum_proof/API.md
@@ -510,8 +510,115 @@ Completes a pending transfer. The intended recipient accepts and becomes the new
 
 ## 7. Credential Revocation
 
-There are three revocation paths: issuer-initiated, holder-initiated (consent withdrawal),
-and a holder-request workflow where the issuer approves or denies.
+There are four revocation paths: issuer registry requests with a time-lock, legacy immediate
+issuer revocation, holder-initiated consent withdrawal, and a holder-request workflow where the
+issuer approves or denies.
+
+### Issuer Revocation Registry Workflow
+
+The registry path is recommended for issuer operational revocations. Requests are reversible
+during the configured time-lock window and become effective only after finalization.
+
+State transition:
+
+```text
+pending -> finalized -> active
+```
+
+The default time-lock is **48 hours**. Admins may configure a different default with
+`set_revocation_time_lock`. Callers may provide a per-request lock with
+`initiate_revocation_with_lock` or `batch_initiate_revocations`; passing `0` uses the default.
+
+Only the original credential issuer or an issuer-delegated revocation agent may initiate,
+cancel, or finalize registry revocations. Emergency fast-track revocation bypasses the time-lock
+and is admin-only.
+
+### `set_revocation_time_lock(env, admin, seconds)`
+
+Configures the default registry time-lock in seconds. Admin only.
+
+### `get_revocation_time_lock(env) -> u64`
+
+Returns the configured registry time-lock, or `172800` when unset.
+
+### `add_revocation_agent(env, issuer, agent)`
+
+Delegates revocation authority from an issuer to an operational agent.
+
+### `remove_revocation_agent(env, issuer, agent)`
+
+Removes delegated revocation authority for an agent.
+
+### `is_revocation_agent(env, issuer, agent) -> bool`
+
+Returns whether `agent` currently has issuer-delegated revocation authority.
+
+### `get_revocation_agents(env, issuer) -> Vec<Address>`
+
+Lists delegated revocation agents for an issuer.
+
+### `initiate_revocation(env, actor, credential_id, reason) -> u64`
+
+Creates a pending issuer-side revocation request using the default time-lock.
+
+| Parameter       | Type      | Description                                         |
+|-----------------|-----------|-----------------------------------------------------|
+| `actor`         | `Address` | Credential issuer or delegated revocation agent.    |
+| `credential_id` | `u64`     | Credential to revoke after the time-lock expires.   |
+| `reason`        | `String`  | Immutable reason stored in the request audit trail. |
+
+### `initiate_revocation_with_lock(env, actor, credential_id, reason, time_lock_seconds) -> u64`
+
+Creates a pending issuer-side revocation request with a custom time-lock. A value of `0`
+uses the configured default.
+
+### `batch_initiate_revocations(env, actor, requests, time_lock_seconds) -> Vec<u64>`
+
+Creates up to **128** pending revocation requests in one authorized call.
+
+`RevocationInput` fields:
+
+| Field           | Type     | Description                         |
+|-----------------|----------|-------------------------------------|
+| `credential_id` | `u64`    | Credential to revoke.               |
+| `reason`        | `String` | Reason attached to the audit trail. |
+
+### `cancel_revocation_request(env, actor, request_id, reason)`
+
+Cancels a pending revocation request before its `unlocks_at` timestamp. This is the reversible
+time-lock action. Once the lock has expired or the request is active, cancellation is rejected.
+
+### `finalize_revocation_request(env, actor, request_id) -> RevocationRequest`
+
+Finalizes an expired pending request and activates the credential revocation. The audit trail
+records both `Finalized` and `Activated` actions.
+
+### `batch_finalize_revocations(env, actor, request_ids) -> u32`
+
+Finalizes up to **128** expired revocation requests in one call. Returns the number finalized.
+
+### `emergency_revoke_credential(env, admin, credential_id, reason) -> u64`
+
+Admin-only fast-track revocation for active security incidents. Creates an active registry
+request immediately and records an `EmergencyActivated` audit action.
+
+### `get_revocation_registry_request(env, request_id) -> Option<RevocationRequest>`
+
+Returns a registry request by ID.
+
+**Returns:** `Option<RevocationRequest { id, credential_id, issuer, requested_by, timestamp, unlocks_at, reason, status, finalized_at, activated_at }>`
+
+### `get_credential_revocation_registry_request(env, credential_id) -> Option<RevocationRequest>`
+
+Returns the latest registry request associated with a credential, if any.
+
+### `get_revocation_registry_audit(env, request_id) -> Vec<RegistryRevocationAuditEntry>`
+
+Returns the immutable audit trail for a registry request.
+
+### `get_revocation_metrics(env) -> RevocationMetrics`
+
+Returns aggregate registry counters: request, finalized, active, cancelled, and emergency counts.
 
 ### `revoke_credential(env, issuer, credential_id)`
 

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -44,6 +44,8 @@ const DEFAULT_RATE_LIMIT_MAX_CALLS: u32 = 1000;
 const DEFAULT_RATE_LIMIT_WINDOW_SECONDS: u64 = 86400; // 1 day
 /// Issue #519: Cache TTL for metadata hash validation (~1 hour wall-clock seconds)
 const METADATA_CACHE_TTL_SECS: u64 = 3_600;
+const DEFAULT_REVOCATION_TIME_LOCK_SECONDS: u64 = 172_800; // 48 hours
+const MAX_REVOCATION_BATCH_SIZE: u32 = 128;
 
 #[contracttype]
 #[derive(Clone)]
@@ -446,6 +448,12 @@ pub enum ContractError {
     QuotaExceeded = 54,
     /// Issue #597: No quota configured for this issuer
     QuotaNotFound = 55,
+    /// Revocation request is still inside its time-lock window
+    RevocationTimeLockActive = 56,
+    /// Revocation request cannot be changed from its current state
+    InvalidRevocationState = 57,
+    /// Revocation batch exceeds the registry limit
+    RevocationBatchTooLarge = 58,
 }
 
 #[contracttype]
@@ -523,6 +531,14 @@ pub enum DataKey2 {
     IssuerQuota(Address),
     /// Issue #597: Per-issuer usage counter within the current quota window
     IssuerQuotaUsage(Address),
+    RevocationRegistryRequest(u64),
+    RevocationRegistryRequestCount,
+    CredentialRevocationRegistryRequest(u64),
+    RevocationRegistryAuditTrail(u64),
+    RevocationAgent(Address, Address),
+    IssuerRevocationAgents(Address),
+    RevocationTimeLockSeconds,
+    RevocationMetrics,
 }
 
 #[contracttype]
@@ -592,6 +608,78 @@ pub struct RevocationAuditEntry {
     pub timestamp: u64,
     pub ledger_sequence: u32,
     pub status: RevocationStatus,
+}
+
+/// State for issuer/agent initiated credential revocation requests.
+#[contracttype]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(u32)]
+pub enum RegistryRevocationStatus {
+    Pending = 1,
+    Finalized = 2,
+    Active = 3,
+    Cancelled = 4,
+}
+
+/// Action recorded in the immutable issuer revocation registry audit trail.
+#[contracttype]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(u32)]
+pub enum RegistryRevocationAuditAction {
+    Requested = 1,
+    Cancelled = 2,
+    Finalized = 3,
+    Activated = 4,
+    EmergencyActivated = 5,
+}
+
+/// Issuer-side revocation request with a ledger timestamp based time-lock.
+#[contracttype]
+#[derive(Clone)]
+pub struct RevocationRequest {
+    pub id: u64,
+    pub credential_id: CredentialId,
+    pub issuer: Address,
+    pub requested_by: Address,
+    pub timestamp: u64,
+    pub unlocks_at: u64,
+    pub reason: String,
+    pub status: RegistryRevocationStatus,
+    pub finalized_at: Option<u64>,
+    pub activated_at: Option<u64>,
+}
+
+/// Batch input for issuer/agent revocation requests.
+#[contracttype]
+#[derive(Clone)]
+pub struct RevocationInput {
+    pub credential_id: CredentialId,
+    pub reason: String,
+}
+
+/// Immutable issuer revocation registry audit entry.
+#[contracttype]
+#[derive(Clone)]
+pub struct RegistryRevocationAuditEntry {
+    pub request_id: u64,
+    pub credential_id: CredentialId,
+    pub actor: Address,
+    pub action: RegistryRevocationAuditAction,
+    pub status: RegistryRevocationStatus,
+    pub timestamp: u64,
+    pub ledger_sequence: u32,
+    pub reason: String,
+}
+
+/// Aggregate operational metrics for issuer-side revocation requests.
+#[contracttype]
+#[derive(Clone)]
+pub struct RevocationMetrics {
+    pub request_count: u64,
+    pub finalized_count: u64,
+    pub active_count: u64,
+    pub cancelled_count: u64,
+    pub emergency_count: u64,
 }
 
 /// Encrypted credential metadata stored on-chain (ciphertext only).
@@ -1890,6 +1978,221 @@ impl QuorumProofContract {
         env.storage()
             .instance()
             .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+    }
+
+    fn default_revocation_time_lock(env: &Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey2::RevocationTimeLockSeconds)
+            .unwrap_or(DEFAULT_REVOCATION_TIME_LOCK_SECONDS)
+    }
+
+    fn require_revocation_actor(env: &Env, actor: &Address, credential: &Credential) {
+        if actor == &credential.issuer {
+            return;
+        }
+        let delegated = env
+            .storage()
+            .instance()
+            .get::<DataKey2, bool>(&DataKey2::RevocationAgent(
+                credential.issuer.clone(),
+                actor.clone(),
+            ))
+            .unwrap_or(false);
+        if !delegated {
+            panic_with_error!(env, ContractError::UnauthorizedAction);
+        }
+    }
+
+    fn append_registry_revocation_audit(
+        env: &Env,
+        request: &RevocationRequest,
+        actor: Address,
+        action: RegistryRevocationAuditAction,
+        reason: String,
+    ) {
+        let entry = RegistryRevocationAuditEntry {
+            request_id: request.id,
+            credential_id: request.credential_id,
+            actor,
+            action,
+            status: request.status,
+            timestamp: env.ledger().timestamp(),
+            ledger_sequence: env.ledger().sequence(),
+            reason,
+        };
+        let mut trail: Vec<RegistryRevocationAuditEntry> = env
+            .storage()
+            .instance()
+            .get(&DataKey2::RevocationRegistryAuditTrail(request.id))
+            .unwrap_or(Vec::new(env));
+        trail.push_back(entry);
+        env.storage()
+            .instance()
+            .set(&DataKey2::RevocationRegistryAuditTrail(request.id), &trail);
+        env.storage()
+            .instance()
+            .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+    }
+
+    fn get_revocation_metrics_internal(env: &Env) -> RevocationMetrics {
+        env.storage()
+            .instance()
+            .get(&DataKey2::RevocationMetrics)
+            .unwrap_or(RevocationMetrics {
+                request_count: 0,
+                finalized_count: 0,
+                active_count: 0,
+                cancelled_count: 0,
+                emergency_count: 0,
+            })
+    }
+
+    fn set_revocation_metrics_internal(env: &Env, metrics: &RevocationMetrics) {
+        env.storage()
+            .instance()
+            .set(&DataKey2::RevocationMetrics, metrics);
+        env.storage()
+            .instance()
+            .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+    }
+
+    fn next_revocation_registry_request_id(env: &Env) -> u64 {
+        let next = env
+            .storage()
+            .instance()
+            .get(&DataKey2::RevocationRegistryRequestCount)
+            .unwrap_or(0u64)
+            .saturating_add(1);
+        env.storage()
+            .instance()
+            .set(&DataKey2::RevocationRegistryRequestCount, &next);
+        next
+    }
+
+    fn create_revocation_registry_request(
+        env: &Env,
+        actor: Address,
+        credential_id: CredentialId,
+        reason: String,
+        time_lock_seconds: u64,
+    ) -> u64 {
+        let credential: Credential = env
+            .storage()
+            .instance()
+            .get(&DataKey::Credential(credential_id))
+            .unwrap_or_else(|| panic_with_error!(env, ContractError::CredentialNotFound));
+        assert!(!credential.revoked, "credential already revoked");
+        Self::require_revocation_actor(env, &actor, &credential);
+        if let Some(existing_id) = env
+            .storage()
+            .instance()
+            .get::<DataKey2, u64>(&DataKey2::CredentialRevocationRegistryRequest(credential_id))
+        {
+            let existing: RevocationRequest = env
+                .storage()
+                .instance()
+                .get(&DataKey2::RevocationRegistryRequest(existing_id))
+                .unwrap_or_else(|| panic_with_error!(env, ContractError::RevocationRequestNotFound));
+            if existing.status == RegistryRevocationStatus::Pending {
+                panic_with_error!(env, ContractError::RevocationNotPending);
+            }
+        }
+
+        let now = env.ledger().timestamp();
+        let lock_seconds = if time_lock_seconds == 0 {
+            Self::default_revocation_time_lock(env)
+        } else {
+            time_lock_seconds
+        };
+        let request = RevocationRequest {
+            id: Self::next_revocation_registry_request_id(env),
+            credential_id,
+            issuer: credential.issuer.clone(),
+            requested_by: actor.clone(),
+            timestamp: now,
+            unlocks_at: now.saturating_add(lock_seconds),
+            reason: reason.clone(),
+            status: RegistryRevocationStatus::Pending,
+            finalized_at: None,
+            activated_at: None,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey2::RevocationRegistryRequest(request.id), &request);
+        env.storage().instance().set(
+            &DataKey2::CredentialRevocationRegistryRequest(credential_id),
+            &request.id,
+        );
+        let mut metrics = Self::get_revocation_metrics_internal(env);
+        metrics.request_count = metrics.request_count.saturating_add(1);
+        Self::set_revocation_metrics_internal(env, &metrics);
+        Self::append_registry_revocation_audit(
+            env,
+            &request,
+            actor,
+            RegistryRevocationAuditAction::Requested,
+            reason,
+        );
+        request.id
+    }
+
+    fn activate_revocation_request(
+        env: &Env,
+        actor: Address,
+        request_id: u64,
+    ) -> RevocationRequest {
+        let mut request: RevocationRequest = env
+            .storage()
+            .instance()
+            .get(&DataKey2::RevocationRegistryRequest(request_id))
+            .unwrap_or_else(|| panic_with_error!(env, ContractError::RevocationRequestNotFound));
+        if request.status != RegistryRevocationStatus::Pending {
+            panic_with_error!(env, ContractError::InvalidRevocationState);
+        }
+        if env.ledger().timestamp() < request.unlocks_at {
+            panic_with_error!(env, ContractError::RevocationTimeLockActive);
+        }
+        let mut credential: Credential = env
+            .storage()
+            .instance()
+            .get(&DataKey::Credential(request.credential_id))
+            .unwrap_or_else(|| panic_with_error!(env, ContractError::CredentialNotFound));
+        Self::require_revocation_actor(env, &actor, &credential);
+        let now = env.ledger().timestamp();
+        request.status = RegistryRevocationStatus::Finalized;
+        request.finalized_at = Some(now);
+        env.storage()
+            .instance()
+            .set(&DataKey2::RevocationRegistryRequest(request.id), &request);
+        Self::append_registry_revocation_audit(
+            env,
+            &request,
+            actor.clone(),
+            RegistryRevocationAuditAction::Finalized,
+            request.reason.clone(),
+        );
+
+        if !credential.revoked {
+            Self::mark_credential_revoked(env, request.credential_id, &mut credential, actor.clone());
+        }
+        request.status = RegistryRevocationStatus::Active;
+        request.activated_at = Some(now);
+        env.storage()
+            .instance()
+            .set(&DataKey2::RevocationRegistryRequest(request.id), &request);
+        Self::append_registry_revocation_audit(
+            env,
+            &request,
+            actor,
+            RegistryRevocationAuditAction::Activated,
+            request.reason.clone(),
+        );
+        let mut metrics = Self::get_revocation_metrics_internal(env);
+        metrics.finalized_count = metrics.finalized_count.saturating_add(1);
+        metrics.active_count = metrics.active_count.saturating_add(1);
+        Self::set_revocation_metrics_internal(env, &metrics);
+        request
     }
 
     fn mark_credential_revoked(
@@ -3478,6 +3781,330 @@ impl QuorumProofContract {
             .instance()
             .get(&DataKey2::RevocationAuditTrail(credential_id))
             .unwrap_or(Vec::new(&env))
+    }
+
+    /// Configure the default issuer revocation time-lock. Admin only.
+    pub fn set_revocation_time_lock(env: Env, admin: Address, seconds: u64) {
+        admin.require_auth();
+        let stored: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        assert!(stored == admin, "unauthorized");
+        env.storage()
+            .instance()
+            .set(&DataKey2::RevocationTimeLockSeconds, &seconds);
+        env.storage()
+            .instance()
+            .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+    }
+
+    /// Return the configured issuer revocation time-lock, defaulting to 48 hours.
+    pub fn get_revocation_time_lock(env: Env) -> u64 {
+        Self::default_revocation_time_lock(&env)
+    }
+
+    /// Delegate issuer revocation authority to an operational agent.
+    pub fn add_revocation_agent(env: Env, issuer: Address, agent: Address) {
+        issuer.require_auth();
+        Self::require_not_paused(&env);
+        env.storage().instance().set(
+            &DataKey2::RevocationAgent(issuer.clone(), agent.clone()),
+            &true,
+        );
+        let mut agents: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey2::IssuerRevocationAgents(issuer.clone()))
+            .unwrap_or(Vec::new(&env));
+        let mut exists = false;
+        for existing in agents.iter() {
+            if existing == agent {
+                exists = true;
+                break;
+            }
+        }
+        if !exists {
+            agents.push_back(agent);
+            env.storage()
+                .instance()
+                .set(&DataKey2::IssuerRevocationAgents(issuer), &agents);
+        }
+        env.storage()
+            .instance()
+            .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+    }
+
+    /// Revoke an operational agent's issuer revocation authority.
+    pub fn remove_revocation_agent(env: Env, issuer: Address, agent: Address) {
+        issuer.require_auth();
+        Self::require_not_paused(&env);
+        env.storage()
+            .instance()
+            .remove(&DataKey2::RevocationAgent(issuer.clone(), agent.clone()));
+        let agents: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey2::IssuerRevocationAgents(issuer.clone()))
+            .unwrap_or(Vec::new(&env));
+        let mut retained: Vec<Address> = Vec::new(&env);
+        for existing in agents.iter() {
+            if existing != agent {
+                retained.push_back(existing);
+            }
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey2::IssuerRevocationAgents(issuer), &retained);
+        env.storage()
+            .instance()
+            .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+    }
+
+    /// Check whether an address is delegated to initiate issuer revocations.
+    pub fn is_revocation_agent(env: Env, issuer: Address, agent: Address) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey2::RevocationAgent(issuer, agent))
+            .unwrap_or(false)
+    }
+
+    /// List currently delegated revocation agents for an issuer.
+    pub fn get_revocation_agents(env: Env, issuer: Address) -> Vec<Address> {
+        env.storage()
+            .instance()
+            .get(&DataKey2::IssuerRevocationAgents(issuer))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Initiate an issuer-side revocation request with the default 48-hour time-lock.
+    pub fn initiate_revocation(
+        env: Env,
+        actor: Address,
+        credential_id: CredentialId,
+        reason: String,
+    ) -> u64 {
+        actor.require_auth();
+        Self::require_not_paused(&env);
+        Self::require_rate_limit(&env, &actor);
+        Self::create_revocation_registry_request(&env, actor, credential_id, reason, 0)
+    }
+
+    /// Initiate an issuer-side revocation request with a custom time-lock.
+    pub fn initiate_revocation_with_lock(
+        env: Env,
+        actor: Address,
+        credential_id: CredentialId,
+        reason: String,
+        time_lock_seconds: u64,
+    ) -> u64 {
+        actor.require_auth();
+        Self::require_not_paused(&env);
+        Self::require_rate_limit(&env, &actor);
+        Self::create_revocation_registry_request(
+            &env,
+            actor,
+            credential_id,
+            reason,
+            time_lock_seconds,
+        )
+    }
+
+    /// Initiate many issuer-side revocation requests in one authorized call.
+    pub fn batch_initiate_revocations(
+        env: Env,
+        actor: Address,
+        requests: Vec<RevocationInput>,
+        time_lock_seconds: u64,
+    ) -> Vec<u64> {
+        actor.require_auth();
+        Self::require_not_paused(&env);
+        Self::require_rate_limit(&env, &actor);
+        if requests.len() > MAX_REVOCATION_BATCH_SIZE {
+            panic_with_error!(&env, ContractError::RevocationBatchTooLarge);
+        }
+        let mut ids: Vec<u64> = Vec::new(&env);
+        for input in requests.iter() {
+            let id = Self::create_revocation_registry_request(
+                &env,
+                actor.clone(),
+                input.credential_id,
+                input.reason,
+                time_lock_seconds,
+            );
+            ids.push_back(id);
+        }
+        ids
+    }
+
+    /// Cancel a pending issuer-side revocation while it is still reversible.
+    pub fn cancel_revocation_request(env: Env, actor: Address, request_id: u64, reason: String) {
+        actor.require_auth();
+        Self::require_not_paused(&env);
+        let mut request: RevocationRequest = env
+            .storage()
+            .instance()
+            .get(&DataKey2::RevocationRegistryRequest(request_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::RevocationRequestNotFound));
+        if request.status != RegistryRevocationStatus::Pending {
+            panic_with_error!(&env, ContractError::InvalidRevocationState);
+        }
+        if env.ledger().timestamp() >= request.unlocks_at {
+            panic_with_error!(&env, ContractError::RevocationTimeLockActive);
+        }
+        let credential: Credential = env
+            .storage()
+            .instance()
+            .get(&DataKey::Credential(request.credential_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::CredentialNotFound));
+        Self::require_revocation_actor(&env, &actor, &credential);
+        request.status = RegistryRevocationStatus::Cancelled;
+        env.storage()
+            .instance()
+            .set(&DataKey2::RevocationRegistryRequest(request.id), &request);
+        Self::append_registry_revocation_audit(
+            &env,
+            &request,
+            actor,
+            RegistryRevocationAuditAction::Cancelled,
+            reason,
+        );
+        let mut metrics = Self::get_revocation_metrics_internal(&env);
+        metrics.cancelled_count = metrics.cancelled_count.saturating_add(1);
+        Self::set_revocation_metrics_internal(&env, &metrics);
+    }
+
+    /// Finalize a pending issuer-side revocation after its time-lock expires.
+    pub fn finalize_revocation_request(
+        env: Env,
+        actor: Address,
+        request_id: u64,
+    ) -> RevocationRequest {
+        actor.require_auth();
+        Self::require_not_paused(&env);
+        Self::activate_revocation_request(&env, actor, request_id)
+    }
+
+    /// Finalize many expired revocation requests in one call.
+    pub fn batch_finalize_revocations(
+        env: Env,
+        actor: Address,
+        request_ids: Vec<u64>,
+    ) -> u32 {
+        actor.require_auth();
+        Self::require_not_paused(&env);
+        if request_ids.len() > MAX_REVOCATION_BATCH_SIZE {
+            panic_with_error!(&env, ContractError::RevocationBatchTooLarge);
+        }
+        let mut finalized = 0u32;
+        for request_id in request_ids.iter() {
+            Self::activate_revocation_request(&env, actor.clone(), request_id);
+            finalized = finalized.saturating_add(1);
+        }
+        finalized
+    }
+
+    /// Admin-only immediate revocation for active security incidents.
+    pub fn emergency_revoke_credential(
+        env: Env,
+        admin: Address,
+        credential_id: CredentialId,
+        reason: String,
+    ) -> u64 {
+        admin.require_auth();
+        Self::require_not_paused(&env);
+        let stored: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        assert!(stored == admin, "unauthorized");
+        let mut credential: Credential = env
+            .storage()
+            .instance()
+            .get(&DataKey::Credential(credential_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::CredentialNotFound));
+        assert!(!credential.revoked, "credential already revoked");
+        let now = env.ledger().timestamp();
+        let request = RevocationRequest {
+            id: Self::next_revocation_registry_request_id(&env),
+            credential_id,
+            issuer: credential.issuer.clone(),
+            requested_by: admin.clone(),
+            timestamp: now,
+            unlocks_at: now,
+            reason: reason.clone(),
+            status: RegistryRevocationStatus::Active,
+            finalized_at: Some(now),
+            activated_at: Some(now),
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey2::RevocationRegistryRequest(request.id), &request);
+        env.storage().instance().set(
+            &DataKey2::CredentialRevocationRegistryRequest(credential_id),
+            &request.id,
+        );
+        Self::mark_credential_revoked(&env, credential_id, &mut credential, admin.clone());
+        Self::append_registry_revocation_audit(
+            &env,
+            &request,
+            admin,
+            RegistryRevocationAuditAction::EmergencyActivated,
+            reason,
+        );
+        let mut metrics = Self::get_revocation_metrics_internal(&env);
+        metrics.request_count = metrics.request_count.saturating_add(1);
+        metrics.finalized_count = metrics.finalized_count.saturating_add(1);
+        metrics.active_count = metrics.active_count.saturating_add(1);
+        metrics.emergency_count = metrics.emergency_count.saturating_add(1);
+        Self::set_revocation_metrics_internal(&env, &metrics);
+        request.id
+    }
+
+    /// Return an issuer-side revocation registry request by ID.
+    pub fn get_revocation_registry_request(
+        env: Env,
+        request_id: u64,
+    ) -> Option<RevocationRequest> {
+        env.storage()
+            .instance()
+            .get(&DataKey2::RevocationRegistryRequest(request_id))
+    }
+
+    /// Return the latest issuer-side revocation request for a credential, if any.
+    pub fn get_credential_revocation_registry_request(
+        env: Env,
+        credential_id: CredentialId,
+    ) -> Option<RevocationRequest> {
+        let request_id: Option<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey2::CredentialRevocationRegistryRequest(credential_id));
+        match request_id {
+            Some(id) => env
+                .storage()
+                .instance()
+                .get(&DataKey2::RevocationRegistryRequest(id)),
+            None => None,
+        }
+    }
+
+    /// Return the immutable audit trail for an issuer-side revocation request.
+    pub fn get_revocation_registry_audit(
+        env: Env,
+        request_id: u64,
+    ) -> Vec<RegistryRevocationAuditEntry> {
+        env.storage()
+            .instance()
+            .get(&DataKey2::RevocationRegistryAuditTrail(request_id))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Return aggregate revocation registry metrics.
+    pub fn get_revocation_metrics(env: Env) -> RevocationMetrics {
+        Self::get_revocation_metrics_internal(&env)
     }
 
     /// Store AES-256 encrypted credential metadata. Encryption/decryption is performed
@@ -8495,6 +9122,187 @@ mod tests {
             min_temp_entry_ttl: 16,
             max_entry_ttl: 6_312_000,
         });
+    }
+
+    fn issue_test_credential(
+        env: &Env,
+        client: &QuorumProofContractClient<'_>,
+        issuer: &Address,
+        subject: &Address,
+        credential_type: u32,
+    ) -> u64 {
+        let metadata = Bytes::from_slice(env, b"QmRevocationRegistryTestHash000000");
+        client.issue_credential(issuer, subject, &credential_type, &metadata, &None, &0u64)
+    }
+
+    #[test]
+    fn test_revocation_registry_time_lock_window_behavior() {
+        let env = Env::default();
+        let (client, _) = setup(&env);
+        set_ledger_timestamp(&env, 1_000);
+        let issuer = Address::generate(&env);
+        let holder = Address::generate(&env);
+        let cred_id = issue_test_credential(&env, &client, &issuer, &holder, 1);
+
+        let request_id = client.initiate_revocation_with_lock(
+            &issuer,
+            &cred_id,
+            &String::from_str(&env, "key compromise investigation"),
+            &100u64,
+        );
+        let request = client.get_revocation_registry_request(&request_id).unwrap();
+        assert_eq!(request.status, RegistryRevocationStatus::Pending);
+        assert_eq!(request.timestamp, 1_000);
+        assert_eq!(request.unlocks_at, 1_100);
+        assert!(!client.is_revoked(&cred_id));
+
+        set_ledger_timestamp(&env, 1_050);
+        let early = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.finalize_revocation_request(&issuer, &request_id);
+        }));
+        assert!(early.is_err(), "request should not finalize before unlock");
+        assert!(!client.is_revoked(&cred_id));
+
+        client.cancel_revocation_request(
+            &issuer,
+            &request_id,
+            &String::from_str(&env, "incident cleared"),
+        );
+        let cancelled = client.get_revocation_registry_request(&request_id).unwrap();
+        assert_eq!(cancelled.status, RegistryRevocationStatus::Cancelled);
+        assert!(!client.is_revoked(&cred_id));
+
+        let second_id = client.initiate_revocation_with_lock(
+            &issuer,
+            &cred_id,
+            &String::from_str(&env, "confirmed compromise"),
+            &100u64,
+        );
+        set_ledger_timestamp(&env, 1_200);
+        let active = client.finalize_revocation_request(&issuer, &second_id);
+        assert_eq!(active.status, RegistryRevocationStatus::Active);
+        assert!(client.is_revoked(&cred_id));
+        let audit = client.get_revocation_registry_audit(&second_id);
+        assert_eq!(audit.len(), 3);
+    }
+
+    #[test]
+    fn test_revocation_registry_permissions_for_issuer_and_agents() {
+        let env = Env::default();
+        let (client, _) = setup(&env);
+        let issuer = Address::generate(&env);
+        let holder = Address::generate(&env);
+        let agent = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        let cred_id = issue_test_credential(&env, &client, &issuer, &holder, 1);
+
+        let unauthorized = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.initiate_revocation(
+                &stranger,
+                &cred_id,
+                &String::from_str(&env, "not authorized"),
+            );
+        }));
+        assert!(unauthorized.is_err(), "stranger must not initiate revocation");
+
+        client.add_revocation_agent(&issuer, &agent);
+        assert!(client.is_revocation_agent(&issuer, &agent));
+        let request_id = client.initiate_revocation_with_lock(
+            &agent,
+            &cred_id,
+            &String::from_str(&env, "agent detected compromise"),
+            &1u64,
+        );
+        set_ledger_timestamp(&env, 2);
+        client.finalize_revocation_request(&agent, &request_id);
+        assert!(client.is_revoked(&cred_id));
+    }
+
+    #[test]
+    fn test_revocation_registry_batch_operations_over_100_requests() {
+        let env = Env::default();
+        let (client, _) = setup(&env);
+        let issuer = Address::generate(&env);
+        let mut inputs: Vec<RevocationInput> = Vec::new(&env);
+        let mut request_ids_for_finalize: Vec<u64> = Vec::new(&env);
+        let reason = String::from_str(&env, "issuer key rotation");
+
+        for i in 0..101u32 {
+            let holder = Address::generate(&env);
+            let cred_id = issue_test_credential(&env, &client, &issuer, &holder, i + 1);
+            inputs.push_back(RevocationInput {
+                credential_id: cred_id,
+                reason: reason.clone(),
+            });
+        }
+
+        let request_ids = client.batch_initiate_revocations(&issuer, &inputs, &10u64);
+        assert_eq!(request_ids.len(), 101);
+        for request_id in request_ids.iter() {
+            request_ids_for_finalize.push_back(request_id);
+        }
+
+        set_ledger_timestamp(&env, 11);
+        let finalized = client.batch_finalize_revocations(&issuer, &request_ids_for_finalize);
+        assert_eq!(finalized, 101u32);
+        let metrics = client.get_revocation_metrics();
+        assert_eq!(metrics.request_count, 101);
+        assert_eq!(metrics.active_count, 101);
+    }
+
+    #[test]
+    fn test_revocation_registry_emergency_fast_track_is_admin_only() {
+        let env = Env::default();
+        let (client, admin) = setup(&env);
+        let issuer = Address::generate(&env);
+        let holder = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        let cred_id = issue_test_credential(&env, &client, &issuer, &holder, 1);
+
+        let unauthorized = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.emergency_revoke_credential(
+                &stranger,
+                &cred_id,
+                &String::from_str(&env, "security incident"),
+            );
+        }));
+        assert!(unauthorized.is_err(), "only admin can emergency revoke");
+
+        let request_id = client.emergency_revoke_credential(
+            &admin,
+            &cred_id,
+            &String::from_str(&env, "security incident"),
+        );
+        let request = client.get_revocation_registry_request(&request_id).unwrap();
+        assert_eq!(request.status, RegistryRevocationStatus::Active);
+        assert!(client.is_revoked(&cred_id));
+        let metrics = client.get_revocation_metrics();
+        assert_eq!(metrics.emergency_count, 1);
+    }
+
+    #[test]
+    fn test_revocation_registry_updates_credential_verification_workflow() {
+        let env = Env::default();
+        let (client, _) = setup(&env);
+        let issuer = Address::generate(&env);
+        let holder = Address::generate(&env);
+        let attestor = Address::generate(&env);
+        let cred_id = issue_test_credential(&env, &client, &issuer, &holder, 1);
+        let attestors = vec![&env, attestor.clone()];
+        let weights = vec![&env, 1u32];
+        let slice_id = client.create_slice(&issuer, &attestors, &weights, &1u32);
+        client.attest(&attestor, &cred_id, &slice_id, &true, &None);
+        assert!(client.verify_credential(&cred_id, &slice_id));
+
+        let request_id = client.initiate_revocation_with_lock(
+            &issuer,
+            &cred_id,
+            &String::from_str(&env, "verification should fail after revoke"),
+            &1u64,
+        );
+        set_ledger_timestamp(&env, 2);
+        client.finalize_revocation_request(&issuer, &request_id);
+        assert!(!client.verify_credential(&cred_id, &slice_id));
     }
 
     #[test]


### PR DESCRIPTION
closes #652 
## Summary
- Add issuer-side credential revocation registry with configurable time-locks and reason tracking
- Support delegated revocation agents, reversible pending requests, batch initiate/finalize operations, and admin-only emergency fast-track revocation
- Add revocation metrics, immutable audit trail, focused tests, and API workflow documentation

## Testing
- git diff --check

Note: Rust tests and rustfmt were not run because this environment does not have cargo, rustc, or rustfmt installed.