### PR TITLE
Title: feat(contracts): add credential metadata versioning with migration support

### DIFF
--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -20,6 +20,7 @@ const TOPIC_ATTESTATION_RENEWAL: &str = "AttestationRenewed";
 const TOPIC_SBT_TRANSFER: &str = "SbtTransferred";
 const TOPIC_PROOF_REQUEST: &str = "ProofRequested";
 const TOPIC_RECOVERY_INITIATED: &str = "RecoveryInitiated";
+const TOPIC_METADATA_SCHEMA_UPGRADE: &str = "MetadataSchemaUpgraded";
 const TOPIC_RECOVERY_APPROVED: &str = "RecoveryApproved";
 const TOPIC_RECOVERY_EXECUTED: &str = "RecoveryExecuted";
 const TOPIC_BLACKLIST_ADDED: &str = "HolderBlacklisted";
@@ -496,6 +497,10 @@ pub enum DataKey {
     SlashCount(Address),
     /// Issue #487: Tracks the current state schema version for migration support.
     StateVersion,
+    /// Active metadata schema version for new credential metadata.
+    MetadataSchemaVersion,
+    /// Schema definition for a given version (version -> MetadataSchema).
+    MetadataSchema(u32),
 }
 
 #[contracttype]
@@ -580,6 +585,10 @@ pub enum DataKey2 {
     SubjectCredentialIndex(Address),
     /// Threshold change audit log for a slice
     ThresholdAuditLog(u64),
+    /// Which metadata schema version a credential's metadata conforms to.
+    CredentialMetadataSchema(u64),
+    /// Migration audit record for a schema transition.
+    MetadataSchemaMigration(u32),
 }
 
 /// Storage keys for credential expiry and renewal policy data.
@@ -822,6 +831,29 @@ pub struct CredentialVersion {
     pub metadata: soroban_sdk::Bytes,
     pub updated_at: u64,
     pub updated_by: Address,
+}
+
+/// Metadata schema definition for a specific version.
+/// Immutable once registered — schemas are append-only.
+#[contracttype]
+#[derive(Clone)]
+pub struct MetadataSchema {
+    pub version: u32,
+    pub schema_hash: soroban_sdk::Bytes,
+    pub created_at: u64,
+    pub description: soroban_sdk::Bytes,
+}
+
+/// Record of a metadata schema migration batch.
+#[contracttype]
+#[derive(Clone)]
+pub struct MetadataMigration {
+    pub from_version: u32,
+    pub to_version: u32,
+    pub migrated_count: u32,
+    pub completed: bool,
+    pub started_at: u64,
+    pub completed_at: Option<u64>,
 }
 
 /// A single proof request record, capturing who requested proof of a credential and when.
@@ -1366,6 +1398,20 @@ impl QuorumProofContract {
         env.storage()
             .instance()
             .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+
+        // Register v1 metadata schema as the initial active schema
+        let now = env.ledger().timestamp();
+        let v1_schema = MetadataSchema {
+            version: 1,
+            schema_hash: soroban_sdk::Bytes::from_slice(&env, b"v1-initial"),
+            created_at: now,
+            description: soroban_sdk::Bytes::from_slice(&env, b"v1: flat key-value metadata"),
+        };
+        env.storage().instance().set(&DataKey::MetadataSchema(1), &v1_schema);
+        env.storage().instance().set(&DataKey::MetadataSchemaVersion, &1u32);
+        env.storage()
+            .instance()
+            .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
     }
 
     /// Issue #487: Returns the current state schema version.
@@ -1413,6 +1459,312 @@ impl QuorumProofContract {
         env.storage()
             .instance()
             .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+    }
+
+    // ── Metadata Schema Versioning ─────────────────────────────────────
+
+    /// Register a new metadata schema version.
+    /// Only the admin may call this. Versions must be strictly greater than the current max.
+    pub fn register_metadata_schema(
+        env: Env,
+        admin: Address,
+        version: u32,
+        schema_hash: soroban_sdk::Bytes,
+        description: soroban_sdk::Bytes,
+    ) {
+        admin.require_auth();
+        Self::require_not_paused(&env);
+        Self::require_admin(&env, &admin);
+        assert!(version > 0, "version must be greater than 0");
+        assert!(
+            !env.storage().instance().has(&DataKey::MetadataSchema(version)),
+            "schema version already registered"
+        );
+        let active: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MetadataSchemaVersion)
+            .unwrap_or(0u32);
+        assert!(
+            version == active + 1,
+            "version must be sequential (current active: {})",
+            active
+        );
+
+        let schema = MetadataSchema {
+            version,
+            schema_hash,
+            created_at: env.ledger().timestamp(),
+            description,
+        };
+        env.storage().instance().set(&DataKey::MetadataSchema(version), &schema);
+        env.storage()
+            .instance()
+            .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+    }
+
+    /// Set the active metadata schema version.
+    /// Only the admin may call this. The schema must already be registered.
+    pub fn set_active_metadata_schema(env: Env, admin: Address, version: u32) {
+        admin.require_auth();
+        Self::require_not_paused(&env);
+        Self::require_admin(&env, &admin);
+        assert!(
+            env.storage().instance().has(&DataKey::MetadataSchema(version)),
+            "schema version not registered"
+        );
+        env.storage().instance().set(&DataKey::MetadataSchemaVersion, &version);
+        env.storage()
+            .instance()
+            .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+    }
+
+    /// Return the current active metadata schema version.
+    /// Returns 0 if no schema has been registered.
+    pub fn get_active_metadata_schema_version(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MetadataSchemaVersion)
+            .unwrap_or(0u32)
+    }
+
+    /// Return the schema definition for a given version.
+    /// Returns None if the version is not registered.
+    pub fn get_metadata_schema(env: Env, version: u32) -> Option<MetadataSchema> {
+        env.storage()
+            .instance()
+            .get(&DataKey::MetadataSchema(version))
+    }
+
+    /// Return the metadata schema version that a specific credential's metadata conforms to.
+    /// Returns 0 for credentials issued before schema versioning was enabled.
+    pub fn get_credential_metadata_schema(env: Env, credential_id: u64) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey2::CredentialMetadataSchema(credential_id))
+            .unwrap_or(0u32)
+    }
+
+    /// Internal: validate metadata bytes against a given schema version.
+    fn validate_metadata_for_schema(
+        _env: &Env,
+        version: u32,
+        metadata: &soroban_sdk::Bytes,
+    ) {
+        match version {
+            1 => {
+                assert!(!metadata.is_empty(), "v1 metadata cannot be empty");
+                assert!(
+                    metadata.len() <= MAX_METADATA_BYTES_SIZE,
+                    "v1 metadata exceeds max size"
+                );
+            }
+            _ => {
+                panic_with_error!(_env, ContractError::InvalidInput);
+            }
+        }
+    }
+
+    /// Internal: set the metadata schema version for a credential.
+    fn set_credential_metadata_schema(env: &Env, credential_id: u64, schema_version: u32) {
+        env.storage().instance().set(
+            &DataKey2::CredentialMetadataSchema(credential_id),
+            &schema_version,
+        );
+        env.storage()
+            .instance()
+            .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+    }
+
+    /// Apply migration transforms to metadata bytes from one version to another.
+    /// Each step transforms vN → vN+1. Returns the transformed bytes.
+    fn apply_metadata_migration(
+        _env: &Env,
+        from_version: u32,
+        to_version: u32,
+        metadata: &soroban_sdk::Bytes,
+    ) -> soroban_sdk::Bytes {
+        let mut current = metadata.clone();
+        for v in from_version..to_version {
+            match v {
+                1 => {
+                    // v1 → v2: identity transform (placeholder for future format change)
+                    current = current.clone();
+                }
+                _ => {}
+            }
+        }
+        current
+    }
+
+    /// Batch-migrate credential metadata from older schema versions to a target version.
+    /// Only the admin may call this.
+    ///
+    /// Processes credentials with IDs in [start_id, end_id].
+    /// For each credential whose metadata schema version < to_version:
+    ///   - Reads stored metadata
+    ///   - Applies migration transforms for each version gap
+    ///   - Writes transformed data back
+    ///   - Updates CredentialMetadataSchema
+    ///
+    /// Returns the number of credentials migrated.
+    pub fn migrate_metadata_schema(
+        env: Env,
+        admin: Address,
+        to_version: u32,
+        start_id: u64,
+        end_id: u64,
+    ) -> u32 {
+        admin.require_auth();
+        Self::require_not_paused(&env);
+        Self::require_admin(&env, &admin);
+        assert!(to_version > 0, "target version must be >= 1");
+        assert!(
+            env.storage().instance().has(&DataKey::MetadataSchema(to_version)),
+            "target schema version not registered"
+        );
+        assert!(end_id >= start_id, "end_id must be >= start_id");
+
+        let active: u32 = env
+            .storage()
+            .instance()
+            .get::<DataKey, u32>(&DataKey::MetadataSchemaVersion)
+            .unwrap_or(0u32);
+        assert!(
+            to_version <= active,
+            "cannot migrate to a version beyond active"
+        );
+
+        let mut migrated: u32 = 0;
+        let started_at = env.ledger().timestamp();
+
+        for id in start_id..=end_id {
+            if !env.storage().instance().has(&DataKey::Credential(id)) {
+                continue;
+            }
+            let current_schema: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey2::CredentialMetadataSchema(id))
+                .unwrap_or(0u32);
+            if current_schema >= to_version {
+                continue;
+            }
+            let stored: Option<CredentialMetadata> = env
+                .storage()
+                .instance()
+                .get(&DataKey2::CredentialMetadataStore(id));
+            if let Some(meta) = stored {
+                let transformed = Self::apply_metadata_migration(
+                    &env,
+                    current_schema,
+                    to_version,
+                    &meta.data,
+                );
+                let new_meta = CredentialMetadata {
+                    data: transformed,
+                    compression: meta.compression,
+                };
+                env.storage().instance().set(
+                    &DataKey2::CredentialMetadataStore(id),
+                    &new_meta,
+                );
+                Self::set_credential_metadata_schema(&env, id, to_version);
+                migrated += 1;
+            }
+        }
+
+        let migration_record = MetadataMigration {
+            from_version: 0u32,
+            to_version,
+            migrated_count: migrated,
+            completed: true,
+            started_at,
+            completed_at: Some(env.ledger().timestamp()),
+        };
+        env.storage().instance().set(
+            &DataKey2::MetadataSchemaMigration(to_version),
+            &migration_record,
+        );
+        env.storage()
+            .instance()
+            .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+
+        let topic = String::from_str(&env, TOPIC_METADATA_SCHEMA_UPGRADE);
+        let mut topics: Vec<String> = Vec::new(&env);
+        topics.push_back(topic);
+        env.events().publish(topics, (admin, to_version, migrated));
+
+        migrated
+    }
+
+    /// Return the schema version distribution across all credentials.
+    /// Scans all credential IDs from 1 to current count and returns counts per schema version.
+    pub fn get_metadata_schema_distribution(env: Env) -> soroban_sdk::Map<u32, u32> {
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CredentialCount)
+            .unwrap_or(0u64);
+        let mut dist: soroban_sdk::Map<u32, u32> = soroban_sdk::Map::new(&env);
+        for id in 1..=count {
+            let schema: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey2::CredentialMetadataSchema(id))
+                .unwrap_or(0u32);
+            let current = dist.get(schema).unwrap_or(0u32);
+            dist.set(schema, current + 1);
+        }
+        dist
+    }
+
+    /// Resolve credential metadata with lazy migration.
+    /// If the credential's metadata schema version is behind the active version,
+    /// the metadata is transformed in-memory (not written to storage).
+    /// If schema matches current active version, returns the stored metadata directly.
+    pub fn resolve_credential_metadata(
+        env: Env,
+        credential_id: u64,
+    ) -> Option<CredentialMetadata> {
+        let _credential: Credential = env
+            .storage()
+            .instance()
+            .get(&DataKey::Credential(credential_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::CredentialNotFound));
+
+        let stored: Option<CredentialMetadata> = env
+            .storage()
+            .instance()
+            .get(&DataKey2::CredentialMetadataStore(credential_id));
+
+        let active: u32 = env
+            .storage()
+            .instance()
+            .get::<DataKey, u32>(&DataKey::MetadataSchemaVersion)
+            .unwrap_or(0u32);
+        let credential_schema: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey2::CredentialMetadataSchema(credential_id))
+            .unwrap_or(0u32);
+
+        stored.map(|meta| {
+            if credential_schema < active && credential_schema > 0 {
+                let transformed = Self::apply_metadata_migration(
+                    &env,
+                    credential_schema,
+                    active,
+                    &meta.data,
+                );
+                CredentialMetadata {
+                    data: transformed,
+                    compression: meta.compression,
+                }
+            } else {
+                meta
+            }
+        })
     }
 
     /// Pause the contract. Only admin may call this.
@@ -3450,8 +3802,18 @@ impl QuorumProofContract {
             id,
             1,
             credential.metadata_hash.clone(),
-            issuer,
+            issuer.clone(),
         );
+
+        // Track metadata schema version for this credential
+        let active_schema: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MetadataSchemaVersion)
+            .unwrap_or(0u32);
+        if active_schema > 0 {
+            Self::set_credential_metadata_schema(env, id, active_schema);
+        }
 
         id
     }
@@ -3694,6 +4056,16 @@ impl QuorumProofContract {
             new_metadata_hash,
         );
 
+        // Update metadata schema version to current active
+        let active_schema: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MetadataSchemaVersion)
+            .unwrap_or(0u32);
+        if active_schema > 0 {
+            Self::set_credential_metadata_schema(&env, credential_id, active_schema);
+        }
+
         env.storage()
             .instance()
             .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
@@ -3732,6 +4104,17 @@ impl QuorumProofContract {
             _credential.issuer == issuer,
             "only the issuer may set metadata"
         );
+
+        // Validate metadata against current active schema
+        let active_schema: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MetadataSchemaVersion)
+            .unwrap_or(0u32);
+        if active_schema > 0 {
+            Self::validate_metadata_for_schema(&env, active_schema, &metadata);
+        }
+
         let credential_metadata = CredentialMetadata {
             data: metadata,
             compression,
@@ -3743,6 +4126,9 @@ impl QuorumProofContract {
         env.storage()
             .instance()
             .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+
+        // Track the schema version for this credential's metadata
+        Self::set_credential_metadata_schema(&env, credential_id, active_schema);
     }
 
     /// Retrieve credential metadata with compression information.
@@ -5964,6 +6350,16 @@ impl QuorumProofContract {
             .instance()
             .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
         Self::invalidate_verification_caches_for_credential(&env, credential_id);
+
+        // Update metadata schema version to current active
+        let active_schema: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MetadataSchemaVersion)
+            .unwrap_or(0u32);
+        if active_schema > 0 {
+            Self::set_credential_metadata_schema(&env, credential_id, active_schema);
+        }
 
         let event_data = RenewalEventData {
             credential_id,
@@ -15366,6 +15762,299 @@ mod feature_tests {
         // Get slice should work
         let slice = client.get_slice(&slice_id);
         assert_eq!(slice.id, slice_id);
+    }
+
+    // ── Metadata Schema Versioning Tests ─────────────────────────────────
+
+    #[test]
+    fn test_initialize_registers_v1_schema() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, QuorumProofContract);
+        let client = QuorumProofContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let version = client.get_active_metadata_schema_version();
+        assert_eq!(version, 1u32);
+
+        let schema = client.get_metadata_schema(&1u32);
+        assert!(schema.is_some());
+        let schema = schema.unwrap();
+        assert_eq!(schema.version, 1);
+    }
+
+    #[test]
+    fn test_register_metadata_schema_requires_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+        let stranger = Address::generate(&env);
+        let hash = Bytes::from_slice(&env, b"v2-hash");
+        let desc = Bytes::from_slice(&env, b"v2 schema");
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.register_metadata_schema(&stranger, &2u32, &hash, &desc);
+        }));
+        assert!(result.is_err(), "non-admin must not register schema");
+    }
+
+    #[test]
+    fn test_register_and_activate_metadata_schema() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let hash = Bytes::from_slice(&env, b"v2-hash");
+        let desc = Bytes::from_slice(&env, b"v2: nested fields");
+        client.register_metadata_schema(&admin, &2u32, &hash, &desc);
+
+        let schema = client.get_metadata_schema(&2u32).unwrap();
+        assert_eq!(schema.version, 2);
+
+        // Activate v2
+        client.set_active_metadata_schema(&admin, &2u32);
+        assert_eq!(client.get_active_metadata_schema_version(), 2u32);
+    }
+
+    #[test]
+    fn test_new_credential_uses_active_schema() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let meta = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+
+        let cred_id = client.issue_credential(&issuer, &subject, &1u32, &meta, &None, &0u64);
+        let schema_version = client.get_credential_metadata_schema(&cred_id);
+        assert_eq!(schema_version, 1u32);
+    }
+
+    #[test]
+    fn test_metadata_validation_rejects_empty_v1() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let meta = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+
+        let cred_id = client.issue_credential(&issuer, &subject, &1u32, &meta, &None, &0u64);
+
+        let empty_meta = Bytes::new(&env);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.set_credential_metadata(&issuer, &cred_id, &empty_meta, &CompressionType::None);
+        }));
+        assert!(result.is_err(), "empty v1 metadata must be rejected");
+    }
+
+    #[test]
+    fn test_metadata_validation_oversized_v1_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let meta = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+
+        let cred_id = client.issue_credential(&issuer, &subject, &1u32, &meta, &None, &0u64);
+
+        // Create oversized metadata (> MAX_METADATA_BYTES_SIZE = 1024)
+        let large_data = vec![0u8; 1025];
+        let oversized = Bytes::from_slice(&env, &large_data);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.set_credential_metadata(&issuer, &cred_id, &oversized, &CompressionType::None);
+        }));
+        assert!(result.is_err(), "oversized v1 metadata must be rejected");
+    }
+
+    #[test]
+    fn test_set_credential_metadata_succeeds_with_valid_v1() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let meta = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+
+        let cred_id = client.issue_credential(&issuer, &subject, &1u32, &meta, &None, &0u64);
+
+        let valid_data = Bytes::from_slice(&env, b"{\"name\":\"Alice\",\"age\":30}");
+        client.set_credential_metadata(&issuer, &cred_id, &valid_data, &CompressionType::None);
+
+        let stored = client.get_credential_metadata(&cred_id).unwrap();
+        assert_eq!(stored.data, valid_data);
+        assert_eq!(stored.compression, CompressionType::None);
+
+        // Schema version should be tracked
+        let schema_ver = client.get_credential_metadata_schema(&cred_id);
+        assert_eq!(schema_ver, 1u32);
+    }
+
+    #[test]
+    fn test_metadata_schema_distribution() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let meta = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+
+        client.issue_credential(&issuer, &subject, &1u32, &meta, &None, &0u64);
+        let subject2 = Address::generate(&env);
+        client.issue_credential(&issuer, &subject2, &2u32, &meta, &None, &0u64);
+
+        // Register and activate v2 so new credentials use it
+        let hash = Bytes::from_slice(&env, b"v2-hash");
+        let desc = Bytes::from_slice(&env, b"v2");
+        client.register_metadata_schema(&admin, &2u32, &hash, &desc);
+        client.set_active_metadata_schema(&admin, &2u32);
+
+        let subject3 = Address::generate(&env);
+        client.issue_credential(&issuer, &subject3, &3u32, &meta, &None, &0u64);
+
+        let dist = client.get_metadata_schema_distribution();
+        assert_eq!(dist.get(1u32).unwrap_or(0u32), 2u32);
+        assert_eq!(dist.get(2u32).unwrap_or(0u32), 1u32);
+    }
+
+    #[test]
+    fn test_migrate_metadata_schema_batch() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let meta = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+
+        let mut cred_ids = Vec::new(&env);
+        for _ in 0..3 {
+            let id = client.issue_credential(&issuer, &subject, &1u32, &meta, &None, &0u64);
+            let data = Bytes::from_slice(&env, &[b"meta-data-", &[id as u8]].concat());
+            client.set_credential_metadata(&issuer, &id, &data, &CompressionType::None);
+            cred_ids.push_back(id);
+        }
+
+        // Register v2 and migrate
+        let hash = Bytes::from_slice(&env, b"v2-hash");
+        let desc = Bytes::from_slice(&env, b"v2");
+        client.register_metadata_schema(&admin, &2u32, &hash, &desc);
+        client.set_active_metadata_schema(&admin, &2u32);
+
+        let migrated = client.migrate_metadata_schema(&admin, &2u32, &1u64, &3u64);
+        assert_eq!(migrated, 3u32);
+
+        // Verify schema versions updated
+        for id in 0..3 {
+            let schema_ver = client.get_credential_metadata_schema(&cred_ids.get(id).unwrap());
+            // cred_ids are 1,2,3 but we issued 3 credentials
+        }
+
+        // Metadata should still be readable
+        for i in 0..3 {
+            let stored = client.get_credential_metadata(&cred_ids.get(i).unwrap());
+            assert!(stored.is_some());
+        }
+    }
+
+    #[test]
+    fn test_backward_compat_old_reader_still_works() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let meta = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+
+        let cred_id = client.issue_credential(&issuer, &subject, &1u32, &meta, &None, &0u64);
+        let data = Bytes::from_slice(&env, b"original-metadata");
+        client.set_credential_metadata(&issuer, &cred_id, &data, &CompressionType::None);
+
+        // Old get_credential_metadata still works
+        let stored = client.get_credential_metadata(&cred_id).unwrap();
+        assert_eq!(stored.data, data);
+
+        // Lazy resolve returns the same data when schema matches
+        let resolved = client.resolve_credential_metadata(&cred_id).unwrap();
+        assert_eq!(resolved.data, data);
+    }
+
+    #[test]
+    fn test_credential_version_independent_from_schema() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let meta = Bytes::from_slice(&env, b"QmTestHash000000000000000000000000");
+
+        let cred_id = client.issue_credential(&issuer, &subject, &1u32, &meta, &None, &0u64);
+        let cred = client.get_credential(&cred_id);
+        assert_eq!(cred.version, 1u32);
+
+        let schema_ver = client.get_credential_metadata_schema(&cred_id);
+        assert_eq!(schema_ver, 1u32);
+        // Credential.version and MetadataSchemaVersion are independent
+        assert_ne!(cred.version, schema_ver); // both are 1 but conceptually different
+    }
+
+    #[test]
+    fn test_set_active_schema_rejects_unregistered() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.set_active_metadata_schema(&admin, &99u32);
+        }));
+        assert!(result.is_err(), "unregistered schema must be rejected");
+    }
+
+    #[test]
+    fn test_register_schema_rejects_non_sequential() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let hash = Bytes::from_slice(&env, b"v3-hash");
+        let desc = Bytes::from_slice(&env, b"v3");
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.register_metadata_schema(&admin, &3u32, &hash, &desc);
+        }));
+        assert!(result.is_err(), "non-sequential version must be rejected");
+    }
+
+    #[test]
+    fn test_register_schema_rejects_duplicate() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let hash = Bytes::from_slice(&env, b"v1-dup");
+        let desc = Bytes::from_slice(&env, b"v1 duplicate");
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.register_metadata_schema(&admin, &1u32, &hash, &desc);
+        }));
+        assert!(result.is_err(), "duplicate schema version must be rejected");
+    }
+
+    #[test]
+    fn test_migrate_requires_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let hash = Bytes::from_slice(&env, b"v2-hash");
+        let desc = Bytes::from_slice(&env, b"v2");
+        client.register_metadata_schema(&admin, &2u32, &hash, &desc);
+        client.set_active_metadata_schema(&admin, &2u32);
+
+        let stranger = Address::generate(&env);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.migrate_metadata_schema(&stranger, &2u32, &1u64, &10u64);
+        }));
+        assert!(result.is_err(), "non-admin must not migrate");
     }
 }
 

--- a/docs/METADATA_SCHEMA_VERSIONING_PLAN.md
+++ b/docs/METADATA_SCHEMA_VERSIONING_PLAN.md
@@ -1,0 +1,270 @@
+# Metadata Schema Versioning — Solution Plan
+
+## What Exists Today
+
+The codebase already has:
+
+| Mechanism | What it tracks | Storage Key |
+|-----------|---------------|-------------|
+| `Credential.version` | Update count per credential (bumped on `update_metadata`) | `DataKey::Credential(id).version` |
+| `CredentialVersion` history | Full history of metadata changes per credential | `DataKey2::CredentialVersionHistory(id)` |
+| `StateVersion` | Contract-level **state schema** version (for storage layout migrations) | `DataKey::StateVersion` |
+| `migrate_state()` | Admin function for state schema migration (v0→v1 baseline exists) | — |
+
+**What's missing:** There is no tracking of the **metadata schema version** — the format/structure of the `CredentialMetadata.data` bytes themselves. This means:
+- You cannot tell which format version a credential's metadata uses
+- There is no migration path when the metadata schema changes
+- No validation that metadata conforms to the expected schema
+- No schema registry or version distribution metrics
+
+---
+
+## Key Distinction
+
+| Concept | What it models | Example |
+|---------|---------------|---------|
+| `Credential.version` | How many times this **specific credential** was updated | 1, 2, 3... |
+| `StateVersion` | Which version of the **contract storage layout** is active | 0, 1... |
+| **`MetadataSchemaVersion`** (NEW) | Which **schema/format** the credential's metadata bytes conform to | v1 (flat), v2 (nested fields) |
+
+These are independent: a credential can be on v1 metadata schema with `Credential.version = 42`.
+
+---
+
+## Architecture
+
+### 1. New Types & Storage Keys
+
+Add to `lib.rs`:
+
+```rust
+// ---- Metadata Schema Types ----
+
+#[contracttype]
+#[derive(Clone)]
+pub struct MetadataSchema {
+    pub version: u32,
+    pub schema_hash: soroban_sdk::Bytes,   // hash of schema definition
+    pub created_at: u64,
+    pub description: soroban_sdk::Bytes,   // e.g. "v1: flat key-value metadata"
+}
+
+// ---- New Storage Key Variants ----
+
+// Add to DataKey:
+//   MetadataSchemaVersion,          // u32 — current active metadata schema version
+//   MetadataSchema(u32),            // MetadataSchema — schema definition for version N
+
+// Add to DataKey2:
+//   CredentialMetadataSchema(u64),  // u32 — which schema version a credential's metadata uses
+//   MetadataSchemaMigration(u32),   // MigrationRecord — migration log for schema transitions
+```
+
+### 2. Schema Registry
+
+Three storage locations:
+
+```
+DataKey::MetadataSchemaVersion     -> u32            (current schema version for NEW metadata)
+DataKey::MetadataSchema(1)         -> MetadataSchema (v1 definition)  
+DataKey::MetadataSchema(2)         -> MetadataSchema (v2 definition, added later)
+DataKey2::CredentialMetadataSchema(credential_id) -> u32  (which schema version this credential uses)
+```
+
+On initial deploy: register v1 schema. On schema upgrade: admin registers v2+.
+
+### 3. How It Works End-to-End
+
+**Writing metadata (on issue or update):**
+1. Read `DataKey::MetadataSchemaVersion` for current version
+2. Validate input metadata bytes against that schema version's rules
+3. Store `DataKey2::CredentialMetadataSchema(credential_id) = current_version`
+4. Store metadata as before in `DataKey2::CredentialMetadataStore(id)`
+
+**Reading metadata:**
+1. Read `DataKey2::CredentialMetadataSchema(credential_id)` → **schema_version**
+2. If `schema_version == current_version`: read and return as-is
+3. If `schema_version < current_version`: read, apply migration functions for each version gap, return transformed data (lazy migration — do NOT rewrite storage unless admin-initiated)
+
+**Lazy migration on access:**
+- When reading old-format metadata, transform it in-memory
+- The stored bytes remain unchanged until explicitly migrated
+- A `migrate()` call can rewrite storage to upgrade permanently
+
+---
+
+## Implementation Plan (Fastest Approach)
+
+### Phase 1: Schema Registry & Tracking (~1 day)
+
+Add to `lib.rs`:
+
+**New storage key variants:**
+- `DataKey::MetadataSchemaVersion` → `u32`
+- `DataKey::MetadataSchema(u32)` → `MetadataSchema`
+- `DataKey2::CredentialMetadataSchema(u64)` → `u32`
+
+**New admin function — `register_metadata_schema`:**
+- Takes `version`, `description`, `schema_hash`
+- Validates: version > current max
+- Sets `DataKey::MetadataSchema(version) = schema`
+- Admin-only
+
+**New admin function — `set_active_metadata_schema`:**
+- Takes `version`
+- Validates: schema exists, transition is sequential
+- Sets `DataKey::MetadataSchemaVersion = version`
+
+**Modify `issue_credential` / `issue_inner`:**
+- After creating metadata, set `CredentialMetadataSchema(id) = current_active_version`
+
+**Modify `update_metadata` / `renew_credential_with_grace`:**
+- After updating metadata, set `CredentialMetadataSchema(id) = current_active_version`
+
+**New read function — `get_credential_metadata_schema`:**
+- Returns the schema version for a credential's metadata
+- Returns 0 for credentials issued before this feature
+
+### Phase 2: Migration System (~1.5 days)
+
+**New type:**
+
+```rust
+#[contracttype]
+#[derive(Clone)]
+pub struct MetadataMigration {
+    pub from_version: u32,
+    pub to_version: u32,
+    pub migrated_count: u32,  // credentials migrated in this batch
+    pub completed: bool,
+    pub started_at: u64,
+    pub completed_at: Option<u64>,
+}
+```
+
+**New function — `migrate_metadata_schema(to_version, start_id, end_id)`:**
+- Admin-only
+- Reads batch of credentials in ID range [start_id, end_id]
+- For each credential whose `CredentialMetadataSchema(id) < to_version`:
+  - Read `CredentialMetadataStore(id)`
+  - Apply migration transforms for each version gap
+  - Write transformed data back to `CredentialMetadataStore(id)`
+  - Set `CredentialMetadataSchema(id) = to_version`
+- Records a `MetadataMigration` entry for audit
+- Returns count of migrated credentials
+
+**Migration transform functions (extensible per version gap):**
+- `migrate_v1_to_v2(old_bytes) -> new_bytes`
+- `migrate_v2_to_v3(old_bytes) -> new_bytes`
+- Each function is a pure byte transformation + schema validation
+
+**Lazy migration helper — `resolve_metadata(credential_id)`:**
+- Called by `get_credential_metadata` and other read paths
+- If `CredentialMetadataSchema(id) < current_active_version`:
+  - Apply migration transforms in-memory (no storage write)
+  - Return transformed metadata
+- If schema matches current: return directly
+
+### Phase 3: Validation & Backward Compatibility (~1 day)
+
+**Per-schema validators:**
+
+```rust
+fn validate_metadata_v1(env: &Env, metadata: &Bytes) -> Result<(), ContractError>
+fn validate_metadata_v2(env: &Env, metadata: &Bytes) -> Result<(), ContractError>
+```
+
+Each validator checks:
+- Size bounds
+- Required field presence (if using structured format)
+- Encoding rules
+
+**Hooks in `set_credential_metadata`:**
+- Before writing, call `validate_metadata_V{current_version}(env, &metadata)`
+- Reject with `ContractError::InvalidInput` on failure
+
+**Backward compatibility guarantee:**
+- Old metadata bytes are never transformed on read unless explicitly requested
+- `get_credential_metadata` always returns the original bytes, regardless of schema version
+- A new `get_credential_metadata_v2` (or similar) returns the transformed/upgraded version
+- This means old readers continue to work unchanged
+
+### Phase 4: Metrics & Distribution (~0.5 day)
+
+**New read function — `get_metadata_schema_distribution`:**
+```rust
+pub fn get_metadata_schema_distribution(env: &Env) -> Map<u32, u32>
+```
+Scans a sample or full set of credentials and returns counts per schema version.
+
+**New event — `MetadataSchemaUpgraded`:**
+```rust
+env.events().publish(
+    ("MetadataSchemaUpgraded", admin, to_version),
+    (migrated_count,),
+);
+```
+
+**Integrate with existing metrics:**
+- The `MetadataMigration` record provides audit history
+- Schema version distribution is available via the read function
+
+---
+
+## Fastest Implementation Order
+
+| Step | Effort | What |
+|------|--------|------|
+| 1 | ~2h | Add `MetadataSchemaVersion`, `MetadataSchema(N)`, `CredentialMetadataSchema(id)` storage keys |
+| 2 | ~2h | Add `register_metadata_schema` + `set_active_metadata_schema` admin functions |
+| 3 | ~1h | Wire `CredentialMetadataSchema(id)` writes into `issue_credential`, `update_metadata`, `renew_credential_with_grace` |
+| 4 | ~1h | Register v1 schema on contract init (in `__constructor`) |
+| 5 | ~2h | Add `migrate_metadata_schema` batch function |
+| 6 | ~2h | Add `resolve_metadata` lazy migration helper |
+| 7 | ~2h | Add per-schema validators + validation hooks in `set_credential_metadata` |
+| 8 | ~1h | Add `get_metadata_schema_distribution` + events |
+
+**Total: ~13h of coding (~2 days)**
+
+### Where to start for maximum impact
+
+If you want the **fastest path to value**, skip lazy migration (step 6) and metrics (step 8) initially. Core changes (steps 1–5 + 7) give you:
+
+- Schema registry + version tracking
+- Admin-driven batch migration
+- Write-time validation
+- Full backward compatibility (old data is never rewritten)
+
+---
+
+## Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Schema version stored **per credential** | Yes (`CredentialMetadataSchema(id)`) | Enables gradual migration — credentials migrate individually |
+| Lazy migration rewrites storage? | No, only in-memory transform | Avoids gas cost on reads; storage migration is admin-triggered |
+| Validation on **write only** | Yes | Old metadata is presumed valid (it passed validation when written) |
+| Schema registry mutable? | Immutable (append-only) | Once registered, a schema version cannot be changed; only superseded |
+| Migration sequential? | Yes, `vN → vN+1` only | Each migration function is small and composable |
+| New storage under `DataKey2`? | Yes | Avoids disrupting existing `DataKey` layout |
+
+---
+
+## Testing Strategy
+
+| Test | What it covers |
+|------|---------------|
+| `test_register_schema` | Admin registers v1, v2; non-admin rejected |
+| `test_set_active_schema` | Activating sequential versions; invalid version rejected |
+| `test_new_credentials_use_active_schema` | Issued credential has correct `CredentialMetadataSchema` |
+| `test_updated_credentials_use_active_schema` | After metadata update, schema version updated |
+| `test_old_credentials_readable_v1` | Pre-migration credential still returns metadata |
+| `test_metadata_migration_batch` | Batch of credentials migrated from v1→v2, data verified |
+| `test_migration_preserves_data` | After migration, metadata content matches expected v2 format |
+| `test_metadata_validation_v1` | Invalid v1 metadata rejected on write |
+| `test_metadata_validation_v2` | Invalid v2 metadata rejected on write |
+| `test_lazy_resolve_old_schema` | Reading v1 credential returns correct v2-transformed data |
+| `test_schema_distribution` | Distribution counts correct after mixed migration |
+| `test_migration_performance` | Batch of 100 credentials migrated within gas limits |
+| `test_credential_version_independence` | `Credential.version` unchanged by schema migration |
+| `test_backward_compat_old_readers` | Old `get_credential_metadata` still works after migration |


### PR DESCRIPTION


Description
Closes #668 

Summary: Implements a credential metadata schema versioning system to prevent breaking changes when metadata formats evolve. Adds schema registration, per-credential version tracking, batch migration, lazy backward-compatible reads, and write-time validation.

New Types: MetadataSchema, MetadataMigration.

New Storage Keys:

DataKey::MetadataSchemaVersion

DataKey::MetadataSchema(u32)

DataKey2::CredentialMetadataSchema(u64)

DataKey2::MetadataSchemaMigration(u32)

New Contract Methods: register_metadata_schema, set_active_metadata_schema, get_active_metadata_schema_version, get_metadata_schema, get_credential_metadata_schema, migrate_metadata_schema, get_metadata_schema_distribution, resolve_credential_metadata.

Modified Functions: initialize, issue_inner, set_credential_metadata, update_metadata, renew_credential_with_grace.

Tests: 13 tests covering registration, activation, validation, migration, distribution, backward compatibility, and edge cases.