### PR TITLE
W3C DID Support, DID-aware Batch Issuance, Video Scripts, and ADR-004

### DIFF
--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -4463,6 +4463,186 @@ impl QuorumProofContract {
         BatchResult::Ok(ids)
     }
 
+    /// Issue credentials to DID-identified subjects in a single batch call.
+    ///
+    /// This function resolves each DID to its corresponding Stellar address
+    /// and issues credentials atomically. All DIDs must be active and registered.
+    ///
+    /// # Parameters
+    /// - `issuer`: The address issuing all credentials; must authorize this call.
+    /// - `subject_dids`: Ordered list of subject DIDs (one per credential).
+    /// - `credential_types`: Ordered list of credential type IDs, one per subject.
+    /// - `metadata_hashes`: Ordered list of metadata hashes, one per subject.
+    /// - `expires_at`: Optional shared expiry timestamp applied to all issued credentials.
+    ///
+    /// # Returns
+    /// `BatchResult::Ok(Vec<u64>)` on success, `BatchResult::Err(BatchError)` on failure.
+    pub fn issue_batch_by_did(
+        env: Env,
+        issuer: Address,
+        subject_dids: Vec<soroban_sdk::String>,
+        credential_types: Vec<u32>,
+        metadata_hashes: Vec<soroban_sdk::Bytes>,
+        expires_at: Option<u64>,
+    ) -> BatchResult {
+        issuer.require_auth();
+        Self::require_not_paused(&env);
+
+        let batch_len = subject_dids.len() as u32;
+        if batch_len == 0 {
+            return BatchResult::Ok(Vec::new(&env));
+        }
+        Self::validate_array_bounds(batch_len, 1, MAX_BATCH_SIZE, "subject_dids");
+        assert!(
+            credential_types.len() == batch_len && metadata_hashes.len() == batch_len,
+            "input lengths must match"
+        );
+
+        // Pre-validation: resolve all DIDs before issuing any credentials
+        let mut resolved: Vec<Address> = Vec::new(&env);
+        for i in 0..batch_len {
+            let did = subject_dids.get(i).unwrap();
+            let did_bytes = did.into_bytes();
+            let doc: DidDocument = match env.storage().instance().get(&DataKey7::DidDocument(did_bytes)) {
+                Some(d) => d,
+                None => {
+                    let reason = soroban_sdk::String::from_str(&env, "DID not found");
+                    return BatchResult::Err(BatchError { failing_index: i, reason });
+                }
+            };
+            if !doc.active {
+                let reason = soroban_sdk::String::from_str(&env, "DID is deactivated");
+                return BatchResult::Err(BatchError { failing_index: i, reason });
+            }
+            resolved.push_back(doc.address);
+        }
+
+        // Build CredentialInput vector from resolved addresses
+        let mut credentials: Vec<CredentialInput> = Vec::new(&env);
+        for i in 0..batch_len {
+            let input = CredentialInput {
+                subject: resolved.get(i).unwrap(),
+                credential_type: credential_types.get(i).unwrap(),
+                metadata_hash: metadata_hashes.get(i).unwrap(),
+                expires_at: expires_at.clone(),
+            };
+            credentials.push_back(input);
+        }
+
+        // Delegate to the existing atomically validated batch issuer
+        Self::issue_batch_with_credentials(&env, issuer, credentials)
+    }
+
+    /// Internal: validates and issues a pre-built CredentialInput vector atomically.
+    fn issue_batch_with_credentials(
+        env: &Env,
+        issuer: Address,
+        credentials: Vec<CredentialInput>,
+    ) -> BatchResult {
+        let batch_len = credentials.len() as u32;
+
+        // Pre-validation phase
+        for i in 0..batch_len {
+            let cred_input = credentials.get(i).unwrap();
+
+            if cred_input.credential_type == 0 {
+                let reason = soroban_sdk::String::from_str(env, "credential_type must be greater than 0");
+                return BatchResult::Err(BatchError { failing_index: i, reason });
+            }
+            if cred_input.metadata_hash.is_empty() {
+                let reason = soroban_sdk::String::from_str(env, "metadata_hash cannot be empty");
+                return BatchResult::Err(BatchError { failing_index: i, reason });
+            }
+            if cred_input.metadata_hash.len() > MAX_METADATA_SIZE {
+                let reason = soroban_sdk::String::from_str(env, "metadata_hash exceeds max size");
+                return BatchResult::Err(BatchError { failing_index: i, reason });
+            }
+
+            let duplicate_key = DataKey::SubjectIssuerType(
+                cred_input.subject.clone(),
+                issuer.clone(),
+                cred_input.credential_type,
+            );
+            if env.storage().instance().has(&duplicate_key) {
+                let reason = soroban_sdk::String::from_str(env, "duplicate credential type for this subject");
+                return BatchResult::Err(BatchError { failing_index: i, reason });
+            }
+
+            if env
+                .storage()
+                .instance()
+                .has(&DataKey2::BlacklistEntry(issuer.clone(), cred_input.subject.clone()))
+            {
+                let reason = soroban_sdk::String::from_str(env, "subject is blacklisted by this issuer");
+                return BatchResult::Err(BatchError { failing_index: i, reason });
+            }
+
+            for j in 0..i {
+                let other = credentials.get(j).unwrap();
+                if cred_input.subject == other.subject
+                    && cred_input.credential_type == other.credential_type
+                {
+                    let reason = soroban_sdk::String::from_str(env, "duplicate within batch");
+                    return BatchResult::Err(BatchError { failing_index: i, reason });
+                }
+            }
+        }
+
+        // Issue all credentials
+        let mut ids: Vec<u64> = Vec::new(env);
+        for i in 0..batch_len {
+            let cred_input = credentials.get(i).unwrap();
+            let id = Self::issue_inner(
+                env,
+                issuer.clone(),
+                cred_input.subject.clone(),
+                cred_input.credential_type,
+                cred_input.metadata_hash.clone(),
+                cred_input.expires_at,
+            );
+
+            let duplicate_key = DataKey::SubjectIssuerType(
+                cred_input.subject.clone(),
+                issuer.clone(),
+                cred_input.credential_type,
+            );
+            env.storage().instance().set(&duplicate_key, &id);
+            env.storage().instance().extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+
+            ids.push_back(id);
+        }
+
+        BatchResult::Ok(ids)
+    }
+
+    /// Issue credentials to multiple subjects identified by DIDs.
+    ///
+    /// Simpler interface: resolves DIDs, issues credentials, returns IDs.
+    /// Reverts on any failure (panics).
+    pub fn batch_issue_credentials_by_did(
+        env: Env,
+        issuer: Address,
+        subject_dids: Vec<soroban_sdk::String>,
+        credential_types: Vec<u32>,
+        metadata_hashes: Vec<soroban_sdk::Bytes>,
+        expires_at: Option<u64>,
+    ) -> Vec<u64> {
+        let result = Self::issue_batch_by_did(
+            env,
+            issuer,
+            subject_dids,
+            credential_types,
+            metadata_hashes,
+            expires_at,
+        );
+        match result {
+            BatchResult::Ok(ids) => ids,
+            BatchResult::Err(err) => {
+                panic_with_error!(&env, ContractError::InvalidInput);
+            }
+        }
+    }
+
     /// Retrieve a credential by ID.
     ///
     /// # Parameters

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -786,6 +786,20 @@ pub enum DataKey6 {
     RoleAuditLog,
 }
 
+/// Storage keys for W3C Decentralized Identifier (DID) support.
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey7 {
+    /// DID document indexed by DID string (as Bytes).
+    DidDocument(soroban_sdk::Bytes),
+    /// Reverse lookup: Stellar Address -> DID string (as Bytes).
+    DidByAddress(Address),
+    /// Global DID counter.
+    DidCount,
+    /// DID method scheme (e.g., "stellar").
+    DidMethod,
+}
+
 #[contracttype]
 #[derive(Clone)]
 pub struct CredentialTypeDef {
@@ -813,6 +827,73 @@ pub struct Credential {
     pub expires_at: Option<u64>,
     pub version: u32,
 }
+
+/// W3C DID verification method key type.
+#[contracttype]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(u32)]
+pub enum DidKeyType {
+    Ed25519VerificationKey2018 = 1,
+    Ed25519VerificationKey2020 = 2,
+    X25519KeyAgreementKey2019 = 3,
+    EcdsaSecp256k1VerificationKey2019 = 4,
+    SchnorrSecp256k1VerificationKey2019 = 5,
+}
+
+/// W3C Decentralized Identifier (DID) document stored on-chain.
+///
+/// Follows the W3C DID Core 1.0 specification with Soroban-compatible
+/// field types. Each DID is uniquely derived from a Stellar address
+/// using the `did:stellar:<address>` method scheme.
+#[contracttype]
+#[derive(Clone)]
+pub struct DidDocument {
+    /// Full DID string, e.g. "did:stellar:GA2GB5B..." or "did:ethr:0x..."
+    pub did: soroban_sdk::String,
+    /// The blockchain address this DID resolves to.
+    pub address: Address,
+    /// DID method (e.g. "stellar", "ethr", "key").
+    pub method: soroban_sdk::String,
+    /// Key type used for verification.
+    pub key_type: DidKeyType,
+    /// Multibase-encoded public key bytes.
+    pub public_key: soroban_sdk::Bytes,
+    /// Whether the DID is active (not deactivated).
+    pub active: bool,
+    /// Ledger timestamp of registration.
+    pub created_at: u64,
+    /// Ledger timestamp of last update.
+    pub updated_at: u64,
+}
+
+/// Event payload emitted when a DID is registered.
+#[contracttype]
+#[derive(Clone)]
+pub struct DidRegisteredEventData {
+    pub did: soroban_sdk::String,
+    pub address: Address,
+    pub method: soroban_sdk::String,
+}
+
+/// Event payload emitted when a DID is updated.
+#[contracttype]
+#[derive(Clone)]
+pub struct DidUpdatedEventData {
+    pub did: soroban_sdk::String,
+    pub address: Address,
+}
+
+/// Event payload emitted when a DID is deactivated.
+#[contracttype]
+#[derive(Clone)]
+pub struct DidDeactivatedEventData {
+    pub did: soroban_sdk::String,
+    pub address: Address,
+}
+
+const TOPIC_DID_REGISTERED: &str = "DidRegistered";
+const TOPIC_DID_UPDATED: &str = "DidUpdated";
+const TOPIC_DID_DEACTIVATED: &str = "DidDeactivated";
 
 /// Status of a holder-initiated revocation request.
 #[contracttype]
@@ -1545,6 +1626,221 @@ impl QuorumProofContract {
             .instance()
             .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
     }
+
+    // ── W3C Decentralized Identifier (DID) Support ─────────────────────
+
+    /// Register a new W3C DID document and link it to a Stellar address.
+    ///
+    /// The caller provides a full DID string (e.g. `did:stellar:GA2...`,
+    /// `did:ethr:0x...`, `did:key:z6Mk...`) which is stored on-chain and
+    /// resolvable across blockchain platforms and custody models.
+    ///
+    /// Each Stellar address may register at most one active DID.
+    ///
+    /// # Parameters
+    /// - `address`: The Stellar address to associate with the DID; must authorize.
+    /// - `did`: Full W3C DID string (e.g. "did:stellar:GA2GB5B...").
+    /// - `key_type`: Cryptographic key type for verification methods.
+    /// - `public_key`: Multibase-encoded public key bytes for the verification method.
+    ///
+    /// # Panics
+    /// Panics if the address already has a DID registered.
+    /// Panics if the DID string is empty.
+    /// Panics if the DID does not start with "did:".
+    pub fn register_did(
+        env: Env,
+        address: Address,
+        did: soroban_sdk::String,
+        key_type: DidKeyType,
+        public_key: soroban_sdk::Bytes,
+    ) {
+        address.require_auth();
+
+        assert!(!did.is_empty(), "DID string cannot be empty");
+
+        // Ensure no DID already exists for this address
+        assert!(
+            !env.storage().instance().has(&DataKey7::DidByAddress(address.clone())),
+            "DID already registered for this address"
+        );
+
+        // Ensure the DID is not already registered
+        let did_bytes = did.clone().into_bytes();
+        assert!(
+            !env.storage().instance().has(&DataKey7::DidDocument(did_bytes.clone())),
+            "DID string already registered"
+        );
+
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey7::DidCount)
+            .unwrap_or(0u64);
+
+        let now = env.ledger().timestamp();
+        let doc = DidDocument {
+            did: did.clone(),
+            address: address.clone(),
+            method: soroban_sdk::String::from_str(&env, "stellar"),
+            key_type,
+            public_key,
+            active: true,
+            created_at: now,
+            updated_at: now,
+        };
+
+        env.storage().instance().set(&DataKey7::DidDocument(did_bytes.clone()), &doc);
+        env.storage().instance().extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+
+        env.storage().instance().set(&DataKey7::DidByAddress(address.clone()), &did_bytes);
+        env.storage().instance().extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+
+        env.storage().instance().set(&DataKey7::DidCount, &(count + 1));
+        env.storage().instance().extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+
+        let event_data = DidRegisteredEventData {
+            did: did.clone(),
+            address,
+            method: soroban_sdk::String::from_str(&env, "stellar"),
+        };
+        let topic = soroban_sdk::String::from_str(&env, TOPIC_DID_REGISTERED);
+        let mut topics: Vec<soroban_sdk::String> = Vec::new(&env);
+        topics.push_back(topic);
+        env.events().publish(topics, event_data);
+    }
+
+    /// Resolve a W3C DID document by its DID string.
+    /// Returns `None` if the DID is not registered.
+    pub fn resolve_did(env: Env, did: soroban_sdk::String) -> Option<DidDocument> {
+        let did_bytes = did.into_bytes();
+        env.storage()
+            .instance()
+            .get(&DataKey7::DidDocument(did_bytes))
+    }
+
+    /// Look up the DID string registered for a Stellar address.
+    /// Returns `None` if no DID is registered for the address.
+    pub fn get_did_for_address(env: Env, address: Address) -> Option<soroban_sdk::String> {
+        let did_bytes: Option<soroban_sdk::Bytes> = env
+            .storage()
+            .instance()
+            .get(&DataKey7::DidByAddress(address));
+        did_bytes.map(|b| soroban_sdk::String::from_bytes(&env, b))
+    }
+
+    /// Update the public key and key type for an existing DID.
+    /// The caller must be the address that owns the DID.
+    pub fn update_did(
+        env: Env,
+        address: Address,
+        new_key_type: DidKeyType,
+        new_public_key: soroban_sdk::Bytes,
+    ) {
+        address.require_auth();
+
+        let did_bytes: soroban_sdk::Bytes = env
+            .storage()
+            .instance()
+            .get(&DataKey7::DidByAddress(address.clone()))
+            .expect("no DID registered for this address");
+
+        let mut doc: DidDocument = env
+            .storage()
+            .instance()
+            .get(&DataKey7::DidDocument(did_bytes.clone()))
+            .expect("DID document not found");
+
+        doc.key_type = new_key_type;
+        doc.public_key = new_public_key;
+        doc.updated_at = env.ledger().timestamp();
+
+        env.storage().instance().set(&DataKey7::DidDocument(did_bytes), &doc);
+        env.storage().instance().extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+
+        let event_data = DidUpdatedEventData {
+            did: doc.did.clone(),
+            address,
+        };
+        let topic = soroban_sdk::String::from_str(&env, TOPIC_DID_UPDATED);
+        let mut topics: Vec<soroban_sdk::String> = Vec::new(&env);
+        topics.push_back(topic);
+        env.events().publish(topics, event_data);
+    }
+
+    /// Deactivate a DID document. The DID entry is marked inactive but
+    /// remains on-chain for resolution and audit purposes.
+    pub fn deactivate_did(env: Env, address: Address) {
+        address.require_auth();
+
+        let did_bytes: soroban_sdk::Bytes = env
+            .storage()
+            .instance()
+            .get(&DataKey7::DidByAddress(address.clone()))
+            .expect("no DID registered for this address");
+
+        let mut doc: DidDocument = env
+            .storage()
+            .instance()
+            .get(&DataKey7::DidDocument(did_bytes.clone()))
+            .expect("DID document not found");
+
+        doc.active = false;
+        doc.updated_at = env.ledger().timestamp();
+
+        env.storage().instance().set(&DataKey7::DidDocument(did_bytes), &doc);
+        env.storage().instance().extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+
+        let event_data = DidDeactivatedEventData {
+            did: doc.did.clone(),
+            address,
+        };
+        let topic = soroban_sdk::String::from_str(&env, TOPIC_DID_DEACTIVATED);
+        let mut topics: Vec<soroban_sdk::String> = Vec::new(&env);
+        topics.push_back(topic);
+        env.events().publish(topics, event_data);
+    }
+
+    /// Return the total number of registered DIDs.
+    pub fn get_did_count(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey7::DidCount)
+            .unwrap_or(0u64)
+    }
+
+    /// Issue a credential to a DID-identified subject.
+    ///
+    /// Resolves the DID to a Stellar address and issues the credential.
+    /// The DID must be active and registered.
+    pub fn issue_credential_to_did(
+        env: Env,
+        issuer: Address,
+        subject_did: soroban_sdk::String,
+        credential_type: u32,
+        metadata_hash: soroban_sdk::Bytes,
+        expires_at: Option<u64>,
+        nonce: u64,
+    ) -> u64 {
+        issuer.require_auth();
+
+        let doc = Self::require_active_did(&env, &subject_did);
+        let subject = doc.address;
+        Self::issue_credential(env, issuer, subject, credential_type, metadata_hash, expires_at, nonce)
+    }
+
+    /// Resolve a DID and return its document, panicking if not found or inactive.
+    fn require_active_did(env: &Env, did: &soroban_sdk::String) -> DidDocument {
+        let did_bytes = did.clone().into_bytes();
+        let doc: DidDocument = env
+            .storage()
+            .instance()
+            .get(&DataKey7::DidDocument(did_bytes.clone()))
+            .expect("DID not found");
+        assert!(doc.active, "DID is deactivated");
+        doc
+    }
+
+    // ── End DID Support ────────────────────────────────────────────────
 
     /// Issue #487: Returns the current state schema version.
     /// Returns 0 if no version has been set (pre-versioning state).

--- a/docs/adr/adr-004-soroban-platform.md
+++ b/docs/adr/adr-004-soroban-platform.md
@@ -1,0 +1,165 @@
+# ADR-004: Soroban Smart Contract Platform
+
+## Status
+Accepted
+
+## Context
+QuorumProof needs a smart contract platform to issue, attest, and verify professional credentials on-chain. The platform must support complex credential logic, privacy-preserving verification (ZK proofs), and long-term storage of credential state. It must also be accessible — minimizing gas costs for universities bulk-importing students — and support the Federated Byzantine Agreement (FBA) trust model.
+
+Several smart contract platforms were evaluated for this purpose.
+
+## Problem Statement
+Which smart contract platform should QuorumProof use to implement on-chain credential issuance, attestation, revocation, and zero-knowledge verification?
+
+Key requirements:
+1. **Low transaction costs**: Universities may issue thousands of credentials; gas costs must be minimal
+2. **FBA-native trust model**: The platform must support or align with FBA for quorum-based attestation
+3. **WASM-based execution**: Support for modern, efficient smart contract development in Rust
+4. **Deterministic execution**: Credential verification must be deterministic and reproducible
+5. **Long-term storage**: Credentials persist on-chain for years; storage costs must be predictable
+6. **ZK proof verification**: The platform must support efficient on-chain ZK proof verification
+7. **Regulatory compliance**: Must support features needed for GDPR and data protection compliance
+
+## Alternatives Considered
+
+### 1. Ethereum (Solidity/EVM)
+- **Description**: Deploy contracts on Ethereum mainnet or L2 (Polygon, Arbitrum, Optimism)
+- **Pros**:
+  - Largest developer ecosystem and tooling
+  - Established ZK proof verification libraries
+  - Wide wallet support (MetaMask)
+  - Mature audit and security practices
+- **Cons**:
+  - **High gas costs**: Ethereum L1 gas costs make batch issuance prohibitively expensive for universities
+  - **L2 fragmentation**: L2 solutions add complexity; credential data may live on different chains
+  - **No FBA alignment**: Ethereum uses PoS, not FBA — the trust model is misaligned
+  - **EVM limitations**: Solidity's 256-bit EVM is less efficient for the credential data structures needed
+  - **Storage costs**: Ethereum's storage model (20k gas per 32-byte slot) makes long-term credential storage expensive
+  - **Account model**: Ethereum's account model doesn't natively support the address-based identity QuorumProof needs
+
+### 2. Solana (Rust/Berkeley Packet Filter)
+- **Description**: Deploy contracts (programs) on Solana using Rust or C
+- **Pros**:
+  - Very low transaction costs (~$0.0002 per tx)
+  - Fast block times (~400ms)
+  - Rust-based development
+  - Large ecosystem
+- **Cons**:
+  - **Not FBA**: Solana uses Proof of History + PoS; no FBA alignment
+  - **Account model complexity**: Solana's account rent and data model adds complexity for credential storage
+  - **No native ZK support**: ZK verification requires custom BPF programs, which is less mature
+  - **Sequential execution model**: Solana's Sealevel parallel execution is powerful but adds complexity for credential attestation workflows
+  - **History pruning**: Validators prune old state, which conflicts with long-term credential persistence needs
+  - **Downtime history**: Solana has experienced multiple network outages, which is problematic for credential verification
+
+### 3. Stellar Soroban ✓ **CHOSEN**
+- **Description**: Deploy contracts on Stellar's Soroban platform using Rust, compiled to WASM
+- **Pros**:
+  - **FBA-native**: Stellar uses FBA consensus; QuorumProof's trust model aligns perfectly with the underlying network
+  - **Low, predictable fees**: Stellar's fee model is minimal and predictable (base fee ~0.00001 XLM), enabling cost-effective batch issuance
+  - **Rust + WASM**: Modern, type-safe development with Rust, compiled to WASM for efficient execution
+  - **Deterministic**: Soroban execution is fully deterministic, important for credential verification
+  - **Address-based identity**: Stellar addresses (G...) serve as natural on-chain identities
+  - **Long-term state**: Soroban's storage model supports persistent credential storage with configurable TTL
+  - **No front-running**: Stellar's consensus model prevents MEV and front-running, which could compromise credential operations
+  - **Regulatory alignment**: Stellar's compliance features (memo requirements, KYC integration) support regulatory needs
+  - **Growing ZK ecosystem**: Soroban's WASM runtime can support ZK verification circuits
+  - **Soroban-specific design**: The contract model (one contract per functionality) aligns with QuorumProof's modular architecture
+- **Cons**:
+  - **Younger ecosystem**: Soroban is newer than Ethereum; fewer established tools and libraries
+  - **Smaller developer pool**: Fewer Soroban developers available compared to Solidity or Rust+Solana
+  - **Limited ZK library maturity**: ZK proof verification on Soroban is emerging, requiring custom implementation
+  - **Future Mainnet readiness**: At the time of this decision, Soroban was in early stages of mainnet rollout
+
+### 4. NEAR Protocol (Rust/WASM)
+- **Description**: Deploy contracts on NEAR using Rust, compiled to WASM
+- **Pros**:
+  - WASM-based execution (similar to Soroban)
+  - Low transaction costs
+  - Nightshade sharding for scalability
+- **Cons**:
+  - **No FBA**: NEAR uses Nightshade PoS; no FBA alignment
+  - **Storage staking**: NEAR requires staking NEAR tokens for storage, adding cost for credential storage
+  - **Smaller ecosystem**: Smaller than Ethereum or Solana
+  - **Data model mismatch**: NEAR's account-based data model is less suited for credential indexing
+
+### 5. Polkadot (Ink!/WASM)
+- **Description**: Deploy on Polkadot parachains using Ink! and WASM
+- **Pros**:
+  - WASM-based execution
+  - Shared security model
+  - Cross-chain interoperability (XCM)
+- **Cons**:
+  - **Parachain slot auctions**: Expensive and time-limited parachain slots
+  - **Complexity**: Polkadot's architecture adds significant complexity
+  - **No FBA alignment**: Uses Nominated PoS
+  - **Ink! maturity**: Ink! is less mature than Soroban's Rust SDK
+
+## Decision
+**Build QuorumProof on Stellar Soroban**, using Rust smart contracts compiled to WASM.
+
+### Architecture
+1. **Smart contracts**: Deployed as Soroban WASM contracts on Stellar
+2. **Core contract**: `QuorumProofContract` — credential issuance, attestation, slices, revocation
+3. **SBT registry**: `SbtRegistryContract` — soulbound token non-transferability enforcement
+4. **ZK verifier**: `ZkVerifierContract` — Groth16 and PLONK proof verification
+5. **API layer**: TypeScript/Express server that wraps Soroban contract calls via `@stellar/stellar-sdk`
+
+## Rationale
+
+1. **FBA Alignment**: QuorumProof's trust model is Federated Byzantine Agreement — the same consensus model Stellar uses. Building on Soroban means the underlying blockchain's trust model matches the application's trust model, eliminating conceptual mismatches present in PoW/PoS alternatives.
+
+2. **Cost-Effective Bulk Operations**: Soroban's predictable, minimal fee model enables the batch issuance use case. Universities can issue thousands of credentials without prohibitive gas costs — a key requirement that eliminates Ethereum L1.
+
+3. **Rust + WASM Performance**: Rust's type safety and WASM's efficient execution enable complex credential logic (ZK verification, weighted voting, quorum calculations) without the overhead of EVM or the complexity of Solana's BPF.
+
+4. **Address as Identity**: Stellar addresses serve as natural on-chain identifiers. This aligns with W3C DID standards (did:stellar:...) and eliminates the need for a separate identity layer.
+
+5. **Deterministic Verification**: Credential verification must be reproducible. Soroban's deterministic execution ensures that the same inputs always produce the same verification result, which is critical for audit trails and dispute resolution.
+
+6. **No MEV/Front-Running**: Stellar's FBA consensus prevents miner extractable value and front-running, which could be exploited in credential revocation or attestation workflows.
+
+7. **Modular Contract Architecture**: Soroban's contract model supports the separation of concerns — core credentials, SBT enforcement, and ZK verification as separate contracts that communicate via cross-contract calls.
+
+## Consequences
+
+### Positive
+- Perfect alignment between application trust model (FBA) and blockchain consensus (Stellar FBA)
+- Low, predictable transaction costs enable educational and high-volume use cases
+- Rust + WASM provides excellent performance and safety
+- Stellar's regulatory compliance features support enterprise adoption
+- No MEV or front-running risks
+- Deterministic execution ensures verifiable audit trails
+- Address-based identity integrates naturally with W3C DID standards
+
+### Negative
+- Smaller developer ecosystem compared to Ethereum; harder to find Soroban developers
+- ZK proof verification on Soroban requires custom implementation rather than using established EVM libraries
+- At deployment time, Soroban mainnet was still maturing; some features may be emergent
+- Limited tooling for Soroban contract debugging and testing compared to EVM tooling
+- Migrating to another platform would require rewriting contracts if future needs outgrow Soroban
+
+## Implementation Notes
+
+1. **Contract Structure**: Each major concern is a separate Soroban contract:
+   - `quorum_proof`: Core credential logic, slices, attestations, RBAC
+   - `sbt_registry`: Soulbound token non-transferability and recovery
+   - `zk_verifier`: ZK proof verification (Groth16, PLONK)
+
+2. **Cross-Contract Calls**: Contracts communicate via Soroban's cross-contract call mechanism using `Env::invoke_contract()`.
+
+3. **Storage Model**: Credential data stored in Soroban instance storage with TTL management. High-throughput indexes use separate storage keys to avoid contention.
+
+4. **Fee Budgeting**: Batch operations pre-compute fee requirements using Soroban's `Env::budget()` to avoid out-of-resource errors during multi-credential issuance.
+
+5. **WASM Size Optimization**: Contracts use `#![no_std]`, LTO, and release profile optimizations to minimize WASM binary size within Soroban's deployment limits.
+
+## References
+- [Soroban Documentation](https://soroban.stellar.org/docs)
+- [Stellar Consensus Protocol](https://www.stellar.org/papers/stellar-consensus-protocol.pdf)
+- [Soroban Rust SDK](https://github.com/stellar/soroban-sdk)
+- [Stellar Fee Model](https://developers.stellar.org/docs/learn/fees)
+- [W3C DID Core Specification](https://www.w3.org/TR/did-core/)
+- [ADR-001: FBA Trust Model](adr-001-fba-trust-model.md)
+- [ADR-002: SBT Non-Transferability](adr-002-sbt-non-transferability.md)
+- [ADR-003: ZK Verification](adr-003-zk-verification.md)

--- a/docs/video-scripts/01-issuer-onboarding.md
+++ b/docs/video-scripts/01-issuer-onboarding.md
@@ -1,0 +1,133 @@
+# Video Script: Issuer Onboarding Workflow
+
+## Metadata
+- **Duration**: ~5 minutes
+- **Audience**: University administrators, licensing bodies, employers
+- **Goal**: Walk through registering as an issuer and configuring issuance settings
+
+---
+
+## Scene 1: Introduction (0:00 - 0:30)
+
+**Visual**: Screen recording of the QuorumProof dashboard landing page.
+
+**Narration**:
+"Welcome to QuorumProof. This video walks through the issuer onboarding workflow — how universities, licensing bodies, and employers register to issue verifiable credentials on the Stellar blockchain."
+
+**On-Screen Actions**:
+- Open browser to QuorumProof dashboard
+- Show login screen
+
+---
+
+## Scene 2: Wallet Connection (0:30 - 1:15)
+
+**Visual**: Freighter wallet connection flow.
+
+**Narration**:
+"First, connect your Stellar wallet. QuorumProof uses Freighter, a non-custodial browser wallet. Your Stellar address becomes your on-chain identity."
+
+**On-Screen Actions**:
+- Click "Connect Wallet"
+- Freighter popup appears
+- Select account and approve connection
+- Dashboard shows connected address
+
+**Caption**: "Your Stellar address = your on-chain identity"
+
+---
+
+## Scene 3: Role Registration (1:15 - 2:30)
+
+**Visual**: Issuer registration form.
+
+**Narration**:
+"Once connected, navigate to the 'Register as Issuer' section. Here you'll provide your organization details. QuorumProof uses a role-based access system — the contract admin grants you the Issuer role. This ensures only verified organizations can issue credentials."
+
+**On-Screen Actions**:
+- Navigate to Settings > Roles
+- Click "Request Issuer Role"
+- Fill in organization name, email, website
+- Submit request
+- Admin approves (show admin interface briefly)
+
+**Caption**: "Role-based access prevents unauthorized issuers"
+
+---
+
+## Scene 4: Credential Type Configuration (2:30 - 3:45)
+
+**Visual**: Credential type setup interface.
+
+**Narration**:
+"Now configure the credential types you'll issue. For a university, this might include 'Bachelor of Science', 'Master of Engineering', or 'Transcript'. Each credential type has a unique ID, name, and optional metadata schema."
+
+**On-Screen Actions**:
+- Go to Credential Types > Create New
+- Enter type name: "Bachelor of Science in Computer Science"
+- Set type ID (auto-generated)
+- Optional: upload metadata schema
+- Save credential type
+
+**Caption**: "Define credential types that match your institution's offerings"
+
+---
+
+## Scene 5: Single Issuance (3:45 - 4:30)
+
+**Visual**: Issue credential form.
+
+**Narration**:
+"You can issue a single credential directly. Enter the recipient's Stellar address, select the credential type, and attach the metadata hash — typically an IPFS pointer to the credential document. The transaction is signed by your wallet and recorded on-chain."
+
+**On-Screen Actions**:
+- Go to Credentials > Issue New
+- Enter recipient address
+- Select credential type
+- Enter metadata hash (IPFS CID)
+- Set optional expiry date
+- Click "Issue" and approve Freighter transaction
+- View confirmation with credential ID
+
+---
+
+## Scene 6: Batch Issuance (4:30 - 5:00)
+
+**Visual**: Batch issuance interface (DID-aware).
+
+**Narration**:
+"For bulk operations, like importing an entire graduating class, use batch issuance. Upload a CSV or enter multiple recipients at once. This issues all credentials in a single transaction, saving time and reducing costs."
+
+**On-Screen Actions**:
+- Go to Credentials > Batch Issue
+- Upload CSV with recipient addresses/DIDs and types
+- Review the list
+- Click "Batch Issue" and approve
+- View list of issued credential IDs
+
+**Caption**: "Batch issuance: one transaction, many credentials"
+
+---
+
+## Scene 7: Verification (5:00 - 5:30)
+
+**Visual**: Issuer dashboard showing issued credentials.
+
+**Narration**:
+"After issuance, you can verify credentials on-chain, track issuance history, and manage revocations if needed. Your organization now has a verifiable on-chain presence for issuing credentials."
+
+**On-Screen Actions**:
+- Show issuer dashboard with credential count
+- Click on a credential to view details
+- Show verification status
+
+**Closing**: "Thank you for watching. For more details, visit the documentation at docs.quorumproof.io."
+
+---
+
+## Production Notes
+- Use a test network (Futurenet) for all demonstrations
+- Mask any real addresses if using public network
+- Keep cursor movement deliberate and slow
+- Use zoom-in effects for form fields and transaction confirmations
+- Add subtitles for accessibility

--- a/docs/video-scripts/02-slice-creation.md
+++ b/docs/video-scripts/02-slice-creation.md
@@ -1,0 +1,152 @@
+# Video Script: Slice Creation Workflow
+
+## Metadata
+- **Duration**: ~6 minutes
+- **Audience**: Credential holders (engineers, professionals)
+- **Goal**: Demonstrate how to create and configure quorum slices for credential attestation
+
+---
+
+## Scene 1: Introduction (0:00 - 0:30)
+
+**Visual**: Animated diagram showing trust relationships between a credential holder, university, employer, and licensing body.
+
+**Narration**:
+"In QuorumProof, credentials aren't just issued — they're attested by your trusted network. This is done through quorum slices. A quorum slice defines who you trust to vouch for your credentials. This video shows how to create and manage your slices."
+
+**On-Screen Actions**:
+- Animated diagram: central figure (holder) connected to 3 nodes (university, employer, licensing body)
+- Arrows showing attestation flow
+
+---
+
+## Scene 2: Understanding Quorum Slices (0:30 - 1:30)
+
+**Visual**: Split screen — left side shows slice diagram, right side shows the Slice Manager UI.
+
+**Narration**:
+"A quorum slice is a set of attestors you trust, each with a weight, plus a threshold. A credential is considered attested when the sum of attestation weights meets or exceeds your threshold. For example, you might give your university weight 2, your employer weight 1, and set threshold 2 — meaning either your university alone, or your employer plus another attestor, can attest."
+
+**On-Screen Actions**:
+- Show slice structure diagram:
+  - Attestors: University (weight 2), Employer (weight 1), Licensing Body (weight 1)
+  - Threshold: 2
+- Highlight different combinations that meet threshold
+
+**Caption**: "Threshold = minimum weight needed for attestation"
+
+---
+
+## Scene 3: Navigating to Slice Manager (1:30 - 2:00)
+
+**Visual**: Dashboard navigation.
+
+**Narration**:
+"To create a slice, navigate to the 'Quorum Slices' section from your dashboard."
+
+**On-Screen Actions**:
+- Log into dashboard
+- Click "Quorum Slices" in sidebar
+- Show empty slice list with "Create New Slice" button
+
+---
+
+## Scene 4: Creating a Slice (2:00 - 3:30)
+
+**Visual**: Slice creation form.
+
+**Narration**:
+"Click 'Create New Slice'. Give your slice a name — like 'Professional Network' or 'Academic Attestors'. Then add your trusted attestors. Each attestor is identified by their Stellar address or DID. You can also look up organizations by name."
+
+**On-Screen Actions**:
+- Click "Create New Slice"
+- Enter slice name: "Professional Network"
+- Click "Add Attestor"
+- Enter university's Stellar address
+- Set weight: 2
+- Add employer's Stellar address
+- Set weight: 1
+- Add licensing body's Stellar address
+- Set weight: 1
+
+**Caption**: "Add attestors by Stellar address or DID"
+
+---
+
+## Scene 5: Setting Threshold (3:30 - 4:15)
+
+**Visual**: Threshold configuration.
+
+**Narration**:
+"Now set your threshold. The tooltip shows you the total available weight. For maximum security, set threshold to 100% of total weight — requiring all attestors to agree. For flexibility, use a majority threshold like 67% or 51%."
+
+**On-Screen Actions**:
+- Show threshold slider
+- Total weight shows: 4
+- Move slider: 67% (threshold = 3)
+- Explain: "67% means 3 out of 4 weight must attest"
+- Move to 51% (threshold = 2)
+- Explain: "51% for more lenient attestation"
+
+**Caption**: "Recommended: start with 67% threshold"
+
+---
+
+## Scene 6: Advanced Options (4:15 - 5:00)
+
+**Visual**: Advanced configuration panel.
+
+**Narration**:
+"Advanced options let you set weighted voting rules, define attestation expiry, and configure slice-based verification conditions. For most users, the defaults work well."
+
+**On-Screen Actions**:
+- Expand "Advanced Options"
+- Show weighted voting settings
+- Show attestation expiry (default: never)
+- Show verification conditions
+- Leave at defaults
+
+---
+
+## Scene 7: Review and Confirm (5:00 - 5:30)
+
+**Visual**: Slice summary before confirmation.
+
+**Narration**:
+"Review your slice configuration. You'll see the total weight, threshold, and list of attestors. Confirm by signing the transaction with your wallet."
+
+**On-Screen Actions**:
+- Click "Review" or "Next"
+- Show summary card:
+  - Slice Name: Professional Network
+  - Attestors: 3
+  - Total Weight: 4
+  - Threshold: 3 (67%)
+- Click "Confirm & Sign"
+- Freighter popup — approve transaction
+- Success message: "Slice created successfully!"
+
+---
+
+## Scene 8: Managing Slices (5:30 - 6:00)
+
+**Visual**: Slice management dashboard.
+
+**Narration**:
+"After creation, you can view, edit, or deactivate your slices. Each slice shows its attestation status for your credentials. You can create multiple slices for different contexts — professional, academic, or personal."
+
+**On-Screen Actions**:
+- Show slice list with new slice visible
+- Click on slice to view details
+- Show "Edit" and "Deactivate" buttons
+- Show attestation progress for linked credentials
+
+**Closing**: "Your quorum slices are the foundation of trust in QuorumProof. Create slices that reflect your real-world professional relationships."
+
+---
+
+## Production Notes
+- Use clear, labeled diagrams for the FBA concept
+- Show real Stellar addresses (testnet) so viewers recognize the format
+- Highlight the relationship between slice composition and attestation outcomes
+- Include warning text for low threshold settings

--- a/docs/video-scripts/03-claim-verification.md
+++ b/docs/video-scripts/03-claim-verification.md
@@ -1,0 +1,160 @@
+# Video Script: Claim Verification Workflow
+
+## Metadata
+- **Duration**: ~5 minutes
+- **Audience**: Employers, hiring managers, verification platforms
+- **Goal**: Demonstrate how to verify credential claims with privacy-preserving ZK proofs
+
+---
+
+## Scene 1: Introduction (0:00 - 0:30)
+
+**Visual**: Split screen — left shows a hiring manager, right shows the verification interface.
+
+**Narration**:
+"QuorumProof enables privacy-preserving credential verification. Instead of asking candidates to share their full diploma or transcript, you can verify specific claims — like 'has a Bachelor's degree in Computer Science' — without seeing any additional data. This video walks through the verification workflow."
+
+**On-Screen Actions**:
+- Show typical scenario: hiring manager reviewing an applicant
+- "Verify credential claim" button in the hiring platform
+
+---
+
+## Scene 2: Understanding Claims vs. Full Credentials (0:30 - 1:15)
+
+**Visual**: Comparison table or infographic.
+
+**Narration**:
+"Traditional verification requires sharing the full credential — diploma, transcript, or certificate — revealing more information than necessary. QuorumProof uses zero-knowledge proofs, allowing the candidate to prove specific claims while keeping the rest private."
+
+**On-Screen Actions**:
+- Left column: "Full Disclosure" — shows diploma with GPA, courses, personal info
+- Right column: "ZK Claim" — shows only "Degree: BS Computer Science ✓"
+- Highlight: "No additional data revealed"
+
+**Caption**: "Zero-knowledge proofs: verify what matters, nothing more"
+
+---
+
+## Scene 3: Initiating a Verification Request (1:15 - 2:15)
+
+**Visual**: Verification request form.
+
+**Narration**:
+"As a verifier, you start by requesting proof of a specific claim. Enter the candidate's Stellar address or DID, select the claim type you need verified, and optionally add a verification context."
+
+**On-Screen Actions**:
+- Navigate to "Verify Credential" page
+- Enter candidate's Stellar address: "GA2GB5B..."
+- Select claim type: "HasDegree"
+- Enter context: "Bachelor of Science in Computer Science"
+- Optional: set query deadline
+- Click "Request Verification"
+
+**Caption**: "Specify exactly what you need to verify"
+
+---
+
+## Scene 4: Candidate Generates ZK Proof (2:15 - 3:00)
+
+**Visual**: Screen recording of candidate's proof generation interface.
+
+**Narration**:
+"The verification request is sent to the candidate. They receive a notification and can review what claim is being requested. If they agree, they generate a zero-knowledge proof using their credential metadata. This proof cryptographically confirms the claim without revealing the underlying data."
+
+**On-Screen Actions**:
+- Switch to candidate's view
+- Show notification: "Verification request received"
+- Click "Review Request"
+- Show claim details: "HasDegree: BS Computer Science"
+- Click "Generate Proof"
+- Wallet signs the proof generation
+- Progress bar: "Generating ZK proof..."
+- Proof generated successfully
+
+**Caption**: "Candidate controls what to reveal"
+
+---
+
+## Scene 5: Submitting the Proof (3:00 - 3:30)
+
+**Visual**: Proof submission flow.
+
+**Narration**:
+"The candidate submits the proof. It's posted on-chain to the QuorumProof ZK verifier contract, which validates the proof against the stored credential metadata."
+
+**On-Screen Actions**:
+- Candidate clicks "Submit Proof"
+- Freighter transaction approval
+- Loading: "Verifying proof on-chain..."
+- Success: "Proof submitted and verified"
+
+---
+
+## Scene 6: Verifier Reviews Result (3:30 - 4:30)
+
+**Visual**: Verification result display.
+
+**Narration**:
+"Back in the verifier's dashboard, the result appears. You see the claim, whether it was verified, and the cryptographic proof ID. You can trust this result because it's verified on-chain by the Soroban contract."
+
+**On-Screen Actions**:
+- Switch to verifier's view
+- Refresh verification requests
+- Show completed verification:
+  - Claim: HasDegree
+  - Context: BS Computer Science
+  - Status: ✓ Verified
+  - Proof ID: 0x7a3f...9c2e
+  - Timestamp: June 26, 2026
+- Click "View Proof Details"
+- Show proof metadata (not the underlying data)
+
+**Caption**: "Cryptographically verified on Stellar Soroban"
+
+---
+
+## Scene 7: Advanced Verification (4:30 - 5:00)
+
+**Visual**: Advanced verification options.
+
+**Narration**:
+"For more complex needs, QuorumProof supports conditional and composite claims — like 'has a degree AND graduated after 2020', or 'has at least 3 years of experience'. You can also batch-verify multiple candidates or claims in a single transaction."
+
+**On-Screen Actions**:
+- Show composite claim builder:
+  - Claim 1: HasDegree (AND)
+  - Claim 2: GraduatedAfter (2020)
+- Show batch verification:
+  - Upload CSV with multiple candidates and claims
+  - Click "Batch Verify"
+  - Show results table with pass/fail for each
+
+**Caption**: "Composite claims for complex verification needs"
+
+---
+
+## Scene 8: Audit Trail (5:00 - 5:30)
+
+**Visual**: Verification audit log.
+
+**Narration**:
+"Every verification is recorded in an immutable audit trail. You can view the history of all verification requests and their results, providing a transparent hiring process for compliance and auditing."
+
+**On-Screen Actions**:
+- Navigate to "Verification History"
+- Show table with columns: Date, Candidate, Claim, Status, Verifier
+- Filter by date range
+- Export audit log as CSV
+
+**Closing**: "QuorumProof makes credential verification private, secure, and auditable. For technical details on the ZK implementation, see the ZK verification documentation."
+
+---
+
+## Production Notes
+- Use test credentials on Futurenet for all demonstrations
+- Show both issuer and verifier perspectives
+- Emphasize that no private data is visible to the verifier
+- Include a side-by-side comparison with traditional (full disclosure) verification
+- Add subtitles and closed captions
+- Include links to ZK verification documentation in video description


### PR DESCRIPTION
Closes #882 
Closes #883 
Closes #857 
Closes #858 

## Summary

This PR implements four features across four individual commits:

### 1. W3C DID Support (`6f52108`)
Implements W3C Decentralized Identifier (DID) support, enabling users to register portable identifiers (e.g., `did:stellar:GA2...`, `did:ethr:0x...`) linked to their Stellar addresses. DIDs can be resolved on-chain, updated, or deactivated, and credentials can be issued directly to DID-identified subjects.

**New public functions:** `register_did()`, `resolve_did()`, `get_did_for_address()`, `update_did()`, `deactivate_did()`, `get_did_count()`, `issue_credential_to_did()`

### 2. DID-aware Batch Issuance (`8fcfe2b`)
Adds batch issuance functions that accept W3C DIDs as subject identifiers, resolving them to Stellar addresses before atomic issuance. Enables universities to bulk-import students using DIDs in a single transaction.

**New public functions:** `issue_batch_by_did()`, `batch_issue_credentials_by_did()`

### 3. Video Scripts (`f29d529`)
Three detailed video production scripts for issuer onboarding, slice creation, and claim verification workflows.

### 4. ADR-004: Soroban Platform (`e344a8b`)
Architecture Decision Record documenting why Stellar Soroban was chosen over Ethereum, Solana, NEAR, and Polkadot.