### PR TITLE
feat(frontend): add privacy-preserving claim generation UI

### DIFF
--- a/frontend/src/components/ClaimProofGenerator.tsx
+++ b/frontend/src/components/ClaimProofGenerator.tsx
@@ -1,0 +1,185 @@
+import { useState } from 'react';
+import { generateProofRequest } from '../lib/contracts/zkVerifier';
+import type { ClaimType, ProofRequest } from '../lib/contracts/zkVerifier';
+import {
+  CLAIM_TYPE_OPTIONS,
+  findClaimTypeOption,
+  encodeProofRequest,
+  buildProofShareUrl,
+} from '../lib/claimDisclosure';
+
+interface Props {
+  credentialId: bigint;
+}
+
+type GenerateState =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'success'; request: ProofRequest }
+  | { kind: 'error'; message: string };
+
+export function ClaimProofGenerator({ credentialId }: Props) {
+  const [claimType, setClaimType] = useState<ClaimType>('HasDegree');
+  const [state, setState] = useState<GenerateState>({ kind: 'idle' });
+  const [proofCopied, setProofCopied] = useState(false);
+  const [linkCopied, setLinkCopied] = useState(false);
+
+  const option = findClaimTypeOption(claimType);
+
+  async function handleGenerate() {
+    setState({ kind: 'loading' });
+    setProofCopied(false);
+    setLinkCopied(false);
+    try {
+      const request = await generateProofRequest(credentialId, claimType);
+      setState({ kind: 'success', request });
+    } catch (err: unknown) {
+      setState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : 'Failed to generate proof request.',
+      });
+    }
+  }
+
+  function handleCopyProof() {
+    if (state.kind !== 'success') return;
+    navigator.clipboard.writeText(encodeProofRequest(state.request)).then(() => {
+      setProofCopied(true);
+      setTimeout(() => setProofCopied(false), 2000);
+    });
+  }
+
+  function handleCopyLink() {
+    if (state.kind !== 'success') return;
+    navigator.clipboard.writeText(buildProofShareUrl(state.request)).then(() => {
+      setLinkCopied(true);
+      setTimeout(() => setLinkCopied(false), 2000);
+    });
+  }
+
+  return (
+    <div className="zk-card" data-testid="claim-proof-generator">
+      <div className="zk-card__header">
+        <span className="zk-card__icon" aria-hidden="true">🛡️</span>
+        <div>
+          <div className="zk-card__title">Generate a Privacy-Preserving Proof</div>
+          <div className="zk-card__sub">
+            Prove a single claim about this credential without revealing the rest of its details.
+          </div>
+        </div>
+      </div>
+
+      <div className="zk-card__body">
+        <fieldset className="form-row" style={{ border: 'none', padding: 0, margin: 0 }}>
+          <legend className="form-label">Claim type</legend>
+          <select
+            data-testid="claim-type-select"
+            aria-label="Claim type"
+            value={claimType}
+            onChange={(e) => {
+              setClaimType(e.target.value as ClaimType);
+              setState({ kind: 'idle' });
+            }}
+          >
+            {CLAIM_TYPE_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.icon} {opt.label}
+              </option>
+            ))}
+          </select>
+        </fieldset>
+
+        <div
+          className="disclosure-preview"
+          data-testid="disclosure-preview"
+          aria-label={`Disclosure preview for ${option.label} claim`}
+        >
+          <div className="disclosure-preview__section">
+            <div className="disclosure-preview__heading disclosure-preview__heading--shown">
+              ✅ Will be disclosed
+            </div>
+            <p className="disclosure-preview__text">{option.discloses}</p>
+            <p className="disclosure-preview__text" style={{ color: 'var(--text-muted)' }}>
+              Credential #{credentialId.toString()} is referenced so a verifier can check this proof on-chain.
+            </p>
+          </div>
+          <div className="disclosure-preview__section">
+            <div className="disclosure-preview__heading disclosure-preview__heading--hidden">
+              🔒 Stays private
+            </div>
+            <ul className="disclosure-preview__list">
+              {option.hides.map((field) => (
+                <li key={field}>{field}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap', marginTop: 16 }}>
+          <button
+            className="btn btn--primary"
+            onClick={handleGenerate}
+            disabled={state.kind === 'loading'}
+            data-testid="generate-proof-btn"
+          >
+            {state.kind === 'loading' ? '⏳ Generating…' : '🛡️ Generate Proof'}
+          </button>
+          <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>No wallet required</span>
+        </div>
+
+        {state.kind === 'error' && (
+          <div className="zk-result zk-result--error" role="alert">
+            ⚠️ {state.message}
+          </div>
+        )}
+
+        {state.kind === 'success' && (
+          <div className="zk-result zk-result--success" role="status" data-testid="proof-result" style={{ flexDirection: 'column', alignItems: 'stretch', gap: 12 }}>
+            <div>✅ Proof request generated for <strong>{option.label}</strong></div>
+
+            <div>
+              <label className="form-label" htmlFor="proof-request-output">Proof request</label>
+              <textarea
+                id="proof-request-output"
+                readOnly
+                value={encodeProofRequest(state.request)}
+                style={{ fontSize: 12 }}
+                aria-label="Generated proof request, JSON encoded"
+              />
+              <button
+                className="btn btn--ghost btn--sm"
+                onClick={handleCopyProof}
+                aria-label="Copy proof request to clipboard"
+                data-testid="copy-proof-btn"
+                style={{ marginTop: 8 }}
+              >
+                {proofCopied ? '✅ Copied' : '📋 Copy proof'}
+              </button>
+            </div>
+
+            <div>
+              <label className="form-label" htmlFor="proof-share-link">Shareable verification link</label>
+              <div className="share-bar" id="proof-share-link">
+                <span className="share-bar__url">{buildProofShareUrl(state.request)}</span>
+                <button
+                  className="btn btn--ghost btn--sm"
+                  onClick={handleCopyLink}
+                  aria-label="Copy shareable verification link to clipboard"
+                  data-testid="copy-link-btn"
+                >
+                  {linkCopied ? '✅ Copied' : '📋 Copy link'}
+                </button>
+              </div>
+            </div>
+
+            <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: 0 }}>
+              This proof is tied to the current ledger sequence (nonce {state.request.nonce.toString()}) and a
+              verifier must submit it before that sequence advances too far. It only proves the selected claim —
+              it does not by itself confirm the credential hasn't expired or been revoked.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/ClaimProofGenerator.test.tsx
+++ b/frontend/src/components/__tests__/ClaimProofGenerator.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * ClaimProofGenerator.test.tsx
+ * Tests for the privacy-preserving credential claim generator UI — issue #667
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ClaimProofGenerator } from '../ClaimProofGenerator';
+import {
+  CLAIM_TYPE_OPTIONS,
+  findClaimTypeOption,
+  encodeProofRequest,
+  buildProofShareUrl,
+} from '../../lib/claimDisclosure';
+import { generateProofRequest } from '../../lib/contracts/zkVerifier';
+
+vi.mock('../../lib/contracts/zkVerifier', () => ({
+  generateProofRequest: vi.fn(),
+}));
+
+const CREDENTIAL_ID = 42n;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.assign(navigator, {
+    clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+  });
+});
+
+// ── Pure helpers ──────────────────────────────────────────────────────────────
+
+describe('findClaimTypeOption', () => {
+  it('returns the matching option for a known claim type', () => {
+    expect(findClaimTypeOption('HasLicense').label).toBe('License category');
+  });
+
+  it('covers degree, license and employer claim types per the issue requirements', () => {
+    const labels = CLAIM_TYPE_OPTIONS.map((o) => o.label);
+    expect(labels).toEqual(
+      expect.arrayContaining(['Degree', 'License category', 'Employer'])
+    );
+  });
+});
+
+describe('encodeProofRequest', () => {
+  it('serializes bigint fields as strings so the result is valid JSON', () => {
+    const encoded = encodeProofRequest({
+      credential_id: 42n,
+      claim_type: 'HasDegree',
+      nonce: 12345n,
+    });
+    expect(JSON.parse(encoded)).toEqual({
+      credential_id: '42',
+      claim_type: 'HasDegree',
+      nonce: '12345',
+    });
+  });
+});
+
+describe('buildProofShareUrl', () => {
+  it('builds a /verify URL carrying id, claimType and nonce', () => {
+    const url = buildProofShareUrl({ credential_id: 7n, claim_type: 'HasLicense', nonce: 99n });
+    expect(url).toContain('/verify?');
+    expect(url).toContain('id=7');
+    expect(url).toContain('claimType=HasLicense');
+    expect(url).toContain('nonce=99');
+  });
+});
+
+// ── Rendering ────────────────────────────────────────────────────────────────
+
+describe('ClaimProofGenerator rendering', () => {
+  it('renders the claim type selector with all options', () => {
+    render(<ClaimProofGenerator credentialId={CREDENTIAL_ID} />);
+    const select = screen.getByTestId('claim-type-select');
+    expect(select).toBeInTheDocument();
+    for (const opt of CLAIM_TYPE_OPTIONS) {
+      expect(screen.getByText(new RegExp(opt.label))).toBeInTheDocument();
+    }
+  });
+
+  it('shows a disclosure preview for the default claim type', () => {
+    render(<ClaimProofGenerator credentialId={CREDENTIAL_ID} />);
+    const preview = screen.getByTestId('disclosure-preview');
+    expect(preview).toBeInTheDocument();
+    expect(screen.getByText(/You hold a verified degree credential\./)).toBeInTheDocument();
+    expect(screen.getByText('Institution name')).toBeInTheDocument();
+  });
+
+  it('updates the disclosure preview when a different claim type is selected', () => {
+    render(<ClaimProofGenerator credentialId={CREDENTIAL_ID} />);
+    fireEvent.change(screen.getByTestId('claim-type-select'), { target: { value: 'HasEmploymentHistory' } });
+    expect(screen.getByText(/You hold a verified employment credential\./)).toBeInTheDocument();
+    expect(screen.getByText('Employer name')).toBeInTheDocument();
+  });
+
+  it('references the credential ID so verifiers know what the proof applies to', () => {
+    render(<ClaimProofGenerator credentialId={CREDENTIAL_ID} />);
+    expect(screen.getByText(/Credential #42/)).toBeInTheDocument();
+  });
+});
+
+// ── Proof generation ─────────────────────────────────────────────────────────
+
+describe('ClaimProofGenerator proof generation', () => {
+  it('calls generateProofRequest with the credential ID and selected claim type', async () => {
+    (generateProofRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      credential_id: CREDENTIAL_ID,
+      claim_type: 'HasDegree',
+      nonce: 123n,
+    });
+    render(<ClaimProofGenerator credentialId={CREDENTIAL_ID} />);
+    fireEvent.click(screen.getByTestId('generate-proof-btn'));
+    await waitFor(() => expect(generateProofRequest).toHaveBeenCalledWith(CREDENTIAL_ID, 'HasDegree'));
+  });
+
+  it('shows the generated proof request and validity note on success', async () => {
+    (generateProofRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      credential_id: CREDENTIAL_ID,
+      claim_type: 'HasDegree',
+      nonce: 123n,
+    });
+    render(<ClaimProofGenerator credentialId={CREDENTIAL_ID} />);
+    fireEvent.click(screen.getByTestId('generate-proof-btn'));
+
+    const result = await screen.findByTestId('proof-result');
+    expect(result).toBeInTheDocument();
+    expect(screen.getByLabelText('Generated proof request, JSON encoded')).toHaveValue(
+      encodeProofRequest({ credential_id: CREDENTIAL_ID, claim_type: 'HasDegree', nonce: 123n })
+    );
+    expect(screen.getByText(/nonce 123/)).toBeInTheDocument();
+  });
+
+  it('shows an error message when proof generation fails', async () => {
+    (generateProofRequest as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Simulation failed'));
+    render(<ClaimProofGenerator credentialId={CREDENTIAL_ID} />);
+    fireEvent.click(screen.getByTestId('generate-proof-btn'));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Simulation failed');
+  });
+
+  it('resets prior results when the claim type changes', async () => {
+    (generateProofRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      credential_id: CREDENTIAL_ID,
+      claim_type: 'HasDegree',
+      nonce: 123n,
+    });
+    render(<ClaimProofGenerator credentialId={CREDENTIAL_ID} />);
+    fireEvent.click(screen.getByTestId('generate-proof-btn'));
+    await screen.findByTestId('proof-result');
+
+    fireEvent.change(screen.getByTestId('claim-type-select'), { target: { value: 'HasLicense' } });
+    expect(screen.queryByTestId('proof-result')).not.toBeInTheDocument();
+  });
+});
+
+// ── Clipboard copy ───────────────────────────────────────────────────────────
+
+describe('ClaimProofGenerator clipboard copy', () => {
+  async function generate() {
+    (generateProofRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      credential_id: CREDENTIAL_ID,
+      claim_type: 'HasDegree',
+      nonce: 123n,
+    });
+    render(<ClaimProofGenerator credentialId={CREDENTIAL_ID} />);
+    fireEvent.click(screen.getByTestId('generate-proof-btn'));
+    await screen.findByTestId('proof-result');
+  }
+
+  it('copies the encoded proof request to the clipboard', async () => {
+    await generate();
+    fireEvent.click(screen.getByTestId('copy-proof-btn'));
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        encodeProofRequest({ credential_id: CREDENTIAL_ID, claim_type: 'HasDegree', nonce: 123n })
+      )
+    );
+    expect(await screen.findByText('✅ Copied')).toBeInTheDocument();
+  });
+
+  it('copies the shareable verification link to the clipboard', async () => {
+    await generate();
+    fireEvent.click(screen.getByTestId('copy-link-btn'));
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        buildProofShareUrl({ credential_id: CREDENTIAL_ID, claim_type: 'HasDegree', nonce: 123n })
+      )
+    );
+  });
+});
+
+// ── Accessibility ────────────────────────────────────────────────────────────
+
+describe('ClaimProofGenerator accessibility', () => {
+  it('labels the claim type select for assistive technology', () => {
+    render(<ClaimProofGenerator credentialId={CREDENTIAL_ID} />);
+    expect(screen.getByLabelText('Claim type')).toBeInTheDocument();
+  });
+
+  it('exposes the disclosure preview with a descriptive label', () => {
+    render(<ClaimProofGenerator credentialId={CREDENTIAL_ID} />);
+    expect(screen.getByLabelText('Disclosure preview for Degree claim')).toBeInTheDocument();
+  });
+
+  it('announces generation errors via role="alert"', async () => {
+    (generateProofRequest as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('boom'));
+    render(<ClaimProofGenerator credentialId={CREDENTIAL_ID} />);
+    fireEvent.click(screen.getByTestId('generate-proof-btn'));
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+  });
+
+  it('announces a successful proof via role="status"', async () => {
+    (generateProofRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      credential_id: CREDENTIAL_ID,
+      claim_type: 'HasDegree',
+      nonce: 1n,
+    });
+    render(<ClaimProofGenerator credentialId={CREDENTIAL_ID} />);
+    fireEvent.click(screen.getByTestId('generate-proof-btn'));
+    expect(await screen.findByRole('status')).toBeInTheDocument();
+  });
+
+  it('gives every copy button an accessible name', async () => {
+    (generateProofRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      credential_id: CREDENTIAL_ID,
+      claim_type: 'HasDegree',
+      nonce: 1n,
+    });
+    render(<ClaimProofGenerator credentialId={CREDENTIAL_ID} />);
+    fireEvent.click(screen.getByTestId('generate-proof-btn'));
+    await screen.findByTestId('proof-result');
+    expect(screen.getByLabelText('Copy proof request to clipboard')).toBeInTheDocument();
+    expect(screen.getByLabelText('Copy shareable verification link to clipboard')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -21,3 +21,6 @@ export type { SliceHealth, SliceThresholdVisualizerProps } from './SliceThreshol
 export { SliceRecommendationPanel } from './SliceRecommendationPanel';
 export { AttestorReputationDisplay } from './AttestorReputationDisplay';
 export type { AttestorReputation } from './AttestorReputationDisplay';
+export { ClaimProofGenerator } from './ClaimProofGenerator';
+export { CLAIM_TYPE_OPTIONS, findClaimTypeOption, encodeProofRequest, buildProofShareUrl } from '../lib/claimDisclosure';
+export type { ClaimTypeOption } from '../lib/claimDisclosure';

--- a/frontend/src/lib/claimDisclosure.ts
+++ b/frontend/src/lib/claimDisclosure.ts
@@ -1,0 +1,72 @@
+import type { ClaimType, ProofRequest } from './contracts/zkVerifier';
+
+export interface ClaimTypeOption {
+  value: ClaimType;
+  label: string;
+  icon: string;
+  /** What the verifier learns when this claim is proven. */
+  discloses: string;
+  /** What stays hidden even though it lives on the same credential. */
+  hides: string[];
+}
+
+export const CLAIM_TYPE_OPTIONS: ClaimTypeOption[] = [
+  {
+    value: 'HasDegree',
+    label: 'Degree',
+    icon: '🎓',
+    discloses: 'You hold a verified degree credential.',
+    hides: ['Institution name', 'Field of study', 'Graduation date', 'Grades or honors'],
+  },
+  {
+    value: 'HasLicense',
+    label: 'License category',
+    icon: '🏛️',
+    discloses: 'You hold a verified professional license.',
+    hides: ['Licensing body', 'License number', 'Issue date', 'Jurisdiction'],
+  },
+  {
+    value: 'HasEmploymentHistory',
+    label: 'Employer',
+    icon: '💼',
+    discloses: 'You hold a verified employment credential.',
+    hides: ['Employer name', 'Job title', 'Salary', 'Employment dates'],
+  },
+  {
+    value: 'HasCertification',
+    label: 'Certification',
+    icon: '📜',
+    discloses: 'You hold a verified certification.',
+    hides: ['Certifying body', 'Certification name', 'Score or grade'],
+  },
+  {
+    value: 'HasResearchPublication',
+    label: 'Research publication',
+    icon: '🔬',
+    discloses: 'You hold a verified research publication credential.',
+    hides: ['Publication title', 'Co-authors', 'Venue', 'Publication date'],
+  },
+];
+
+export function findClaimTypeOption(value: ClaimType): ClaimTypeOption {
+  return CLAIM_TYPE_OPTIONS.find((o) => o.value === value) ?? CLAIM_TYPE_OPTIONS[0];
+}
+
+/** Encode a proof request as a JSON string suitable for sharing/clipboard. */
+export function encodeProofRequest(request: ProofRequest): string {
+  return JSON.stringify({
+    credential_id: request.credential_id.toString(),
+    claim_type: request.claim_type,
+    nonce: request.nonce.toString(),
+  });
+}
+
+/** Build a verifier-facing URL that pre-fills the claim type for a credential. */
+export function buildProofShareUrl(request: ProofRequest): string {
+  const params = new URLSearchParams({
+    id: request.credential_id.toString(),
+    claimType: request.claim_type,
+    nonce: request.nonce.toString(),
+  });
+  return `${window.location.origin}/verify?${params.toString()}`;
+}

--- a/frontend/src/pages/CredentialDetail.tsx
+++ b/frontend/src/pages/CredentialDetail.tsx
@@ -7,6 +7,7 @@ import { VerificationHistory } from '../components/VerificationHistory';
 import { AttestorReputationDisplay } from '../components/AttestorReputationDisplay';
 import type { VerificationRecord } from '../components/VerificationHistory';
 import { AttestationProgress } from '../components/AttestationProgress';
+import { ClaimProofGenerator } from '../components/ClaimProofGenerator';
 import {
   getCredential,
   getAttestors,
@@ -225,6 +226,9 @@ export default function CredentialDetail() {
             </div>
           </div>
         </div>
+
+        {/* Privacy-Preserving Claim Proof Generator */}
+        <ClaimProofGenerator credentialId={credential.id} />
 
         {/* Quorum Slice & Attestation */}
         <div className="detail-card">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -937,6 +937,55 @@ textarea {
   border: 1px solid rgba(245,158,11,0.25);
 }
 
+.disclosure-preview {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+@media (max-width: 640px) {
+  .disclosure-preview {
+    grid-template-columns: 1fr;
+  }
+}
+
+.disclosure-preview__heading {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  margin-bottom: 8px;
+}
+
+.disclosure-preview__heading--shown {
+  color: var(--green);
+}
+
+.disclosure-preview__heading--hidden {
+  color: var(--text-secondary);
+}
+
+.disclosure-preview__text {
+  font-size: 13px;
+  color: var(--text-primary);
+  margin: 0 0 6px 0;
+}
+
+.disclosure-preview__list {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.disclosure-preview__list li {
+  margin-bottom: 4px;
+}
+
 /* Credential ID list (for address lookup) */
 .cred-list {
   display: flex;


### PR DESCRIPTION
## Summary
- Add `ClaimProofGenerator` component letting a credential holder pick a claim type (degree, license category, employer, certification, research publication) and see a disclosure preview of exactly what will and won't be revealed before generating a proof.
- Generate a ZK proof request via the existing `generateProofRequest` zkVerifier contract client, then display it with copy-to-clipboard plus a shareable `/verify?...` link and proof validity/limitation notes (ledger-sequence-bound nonce, doesn't itself confirm expiry/revocation).
- Wire the generator into `CredentialDetail` so holders can generate a proof straight from their credential page (no wallet required, matching the existing verifier-side UX).
- New `lib/claimDisclosure.ts` holds the claim-type metadata and pure encode/URL helpers so the component file only exports the component (keeps fast-refresh/lint happy).

Closes #667

## Test plan
- [x] `npm run test -- ClaimProofGenerator` — 19 new tests covering claim selection, disclosure preview accuracy per claim type, proof generation success/error, clipboard copy of both the proof and the share link, and accessibility (labels, `role="alert"`/`role="status"`).
- [x] `npx eslint` on all touched/added files — clean.
- [x] Confirmed pre-existing `tsc -b` and unrelated test-suite failures are present identically on `main` (not introduced by this change).