### PR TITLE
feat(api): add rate limiting and DDoS protection middleware

### DIFF
--- a/api-server/docs/ANALYTICS.md
+++ b/api-server/docs/ANALYTICS.md
@@ -246,10 +246,19 @@ Anomaly detection uses Z-score statistical analysis:
 
 ## Rate Limiting
 
-- **Window**: 60 seconds
-- **Max Requests**: 500 per client per window
-- **Client ID**: Based on IP address
-- **Response**: 429 status code when limit exceeded
+Rate limiting is applied globally via centralized middleware. All `/api/*` routes are protected.
+
+- **Window**: 60 seconds per window
+- **General Limit**: 100 requests per window per client
+- **Client Identification**: Uses `X-Stellar-Address` header for authenticated users, falls back to IP address
+- **Response Headers**:
+  - `X-RateLimit-Limit`: Maximum requests allowed in the window
+  - `X-RateLimit-Remaining`: Requests remaining in the current window
+  - `X-RateLimit-Reset`: Unix timestamp when the window resets
+  - `Retry-After`: Seconds to wait before retrying (when rate limited)
+- **Response**: 429 status code with JSON error body when limit exceeded
+- **Exponential Backoff**: Repeated violations double the wait time per offense (up to `maxViolations` threshold, after which the client is permanently blocked)
+- **DDoS Protection**: Additional layer with request body size limits (100 KB), burst detection (20 requests per 2s window per IP), and concurrent request limits (20 per IP)
 
 ## GDPR Compliance
 

--- a/api-server/docs/RATE_LIMITING.md
+++ b/api-server/docs/RATE_LIMITING.md
@@ -1,0 +1,112 @@
+# Rate Limiting and DDoS Protection
+
+## Overview
+
+Comprehensive rate limiting and DDoS protection for the QuorumProof API server, preventing abuse including credential brute-forcing, proof flooding, and resource exhaustion attacks.
+
+## Rate Limiting
+
+### Configuration
+
+Rate limiting is applied globally to all `/api/*` routes via centralized middleware.
+
+| Parameter | Default | Description |
+|---|---|---|
+| `windowMs` | 60000 (1 minute) | Duration of the rate limit window |
+| `max` | 100 | Maximum requests per window per client |
+| `backoffMultiplier` | 2 | Multiplier for exponential backoff duration |
+| `maxViolations` | 5 | Number of violations before permanent block |
+
+### Client Identification
+
+Clients are identified using a combined strategy:
+
+1. **Authenticated users**: If the `X-Stellar-Address` header is present, it is used as the client identifier. This prevents IP-based bypass techniques for wallet-authenticated users.
+2. **Anonymous users**: Falls back to the client IP address (`req.ip`), respecting `X-Forwarded-For` when `trust proxy` is enabled.
+
+### Rate Limit Headers
+
+Every API response includes the following headers:
+
+| Header | Description | Example |
+|---|---|---|
+| `X-RateLimit-Limit` | Maximum requests allowed in the window | `100` |
+| `X-RateLimit-Remaining` | Requests remaining in the current window | `87` |
+| `X-RateLimit-Reset` | Unix timestamp when the window resets | `1719300000` |
+| `Retry-After` | Seconds to wait before retrying (on 429 only) | `60` |
+
+### 429 Response Body
+
+```json
+{
+  "error": "Rate limit exceeded",
+  "message": "Too many requests. Limit: 100 per 60s. Retry after 60s.",
+  "retryAfter": 60,
+  "limit": 100,
+  "windowMs": 60000
+}
+```
+
+### Exponential Backoff
+
+When a client exceeds the rate limit, the violation is tracked across windows. Each subsequent violation results in a longer backoff period:
+
+- **1st violation**: `windowMs * 1` (e.g., 60s wait)
+- **2nd violation**: `windowMs * 2` (e.g., 120s wait)
+- **3rd violation**: `windowMs * 4` (e.g., 240s wait)
+- **Nth violation**: `windowMs * 2^(N-1)`
+
+After `maxViolations` (default: 5) violations, the client is permanently blocked until the server reset.
+
+### Testing
+
+```bash
+# Test rate limit headers
+curl -I http://localhost:3000/api/analytics/summary
+
+# Trigger rate limit (replace with your IP)
+for i in $(seq 1 101); do curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/api/slices; done | sort | uniq -c
+```
+
+## DDoS Protection
+
+### Request Body Size Limiting
+
+Requests with bodies exceeding 100 KB are rejected with HTTP 413 (Request Entity Too Large). This prevents memory exhaustion attacks via oversized payloads.
+
+### Burst Detection
+
+Rapid requests from the same IP within a short window are throttled:
+
+- **Window**: 2 seconds
+- **Max requests per window**: 20
+- **Action**: HTTP 429 with `"Request burst detected"` message
+
+### Concurrent Request Limiting
+
+Maximum concurrent requests per IP are capped at 20. Additional requests receive HTTP 429 with `"Too many concurrent requests"` message.
+
+## Programmatic Usage
+
+```typescript
+import { createRateLimiter } from './middleware/rateLimiter.js';
+import { createDDoSProtection } from './middleware/ddosProtection.js';
+
+// Custom rate limiter for sensitive endpoints (e.g., credential verification)
+const strictLimiter = createRateLimiter({
+  windowMs: 60000,
+  max: 20,
+  name: 'strict',
+  backoffMultiplier: 4,
+  maxViolations: 3,
+});
+
+// Apply to specific routes
+router.post('/verify-batch', strictLimiter, handler);
+```
+
+## Implementation Details
+
+- **Storage**: In-memory `Map` (per-server instance). Not shared across horizontal scale-out.
+- **Cleanup**: Entries are garbage-collected when windows expire. The `reset()` method clears all state (useful for testing).
+- **Key Functions**: `ipKey`, `userKey`, and `combinedKey` are exported for custom middleware composition.

--- a/api-server/src/index.ts
+++ b/api-server/src/index.ts
@@ -4,9 +4,29 @@ import slicesRouter from './routes/slices.js';
 import credentialsRouter from './routes/credentials.js';
 import notificationsRouter from './routes/notifications.js';
 import analyticsRouter from './routes/analytics.js';
+import { createRateLimiter } from './middleware/rateLimiter.js';
+import { createDDoSProtection } from './middleware/ddosProtection.js';
+import { createWsServer } from './ws/server.js';
+import { getConnectionCount, getSubscriberCount } from './ws/subscriptions.js';
+import { getWsMetrics } from './ws/metrics.js';
+import { broadcastEvent } from './ws/server.js';
 
 const app = express();
-app.use(express.json());
+
+const ddosProtection = createDDoSProtection();
+app.use(ddosProtection);
+
+app.use(express.json({ limit: '100kb' }));
+
+const apiRateLimiter = createRateLimiter({
+  windowMs: 60000,
+  max: 100,
+  name: 'api',
+  backoffMultiplier: 2,
+  maxViolations: 5,
+});
+
+app.use('/api', apiRateLimiter);
 
 app.use((req, _res, next) => {
   console.log(JSON.stringify({

--- a/api-server/src/middleware/ddosProtection.ts
+++ b/api-server/src/middleware/ddosProtection.ts
@@ -1,0 +1,85 @@
+import { Request, Response, NextFunction } from 'express';
+
+export interface DDoSProtectionConfig {
+  maxBodySize: number;
+  maxConcurrentPerIp: number;
+  burstWindowMs: number;
+  burstMaxRequests: number;
+}
+
+interface IpConnection {
+  count: number;
+  timestamps: number[];
+}
+
+const DEFAULT_CONFIG: DDoSProtectionConfig = {
+  maxBodySize: 100 * 1024,
+  maxConcurrentPerIp: 20,
+  burstWindowMs: 2000,
+  burstMaxRequests: 20,
+};
+
+export function createDDoSProtection(config?: Partial<DDoSProtectionConfig>) {
+  const opts = { ...DEFAULT_CONFIG, ...config };
+  const connections = new Map<string, IpConnection>();
+
+  function clientIp(req: Request): string {
+    return (req.ip ?? req.socket.remoteAddress ?? 'unknown');
+  }
+
+  function middleware(req: Request, res: Response, next: NextFunction): void {
+    const ip = clientIp(req);
+
+    const conn = connections.get(ip) ?? { count: 0, timestamps: [] };
+    conn.count++;
+    conn.timestamps.push(Date.now());
+    connections.set(ip, conn);
+
+    res.on('finish', () => {
+      const c = connections.get(ip);
+      if (c) {
+        c.count--;
+        if (c.count <= 0 && c.timestamps.length === 0) {
+          connections.delete(ip);
+        }
+      }
+    });
+
+    if (conn.count > opts.maxConcurrentPerIp) {
+      res.status(429).json({
+        error: 'Too many concurrent requests',
+        message: `Maximum ${opts.maxConcurrentPerIp} concurrent requests per IP allowed`,
+      });
+      return;
+    }
+
+    const now = Date.now();
+    const windowStart = now - opts.burstWindowMs;
+    while (conn.timestamps.length > 0 && conn.timestamps[0] < windowStart) {
+      conn.timestamps.shift();
+    }
+    if (conn.timestamps.length > opts.burstMaxRequests) {
+      res.status(429).json({
+        error: 'Request burst detected',
+        message: `Maximum ${opts.burstMaxRequests} requests per ${opts.burstWindowMs}ms allowed`,
+      });
+      return;
+    }
+
+    const contentLength = parseInt(req.headers['content-length'] ?? '0', 10);
+    if (!isNaN(contentLength) && contentLength > opts.maxBodySize) {
+      res.status(413).json({
+        error: 'Request entity too large',
+        message: `Maximum body size is ${opts.maxBodySize} bytes`,
+      });
+      return;
+    }
+
+    next();
+  }
+
+  middleware.reset = () => connections.clear();
+  middleware.connections = connections;
+
+  return middleware;
+}

--- a/api-server/src/middleware/rateLimiter.ts
+++ b/api-server/src/middleware/rateLimiter.ts
@@ -1,0 +1,135 @@
+import { Request, Response, NextFunction } from 'express';
+
+export interface RateLimitConfig {
+  windowMs: number;
+  max: number;
+  name: string;
+  backoffMultiplier: number;
+  maxViolations: number;
+}
+
+interface RateLimitEntry {
+  count: number;
+  windowResetTime: number;
+  violations: number;
+  backoffEndTime: number | null;
+  permanentlyBlocked: boolean;
+}
+
+export type KeyFn = (req: Request) => string;
+
+function clientIp(req: Request): string {
+  return (req.ip ?? req.socket.remoteAddress ?? 'unknown');
+}
+
+export function ipKey(req: Request): string {
+  return `ip:${clientIp(req)}`;
+}
+
+export function userKey(req: Request): string | null {
+  const addr = req.headers['x-stellar-address'];
+  if (typeof addr === 'string' && addr.length > 0) {
+    return `user:${addr}`;
+  }
+  return null;
+}
+
+export function combinedKey(req: Request): string {
+  const user = userKey(req);
+  if (user) return user;
+  return ipKey(req);
+}
+
+interface CheckResult {
+  allowed: boolean;
+  remaining: number;
+  resetTime: number;
+  retryAfter: number | undefined;
+}
+
+export function createRateLimiter(config: RateLimitConfig, keyFn: KeyFn = combinedKey) {
+  const store = new Map<string, RateLimitEntry>();
+
+  function check(key: string): CheckResult {
+    const now = Date.now();
+    let entry = store.get(key);
+
+    if (!entry) {
+      entry = {
+        count: 1,
+        windowResetTime: now + config.windowMs,
+        violations: 0,
+        backoffEndTime: null,
+        permanentlyBlocked: false,
+      };
+      store.set(key, entry);
+      return { allowed: true, remaining: config.max - 1, resetTime: entry.windowResetTime, retryAfter: undefined };
+    }
+
+    if (entry.permanentlyBlocked) {
+      return { allowed: false, remaining: 0, resetTime: Date.now() + 3600000, retryAfter: 3600 };
+    }
+
+    // If in backoff and still within backoff period
+    if (entry.backoffEndTime !== null && now < entry.backoffEndTime) {
+      const retryAfter = Math.ceil((entry.backoffEndTime - now) / 1000);
+      return { allowed: false, remaining: 0, resetTime: entry.backoffEndTime, retryAfter };
+    }
+
+    // Backoff expired or no backoff - check if window expired
+    if (now >= entry.windowResetTime) {
+      entry.count = 0;
+      entry.windowResetTime = now + config.windowMs;
+      entry.backoffEndTime = null;
+    }
+
+    entry.count++;
+
+    if (entry.count > config.max) {
+      entry.violations++;
+
+      if (entry.violations >= config.maxViolations) {
+        entry.permanentlyBlocked = true;
+        return { allowed: false, remaining: 0, resetTime: Date.now() + 3600000, retryAfter: 3600 };
+      }
+
+      const backoffMs = config.windowMs * Math.pow(config.backoffMultiplier, entry.violations - 1);
+      entry.backoffEndTime = now + backoffMs;
+      const retryAfter = Math.ceil(backoffMs / 1000);
+
+      return { allowed: false, remaining: 0, resetTime: entry.backoffEndTime, retryAfter };
+    }
+
+    return { allowed: true, remaining: config.max - entry.count, resetTime: entry.windowResetTime, retryAfter: undefined };
+  }
+
+  const middleware = (req: Request, res: Response, next: NextFunction): void => {
+    const key = keyFn(req);
+    const result = check(key);
+
+    res.setHeader('X-RateLimit-Limit', String(config.max));
+    res.setHeader('X-RateLimit-Remaining', String(result.remaining));
+    res.setHeader('X-RateLimit-Reset', String(Math.ceil(result.resetTime / 1000)));
+
+    if (!result.allowed) {
+      if (result.retryAfter !== undefined) {
+        res.setHeader('Retry-After', String(result.retryAfter));
+      }
+      res.status(429).json({
+        error: 'Rate limit exceeded',
+        message: `Too many requests. Limit: ${config.max} per ${config.windowMs / 1000}s.${result.retryAfter ? ` Retry after ${result.retryAfter}s.` : ''}`,
+        retryAfter: result.retryAfter,
+        limit: config.max,
+        windowMs: config.windowMs,
+      });
+      return;
+    }
+
+    next();
+  };
+
+  middleware.reset = () => store.clear();
+  middleware.store = store;
+
+  return middleware;
+}

--- a/api-server/src/routes/analytics.ts
+++ b/api-server/src/routes/analytics.ts
@@ -13,41 +13,10 @@ type SorobanClient = {
   addressVal: (a: string) => unknown;
 };
 
-const RATE_LIMIT_WINDOW = 60000; // 1 minute
-const RATE_LIMIT_MAX_REQUESTS = 500; // Increased for test compatibility
-const rateLimitMap = new Map<string, { count: number; resetTime: number }>();
-
-function checkRateLimit(clientId: string): boolean {
-  const now = Date.now();
-  const entry = rateLimitMap.get(clientId);
-
-  if (!entry || now > entry.resetTime) {
-    rateLimitMap.set(clientId, { count: 1, resetTime: now + RATE_LIMIT_WINDOW });
-    return true;
-  }
-
-  if (entry.count >= RATE_LIMIT_MAX_REQUESTS) {
-    return false;
-  }
-
-  entry.count++;
-  return true;
-}
-
-function getClientId(req: Request): string {
-  return req.ip || 'unknown';
-}
-
 export function createAnalyticsRouter(soroban: SorobanClient) {
   const router = Router();
 
   router.post('/events', (req: Request, res: Response) => {
-    const clientId = getClientId(req);
-    if (!checkRateLimit(clientId)) {
-      res.status(429).json({ error: 'Rate limit exceeded' });
-      return;
-    }
-
     const event: CredentialEvent = req.body;
 
     if (!event.type || !event.credential_id || !event.timestamp) {
@@ -65,12 +34,6 @@ export function createAnalyticsRouter(soroban: SorobanClient) {
   });
 
   router.get('/metrics', (req: Request, res: Response) => {
-    const clientId = getClientId(req);
-    if (!checkRateLimit(clientId)) {
-      res.status(429).json({ error: 'Rate limit exceeded' });
-      return;
-    }
-
     const startDate = (req.query.start_date as string) || getDateDaysAgo(90);
     const endDate = (req.query.end_date as string) || new Date().toISOString().split('T')[0];
 
@@ -93,12 +56,6 @@ export function createAnalyticsRouter(soroban: SorobanClient) {
   });
 
   router.get('/anomalies', (req: Request, res: Response) => {
-    const clientId = getClientId(req);
-    if (!checkRateLimit(clientId)) {
-      res.status(429).json({ error: 'Rate limit exceeded' });
-      return;
-    }
-
     const startDate = (req.query.start_date as string) || getDateDaysAgo(30);
     const endDate = (req.query.end_date as string) || new Date().toISOString().split('T')[0];
 
@@ -126,12 +83,6 @@ export function createAnalyticsRouter(soroban: SorobanClient) {
   });
 
   router.get('/events', (req: Request, res: Response) => {
-    const clientId = getClientId(req);
-    if (!checkRateLimit(clientId)) {
-      res.status(429).json({ error: 'Rate limit exceeded' });
-      return;
-    }
-
     const startDateParam = (req.query.start_date as string) || getDateDaysAgo(7);
     const endDateParam = (req.query.end_date as string) || new Date().toISOString();
     const eventType = req.query.type as string | undefined;
@@ -161,12 +112,6 @@ export function createAnalyticsRouter(soroban: SorobanClient) {
   });
 
   router.get('/summary', (req: Request, res: Response) => {
-    const clientId = getClientId(req);
-    if (!checkRateLimit(clientId)) {
-      res.status(429).json({ error: 'Rate limit exceeded' });
-      return;
-    }
-
     const summary = metricsStore.getSummary();
     res.json({
       ...summary,

--- a/api-server/tests/ddosProtection.test.ts
+++ b/api-server/tests/ddosProtection.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createDDoSProtection } from '../src/middleware/ddosProtection.js';
+
+function createTestApp(ddos: ReturnType<typeof createDDoSProtection>) {
+  const app = express();
+  app.set('trust proxy', true);
+  app.use(ddos);
+  app.use(express.json({ limit: '1mb' }));
+  app.get('/api/test', (_req, res) => res.json({ ok: true }));
+  app.post('/api/test', (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+describe('DDoS Protection Middleware', () => {
+  describe('body size limit', () => {
+    it('blocks requests with body exceeding maxBodySize', async () => {
+      const ddos = createDDoSProtection({ maxBodySize: 100, maxConcurrentPerIp: 100, burstWindowMs: 60000, burstMaxRequests: 1000 });
+      const app = createTestApp(ddos);
+
+      const res = await request(app)
+        .post('/api/test')
+        .send({ data: 'x'.repeat(200) });
+
+      expect(res.status).toBe(413);
+      expect(res.body.error).toBe('Request entity too large');
+    });
+
+    it('allows requests within body size limit', async () => {
+      const ddos = createDDoSProtection({ maxBodySize: 1000, maxConcurrentPerIp: 100, burstWindowMs: 60000, burstMaxRequests: 1000 });
+      const app = createTestApp(ddos);
+
+      const res = await request(app)
+        .post('/api/test')
+        .send({ data: 'small' });
+
+      expect(res.status).toBe(200);
+    });
+
+    it('allows GET requests regardless of body', async () => {
+      const ddos = createDDoSProtection({ maxBodySize: 10, maxConcurrentPerIp: 100, burstWindowMs: 60000, burstMaxRequests: 1000 });
+      const app = createTestApp(ddos);
+
+      const res = await request(app).get('/api/test');
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('concurrent request limit', () => {
+    it('tracks connections via store', async () => {
+      const ddos = createDDoSProtection({ maxBodySize: 100000, maxConcurrentPerIp: 5, burstWindowMs: 60000, burstMaxRequests: 1000 });
+      const app = createTestApp(ddos);
+
+      const res = await request(app).get('/api/test').set('X-Forwarded-For', '1.1.1.1');
+      expect(res.status).toBe(200);
+
+      const conns = ddos.connections.get('1.1.1.1');
+      expect(conns).toBeDefined();
+    });
+
+    it('blocks when maxConcurrentPerIp is exceeded using slow handler', async () => {
+      const ddos = createDDoSProtection({ maxBodySize: 100000, maxConcurrentPerIp: 2, burstWindowMs: 60000, burstMaxRequests: 1000 });
+      const slowApp = express();
+      slowApp.set('trust proxy', true);
+      slowApp.use(ddos);
+      slowApp.get('/api/slow', (_req, res) => {
+        setTimeout(() => res.json({ ok: true }), 200);
+      });
+
+      const promises = [];
+      for (let i = 0; i < 5; i++) {
+        promises.push(request(slowApp).get('/api/slow').set('X-Forwarded-For', '1.1.1.1'));
+      }
+
+      const results = await Promise.all(promises);
+      const blocked = results.filter(r => r.status === 429);
+      expect(blocked.length).toBeGreaterThan(0);
+      expect(blocked[0].body.error).toBe('Too many concurrent requests');
+    }, 10000);
+  });
+
+  describe('burst detection', () => {
+    it('blocks rapid requests from the same IP', async () => {
+      const ddos = createDDoSProtection({ maxBodySize: 100000, maxConcurrentPerIp: 100, burstWindowMs: 2000, burstMaxRequests: 3 });
+      const app = createTestApp(ddos);
+
+      for (let i = 0; i < 3; i++) {
+        const res = await request(app).get('/api/test').set('X-Forwarded-For', '1.1.1.1');
+        expect(res.status).toBe(200);
+      }
+
+      const res = await request(app).get('/api/test').set('X-Forwarded-For', '1.1.1.1');
+      expect(res.status).toBe(429);
+      expect(res.body.error).toBe('Request burst detected');
+    });
+
+    it('allows burst from different IPs', async () => {
+      const ddos = createDDoSProtection({ maxBodySize: 100000, maxConcurrentPerIp: 100, burstWindowMs: 2000, burstMaxRequests: 3 });
+      const app = createTestApp(ddos);
+
+      for (let i = 0; i < 3; i++) {
+        const res = await request(app).get('/api/test').set('X-Forwarded-For', `${i}.${i}.${i}.${i}`);
+        expect(res.status).toBe(200);
+      }
+
+      for (let i = 0; i < 3; i++) {
+        const res = await request(app).get('/api/test').set('X-Forwarded-For', `${i}.${i}.${i}.${i}`);
+        expect(res.status).toBe(200);
+      }
+    });
+
+    it('resets burst window after time passes', async () => {
+      const ddos = createDDoSProtection({ maxBodySize: 100000, maxConcurrentPerIp: 100, burstWindowMs: 200, burstMaxRequests: 3 });
+      const app = createTestApp(ddos);
+
+      for (let i = 0; i < 3; i++) {
+        const res = await request(app).get('/api/test').set('X-Forwarded-For', '1.1.1.1');
+        expect(res.status).toBe(200);
+      }
+
+      let res = await request(app).get('/api/test').set('X-Forwarded-For', '1.1.1.1');
+      expect(res.status).toBe(429);
+
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      res = await request(app).get('/api/test').set('X-Forwarded-For', '1.1.1.1');
+      expect(res.status).toBe(200);
+    }, 10000);
+  });
+
+  describe('reset', () => {
+    it('reset clears all connection state', async () => {
+      const ddos = createDDoSProtection({ maxBodySize: 100000, maxConcurrentPerIp: 100, burstWindowMs: 2000, burstMaxRequests: 3 });
+      const app = createTestApp(ddos);
+
+      for (let i = 0; i < 3; i++) {
+        await request(app).get('/api/test').set('X-Forwarded-For', '1.1.1.1');
+      }
+
+      let res = await request(app).get('/api/test').set('X-Forwarded-For', '1.1.1.1');
+      expect(res.status).toBe(429);
+
+      ddos.reset();
+
+      res = await request(app).get('/api/test').set('X-Forwarded-For', '1.1.1.1');
+      expect(res.status).toBe(200);
+    });
+  });
+});

--- a/api-server/tests/rateLimiter.test.ts
+++ b/api-server/tests/rateLimiter.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createRateLimiter, ipKey, userKey, combinedKey } from '../src/middleware/rateLimiter.js';
+
+function createTestApp(rateLimiter: ReturnType<typeof createRateLimiter>) {
+  const app = express();
+  app.set('trust proxy', true);
+  app.use(express.json());
+  app.use('/api', rateLimiter);
+  app.get('/api/test', (_req, res) => res.json({ ok: true }));
+  app.post('/api/test', (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+describe('Rate Limiter Middleware', () => {
+  describe('rate limit enforcement', () => {
+    it('allows requests under the limit', async () => {
+      const limiter = createRateLimiter({ windowMs: 60000, max: 5, name: 'test', backoffMultiplier: 2, maxViolations: 3 });
+      const app = createTestApp(limiter);
+
+      for (let i = 0; i < 5; i++) {
+        const res = await request(app).get('/api/test');
+        expect(res.status).toBe(200);
+      }
+    });
+
+    it('blocks requests exceeding the limit', async () => {
+      const limiter = createRateLimiter({ windowMs: 60000, max: 2, name: 'test', backoffMultiplier: 2, maxViolations: 3 });
+      const app = createTestApp(limiter);
+
+      const res1 = await request(app).get('/api/test');
+      expect(res1.status).toBe(200);
+
+      const res2 = await request(app).get('/api/test');
+      expect(res2.status).toBe(200);
+
+      const res3 = await request(app).get('/api/test');
+      expect(res3.status).toBe(429);
+      expect(res3.body.error).toBe('Rate limit exceeded');
+    });
+
+    it('returns 429 with proper error message', async () => {
+      const limiter = createRateLimiter({ windowMs: 60000, max: 1, name: 'test', backoffMultiplier: 2, maxViolations: 3 });
+      const app = createTestApp(limiter);
+
+      await request(app).get('/api/test');
+      const res = await request(app).get('/api/test');
+
+      expect(res.status).toBe(429);
+      expect(res.body.error).toBe('Rate limit exceeded');
+      expect(res.body.limit).toBe(1);
+      expect(res.body.windowMs).toBe(60000);
+    });
+  });
+
+  describe('rate limit headers', () => {
+    it('includes X-RateLimit-Limit header', async () => {
+      const limiter = createRateLimiter({ windowMs: 60000, max: 10, name: 'test', backoffMultiplier: 2, maxViolations: 3 });
+      const app = createTestApp(limiter);
+
+      const res = await request(app).get('/api/test');
+      expect(res.headers['x-ratelimit-limit']).toBe('10');
+    });
+
+    it('includes X-RateLimit-Remaining header', async () => {
+      const limiter = createRateLimiter({ windowMs: 60000, max: 10, name: 'test', backoffMultiplier: 2, maxViolations: 3 });
+      const app = createTestApp(limiter);
+
+      const res1 = await request(app).get('/api/test');
+      expect(res1.headers['x-ratelimit-remaining']).toBe('9');
+
+      const res2 = await request(app).get('/api/test');
+      expect(res2.headers['x-ratelimit-remaining']).toBe('8');
+    });
+
+    it('includes X-RateLimit-Reset header as unix timestamp', async () => {
+      const limiter = createRateLimiter({ windowMs: 60000, max: 10, name: 'test', backoffMultiplier: 2, maxViolations: 3 });
+      const app = createTestApp(limiter);
+
+      const res = await request(app).get('/api/test');
+      const reset = parseInt(res.headers['x-ratelimit-reset'] as string, 10);
+      const now = Math.floor(Date.now() / 1000);
+      expect(reset).toBeGreaterThanOrEqual(now);
+      expect(reset).toBeLessThanOrEqual(now + 61);
+    });
+
+    it('includes Retry-After header when rate limited', async () => {
+      const limiter = createRateLimiter({ windowMs: 60000, max: 1, name: 'test', backoffMultiplier: 2, maxViolations: 3 });
+      const app = createTestApp(limiter);
+
+      await request(app).get('/api/test');
+      const res = await request(app).get('/api/test');
+
+      expect(res.status).toBe(429);
+      expect(res.headers['retry-after']).toBeDefined();
+      expect(parseInt(res.headers['retry-after'] as string, 10)).toBeGreaterThan(0);
+    });
+  });
+
+  describe('per-IP rate limiting', () => {
+    it('tracks different IPs separately', async () => {
+      const limiter = createRateLimiter({ windowMs: 60000, max: 2, name: 'test', backoffMultiplier: 2, maxViolations: 3 });
+      const app = createTestApp(limiter);
+
+      const res1 = await request(app).get('/api/test').set('X-Forwarded-For', '1.1.1.1');
+      expect(res1.status).toBe(200);
+
+      const res2 = await request(app).get('/api/test').set('X-Forwarded-For', '2.2.2.2');
+      expect(res2.status).toBe(200);
+
+      const res3 = await request(app).get('/api/test').set('X-Forwarded-For', '1.1.1.1');
+      expect(res3.status).toBe(200);
+
+      const res4 = await request(app).get('/api/test').set('X-Forwarded-For', '2.2.2.2');
+      expect(res4.status).toBe(200);
+
+      const res5 = await request(app).get('/api/test').set('X-Forwarded-For', '1.1.1.1');
+      expect(res5.status).toBe(429);
+
+      const res6 = await request(app).get('/api/test').set('X-Forwarded-For', '2.2.2.2');
+      expect(res6.status).toBe(429);
+    });
+  });
+
+  describe('per-user rate limiting', () => {
+    it('uses X-Stellar-Address header for user-based limits', async () => {
+      const limiter = createRateLimiter({ windowMs: 60000, max: 2, name: 'test', backoffMultiplier: 2, maxViolations: 3 });
+      const app = createTestApp(limiter);
+
+      const res1 = await request(app).get('/api/test').set('X-Stellar-Address', 'GAUSER1');
+      expect(res1.status).toBe(200);
+
+      const res2 = await request(app).get('/api/test').set('X-Stellar-Address', 'GAUSER2');
+      expect(res2.status).toBe(200);
+
+      const res3 = await request(app).get('/api/test').set('X-Stellar-Address', 'GAUSER1');
+      expect(res3.status).toBe(200);
+
+      const res4 = await request(app).get('/api/test').set('X-Stellar-Address', 'GAUSER1');
+      expect(res4.status).toBe(429);
+
+      const res5 = await request(app).get('/api/test').set('X-Stellar-Address', 'GAUSER2');
+      expect(res5.status).toBe(200);
+    });
+
+    it('prioritizes user-based key over IP when X-Stellar-Address is present', async () => {
+      const limiter = createRateLimiter({ windowMs: 60000, max: 1, name: 'test', backoffMultiplier: 2, maxViolations: 3 });
+      const app = createTestApp(limiter);
+
+      const res = await request(app)
+        .get('/api/test')
+        .set('X-Stellar-Address', 'GAUSER')
+        .set('X-Forwarded-For', '1.1.1.1');
+      expect(res.status).toBe(200);
+
+      const res2 = await request(app)
+        .get('/api/test')
+        .set('X-Stellar-Address', 'GAUSER')
+        .set('X-Forwarded-For', '2.2.2.2');
+      expect(res2.status).toBe(429);
+    });
+  });
+
+  describe('exponential backoff', () => {
+    it('increases wait time after repeated violations', async () => {
+      const limiter = createRateLimiter({ windowMs: 100, max: 1, name: 'test', backoffMultiplier: 2, maxViolations: 5 });
+      const app = createTestApp(limiter);
+
+      // Use up the limit
+      await request(app).get('/api/test');
+
+      // First violation: backoff is windowMs * 2^0 = 100ms -> Retry-After is at least 1s
+      const res1 = await request(app).get('/api/test');
+      expect(res1.status).toBe(429);
+      const retryAfter1 = parseInt(res1.headers['retry-after'] as string, 10);
+      // Retry-After is in seconds (integer), so 100ms rounds up to 1
+      expect(retryAfter1).toBe(1);
+
+      // Wait for backoff to expire
+      await new Promise(resolve => setTimeout(resolve, 200));
+
+      // Use up limit again
+      await request(app).get('/api/test');
+
+      // Second violation: backoff should be windowMs * 2^1 = 200ms -> 1s (ceil(0.2))
+      const res2 = await request(app).get('/api/test');
+      expect(res2.status).toBe(429);
+      const retryAfter2 = parseInt(res2.headers['retry-after'] as string, 10);
+      expect(retryAfter2).toBe(1);
+
+      // With such small windows, both round to 1, but the backoff duration doubles
+      expect(retryAfter2).toBeGreaterThanOrEqual(retryAfter1);
+    }, 10000);
+
+    it('allows requests again after backoff period expires', async () => {
+      const limiter = createRateLimiter({ windowMs: 50, max: 1, name: 'test', backoffMultiplier: 1, maxViolations: 5 });
+      const app = createTestApp(limiter);
+
+      await request(app).get('/api/test');
+
+      const blocked = await request(app).get('/api/test');
+      expect(blocked.status).toBe(429);
+
+      await new Promise(resolve => setTimeout(resolve, 150));
+
+      const allowed = await request(app).get('/api/test');
+      expect(allowed.status).toBe(200);
+    }, 10000);
+  });
+
+  describe('key functions', () => {
+    it('ipKey returns ip-based key', () => {
+      const req = { ip: '1.2.3.4', socket: { remoteAddress: '5.6.7.8' }, headers: {} } as any;
+      expect(ipKey(req)).toBe('ip:1.2.3.4');
+    });
+
+    it('ipKey falls back to remoteAddress', () => {
+      const req = { ip: undefined, socket: { remoteAddress: '5.6.7.8' }, headers: {} } as any;
+      expect(ipKey(req)).toBe('ip:5.6.7.8');
+    });
+
+    it('userKey returns null when header missing', () => {
+      const req = { headers: {} } as any;
+      expect(userKey(req)).toBeNull();
+    });
+
+    it('userKey returns user key when header present', () => {
+      const req = { headers: { 'x-stellar-address': 'GAABCD' } } as any;
+      expect(userKey(req)).toBe('user:GAABCD');
+    });
+
+    it('combinedKey uses user key when header present', () => {
+      const req = { ip: '1.2.3.4', socket: {}, headers: { 'x-stellar-address': 'GAABCD' } } as any;
+      expect(combinedKey(req)).toBe('user:GAABCD');
+    });
+
+    it('combinedKey falls back to IP when no user header', () => {
+      const req = { ip: '1.2.3.4', socket: {}, headers: {} } as any;
+      expect(combinedKey(req)).toBe('ip:1.2.3.4');
+    });
+  });
+
+  describe('reset', () => {
+    it('reset clears all rate limit state', async () => {
+      const limiter = createRateLimiter({ windowMs: 60000, max: 1, name: 'test', backoffMultiplier: 2, maxViolations: 3 });
+      const app = createTestApp(limiter);
+
+      await request(app).get('/api/test');
+      const blocked = await request(app).get('/api/test');
+      expect(blocked.status).toBe(429);
+
+      limiter.reset();
+
+      const allowed = await request(app).get('/api/test');
+      expect(allowed.status).toBe(200);
+    });
+  });
+
+  describe('custom configuration', () => {
+    it('respects custom windowMs and max values', async () => {
+      const limiter = createRateLimiter({ windowMs: 5000, max: 3, name: 'test', backoffMultiplier: 2, maxViolations: 3 });
+      const app = createTestApp(limiter);
+
+      for (let i = 0; i < 3; i++) {
+        const res = await request(app).get('/api/test');
+        expect(res.status).toBe(200);
+        expect(res.headers['x-ratelimit-limit']).toBe('3');
+      }
+
+      const res = await request(app).get('/api/test');
+      expect(res.status).toBe(429);
+    });
+
+    it('applies to POST requests', async () => {
+      const limiter = createRateLimiter({ windowMs: 60000, max: 1, name: 'test', backoffMultiplier: 2, maxViolations: 3 });
+      const app = createTestApp(limiter);
+
+      const res1 = await request(app).post('/api/test').send({});
+      expect(res1.status).toBe(200);
+
+      const res2 = await request(app).post('/api/test').send({});
+      expect(res2.status).toBe(429);
+    });
+  });
+
+  describe('bypass prevention', () => {
+    it('does not bypass with different X-Forwarded-For when using user key', async () => {
+      const limiter = createRateLimiter({ windowMs: 60000, max: 1, name: 'test', backoffMultiplier: 2, maxViolations: 3 });
+      const app = createTestApp(limiter);
+
+      const res1 = await request(app)
+        .get('/api/test')
+        .set('X-Stellar-Address', 'GAUSER')
+        .set('X-Forwarded-For', '1.1.1.1');
+      expect(res1.status).toBe(200);
+
+      const res2 = await request(app)
+        .get('/api/test')
+        .set('X-Stellar-Address', 'GAUSER')
+        .set('X-Forwarded-For', '2.2.2.2');
+      expect(res2.status).toBe(429);
+    });
+
+    it('prevents using different user agents to bypass IP limits', async () => {
+      const limiter = createRateLimiter({ windowMs: 60000, max: 2, name: 'test', backoffMultiplier: 2, maxViolations: 3 });
+      const app = createTestApp(limiter);
+
+      for (let i = 0; i < 2; i++) {
+        const res = await request(app)
+          .get('/api/test')
+          .set('User-Agent', `UA-${i}`);
+        expect(res.status).toBe(200);
+      }
+
+      const res = await request(app)
+        .get('/api/test')
+        .set('User-Agent', 'UA-different');
+      expect(res.status).toBe(429);
+    });
+  });
+
+  describe('permanent block after maxViolations', () => {
+    it('permanently blocks after maxViolations violations', async () => {
+      const limiter = createRateLimiter({ windowMs: 50, max: 1, name: 'test', backoffMultiplier: 2, maxViolations: 3 });
+      const app = createTestApp(limiter);
+
+      // Violation 1: exceed limit once
+      await request(app).get('/api/test');
+      let res = await request(app).get('/api/test');
+      expect(res.status).toBe(429);
+
+      // Wait for backoff to expire
+      await new Promise(resolve => setTimeout(resolve, 200));
+
+      // Violation 2: exceed limit again  
+      await request(app).get('/api/test');
+      res = await request(app).get('/api/test');
+      expect(res.status).toBe(429);
+
+      // Wait for longer backoff to expire
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      // Violation 3: exceed limit again - should trigger permanent block
+      await request(app).get('/api/test');
+      res = await request(app).get('/api/test');
+      expect(res.status).toBe(429);
+
+      // Wait a long time - should still be blocked
+      await new Promise(resolve => setTimeout(resolve, 500));
+
+      res = await request(app).get('/api/test');
+      expect(res.status).toBe(429);
+    }, 20000);
+  });
+});


### PR DESCRIPTION
Implements comprehensive rate limiting across all /api/* endpoints:
- Per-IP rate limits (default 100 req/min)
- Per-user rate limits via X-Stellar-Address header
- Exponential backoff for repeated violations
- Permanent block after maxViolations threshold
- Rate limit headers (X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After)

DDoS protection layer with:
- Request body size limiting (100 KB)
- Burst detection (20 req/2s per IP)
- Concurrent request capping (20 per IP)

Closes #665