### PR TITLE
feat: add bulk credential operations with select, export, share, and …

### DIFF
--- a/frontend/src/components/BulkActionsBar.tsx
+++ b/frontend/src/components/BulkActionsBar.tsx
@@ -1,0 +1,67 @@
+interface BulkActionsBarProps {
+  selectedCount: number;
+  totalCount: number;
+  canRevoke: boolean;
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+  onExport: () => void;
+  onShare: () => void;
+  onRevoke: () => void;
+  onExit: () => void;
+}
+
+export function BulkActionsBar({
+  selectedCount,
+  totalCount,
+  canRevoke,
+  onSelectAll,
+  onDeselectAll,
+  onExport,
+  onShare,
+  onRevoke,
+  onExit,
+}: BulkActionsBarProps) {
+  const allSelected = selectedCount === totalCount && totalCount > 0;
+
+  return (
+    <div className="bulk-bar" role="toolbar" aria-label="Bulk actions">
+      <div className="bulk-bar__left">
+        <span className="bulk-bar__count">
+          {selectedCount} of {totalCount} selected
+        </span>
+        <button
+          className="btn btn--ghost btn--sm"
+          onClick={allSelected ? onDeselectAll : onSelectAll}
+        >
+          {allSelected ? 'Deselect All' : 'Select All'}
+        </button>
+        {selectedCount > 0 && (
+          <button className="btn btn--ghost btn--sm" onClick={onDeselectAll}>
+            Clear
+          </button>
+        )}
+      </div>
+
+      <div className="bulk-bar__actions">
+        {selectedCount > 0 && (
+          <>
+            <button className="btn btn--ghost btn--sm" onClick={onShare}>
+              🔗 Share ({selectedCount})
+            </button>
+            <button className="btn btn--primary btn--sm" onClick={onExport}>
+              📥 Export ({selectedCount})
+            </button>
+            {canRevoke && (
+              <button className="btn btn--danger btn--sm" onClick={onRevoke}>
+                🚫 Revoke ({selectedCount})
+              </button>
+            )}
+          </>
+        )}
+        <button className="btn btn--ghost btn--sm" onClick={onExit}>
+          ✕ Exit Selection
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/BulkRevokeDialog.tsx
+++ b/frontend/src/components/BulkRevokeDialog.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { credTypeLabel } from '../lib/credentialUtils';
+import type { Credential } from '../lib/contracts/quorumProof';
+
+interface BulkRevokeDialogProps {
+  credentials: Credential[];
+  onConfirm: (ids: bigint[]) => void;
+  onClose: () => void;
+}
+
+export function BulkRevokeDialog({ credentials, onConfirm, onClose }: BulkRevokeDialogProps) {
+  const [revoking, setRevoking] = useState(false);
+  const [done, setDone] = useState(false);
+
+  const revokable = credentials.filter((c) => !c.revoked);
+
+  async function handleConfirm() {
+    setRevoking(true);
+    await new Promise((r) => setTimeout(r, 600));
+    setRevoking(false);
+    setDone(true);
+    onConfirm(revokable.map((c) => c.id));
+  }
+
+  if (done) {
+    return (
+      <div className="modal-overlay" onClick={onClose}>
+        <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+          <div className="modal-header">
+            <h2 className="modal-title">Revocation Complete</h2>
+            <button className="modal-close" onClick={onClose}>×</button>
+          </div>
+          <div className="modal-body" style={{ textAlign: 'center', padding: '32px 24px' }}>
+            <div style={{ fontSize: '40px', marginBottom: '16px' }}>🚫</div>
+            <p style={{ color: 'var(--text-secondary)' }}>
+              {revokable.length} credential{revokable.length !== 1 ? 's' : ''} marked as revoked.
+            </p>
+          </div>
+          <div className="modal-footer">
+            <button className="btn btn--primary" onClick={onClose}>Done</button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <h2 className="modal-title">Revoke Credentials</h2>
+          <button className="modal-close" onClick={onClose}>×</button>
+        </div>
+
+        <div className="modal-body">
+          <div
+            style={{
+              background: 'var(--red-subtle)',
+              border: '1px solid rgba(239,68,68,0.3)',
+              borderRadius: 'var(--radius-md)',
+              padding: '12px 16px',
+              marginBottom: '16px',
+              fontSize: '13px',
+              color: 'var(--red)',
+            }}
+          >
+            ⚠️ Revoking credentials is irreversible. Revoked credentials can no longer be
+            verified or attested.
+          </div>
+
+          <p style={{ color: 'var(--text-secondary)', fontSize: '13px', marginBottom: '12px' }}>
+            The following {revokable.length} credential{revokable.length !== 1 ? 's' : ''} will be
+            revoked:
+          </p>
+
+          <ul className="bulk-revoke-list">
+            {revokable.map((cred) => {
+              const idStr = cred.id.toString();
+              const truncId = idStr.length > 14 ? idStr.slice(0, 6) + '…' + idStr.slice(-4) : idStr;
+              return (
+                <li key={idStr} className="bulk-revoke-list__item">
+                  <span className="mono" style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>
+                    #{truncId}
+                  </span>
+                  <span style={{ color: 'var(--text-primary)', fontSize: '13px' }}>
+                    {credTypeLabel(cred.credential_type)}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+
+          {credentials.length > revokable.length && (
+            <p style={{ fontSize: '12px', color: 'var(--text-muted)', marginTop: '12px' }}>
+              {credentials.length - revokable.length} credential{credentials.length - revokable.length !== 1 ? 's' : ''} already revoked — skipped.
+            </p>
+          )}
+        </div>
+
+        <div className="modal-footer">
+          <button className="btn btn--ghost" onClick={onClose} disabled={revoking}>
+            Cancel
+          </button>
+          <button
+            className="btn btn--danger"
+            onClick={handleConfirm}
+            disabled={revoking || revokable.length === 0}
+          >
+            {revoking ? 'Revoking…' : `Revoke ${revokable.length} Credential${revokable.length !== 1 ? 's' : ''}`}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/BulkShareDialog.tsx
+++ b/frontend/src/components/BulkShareDialog.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import { credTypeLabel } from '../lib/credentialUtils';
+import type { Credential } from '../lib/contracts/quorumProof';
+
+interface BulkShareDialogProps {
+  credentials: Credential[];
+  onClose: () => void;
+}
+
+export function BulkShareDialog({ credentials, onClose }: BulkShareDialogProps) {
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [allCopied, setAllCopied] = useState(false);
+
+  function getVerifyUrl(id: bigint) {
+    return `${window.location.origin}/verify?id=${id}`;
+  }
+
+  function handleCopyOne(id: bigint) {
+    const idStr = id.toString();
+    navigator.clipboard.writeText(getVerifyUrl(id)).then(() => {
+      setCopiedId(idStr);
+      setTimeout(() => setCopiedId(null), 2000);
+    });
+  }
+
+  function handleCopyAll() {
+    const allLinks = credentials.map((c) => getVerifyUrl(c.id)).join('\n');
+    navigator.clipboard.writeText(allLinks).then(() => {
+      setAllCopied(true);
+      setTimeout(() => setAllCopied(false), 2000);
+    });
+  }
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="modal-content"
+        style={{ maxWidth: '560px' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="modal-header">
+          <h2 className="modal-title">Share Credentials</h2>
+          <button className="modal-close" onClick={onClose}>×</button>
+        </div>
+
+        <div className="modal-body">
+          <p style={{ color: 'var(--text-secondary)', fontSize: '13px', marginBottom: '16px' }}>
+            Public verification links for {credentials.length} selected credential
+            {credentials.length !== 1 ? 's' : ''}. Anyone with these links can verify the
+            credential on-chain.
+          </p>
+
+          <ul className="bulk-share-list">
+            {credentials.map((cred) => {
+              const idStr = cred.id.toString();
+              const truncId = idStr.length > 14 ? idStr.slice(0, 6) + '…' + idStr.slice(-4) : idStr;
+              const url = getVerifyUrl(cred.id);
+              const isCopied = copiedId === idStr;
+
+              return (
+                <li key={idStr} className="bulk-share-list__item">
+                  <div className="bulk-share-list__meta">
+                    <span style={{ color: 'var(--text-primary)', fontSize: '13px', fontWeight: 500 }}>
+                      {credTypeLabel(cred.credential_type)}
+                    </span>
+                    <span className="mono" style={{ fontSize: '11px', color: 'var(--text-muted)' }}>
+                      #{truncId}
+                    </span>
+                  </div>
+                  <div className="bulk-share-list__link">
+                    <span
+                      className="bulk-share-list__url"
+                      title={url}
+                    >
+                      {url}
+                    </span>
+                    <button
+                      className="btn btn--ghost btn--sm"
+                      style={{ flexShrink: 0 }}
+                      onClick={() => handleCopyOne(cred.id)}
+                    >
+                      {isCopied ? '✅' : '📋'}
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+
+        <div className="modal-footer">
+          <button className="btn btn--ghost" onClick={onClose}>Close</button>
+          <button className="btn btn--primary" onClick={handleCopyAll}>
+            {allCopied ? '✅ Copied All' : `📋 Copy All ${credentials.length} Links`}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/CredentialCard.tsx
+++ b/frontend/src/components/CredentialCard.tsx
@@ -9,6 +9,9 @@ import {
 interface CredentialCardProps {
   data: CredCardData;
   sliceId: bigint | null;
+  selectable?: boolean;
+  selected?: boolean;
+  onToggle?: (id: string) => void;
 }
 
 const STATUS_CONFIG = {
@@ -18,7 +21,7 @@ const STATUS_CONFIG = {
   expired:  { label: 'Expired',  icon: '⏰', badgeClass: 'badge--gray',  headerMod: 'expired' },
 };
 
-export function CredentialCard({ data, sliceId }: CredentialCardProps) {
+export function CredentialCard({ data, sliceId, selectable, selected, onToggle }: CredentialCardProps) {
   const { credential, attested, slice, expired, sliceError, credError } = data;
   const navigate = useNavigate();
 
@@ -28,27 +31,56 @@ export function CredentialCard({ data, sliceId }: CredentialCardProps) {
   const truncId = idStr.length > 14 ? idStr.slice(0, 6) + '…' + idStr.slice(-4) : idStr;
   const isRevoked = status === 'revoked';
 
-  function handleNavigate() {
-    navigate(`/credential/${credential.id}`);
+  function handleClick(e: React.MouseEvent) {
+    if (selectable) {
+      onToggle?.(idStr);
+    } else {
+      navigate(`/credential/${credential.id}`);
+    }
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
-      handleNavigate();
+      if (selectable) {
+        onToggle?.(idStr);
+      } else {
+        navigate(`/credential/${credential.id}`);
+      }
     }
+  }
+
+  function handleViewDetails(e: React.MouseEvent) {
+    e.stopPropagation();
+    navigate(`/credential/${credential.id}`);
   }
 
   return (
     <div
-      className={`cred-card${isRevoked ? ' cred-card--revoked' : ''}`}
-      role="article"
+      className={[
+        'cred-card',
+        isRevoked ? 'cred-card--revoked' : '',
+        selectable ? 'cred-card--selectable' : '',
+        selected ? 'cred-card--selected' : '',
+      ].filter(Boolean).join(' ')}
+      role={selectable ? 'checkbox' : 'article'}
+      aria-checked={selectable ? selected : undefined}
       tabIndex={0}
-      aria-label={`${credTypeLabel(credential.credential_type)} credential ${truncId}, status: ${label}`}
-      onClick={handleNavigate}
+      aria-label={`${credTypeLabel(credential.credential_type)} credential ${truncId}, status: ${label}${selectable ? (selected ? ', selected' : ', not selected') : ''}`}
+      onClick={handleClick}
       onKeyDown={handleKeyDown}
       style={{ cursor: 'pointer' }}
     >
+      {/* Selection checkbox */}
+      {selectable && (
+        <div
+          className={`cred-card__checkbox${selected ? ' cred-card__checkbox--checked' : ''}`}
+          aria-hidden="true"
+        >
+          {selected ? '✓' : ''}
+        </div>
+      )}
+
       {/* Header */}
       <div className={`cred-card__header cred-card__header--${headerMod}`}>
         <div className="cred-card__type">{credTypeLabel(credential.credential_type)}</div>
@@ -140,7 +172,17 @@ export function CredentialCard({ data, sliceId }: CredentialCardProps) {
 
       {/* Footer */}
       <div className="cred-card__footer" style={{ fontSize: '12px', color: 'var(--text-muted)', textAlign: 'center' }}>
-        Click to view details →
+        {selectable ? (
+          <button
+            className="btn btn--ghost btn--sm"
+            style={{ fontSize: '11px', padding: '4px 10px' }}
+            onClick={handleViewDetails}
+          >
+            View details →
+          </button>
+        ) : (
+          'Click to view details →'
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -5,6 +5,10 @@ import { CredentialCardSkeleton } from '../components/CredentialCardSkeleton';
 import { EmptyState } from '../components/EmptyState';
 import { ExportCredentialsDialog } from '../components/ExportCredentialsDialog';
 import { ImportCredentialsDialog } from '../components/ImportCredentialsDialog';
+import { CredentialSearchFilter, type SearchFilters } from '../components/CredentialSearchFilter';
+import { BulkActionsBar } from '../components/BulkActionsBar';
+import { BulkRevokeDialog } from '../components/BulkRevokeDialog';
+import { BulkShareDialog } from '../components/BulkShareDialog';
 import { useWallet, useRealtimeUpdates } from '../hooks';
 import {
   getCredentialsBySubject,
@@ -33,7 +37,66 @@ export default function Dashboard() {
   const [showImportDialog, setShowImportDialog] = useState(false);
   const [filters, setFilters] = useState<SearchFilters>(DEFAULT_FILTERS);
 
+  // Bulk selection state
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [showBulkExport, setShowBulkExport] = useState(false);
+  const [showBulkShare, setShowBulkShare] = useState(false);
+  const [showBulkRevoke, setShowBulkRevoke] = useState(false);
+
   const visibleCards = useMemo(() => filterAndSortCards(cards, filters), [cards, filters]);
+
+  const selectedCards = useMemo(
+    () => visibleCards.filter((c) => selectedIds.has(c.credential.id.toString())),
+    [visibleCards, selectedIds],
+  );
+
+  const canRevoke = useMemo(
+    () => selectedCards.some((c) => !c.credential.revoked),
+    [selectedCards],
+  );
+
+  function toggleSelectMode() {
+    setSelectMode((v) => !v);
+    setSelectedIds(new Set());
+  }
+
+  function handleToggleCard(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  function handleSelectAll() {
+    setSelectedIds(new Set(visibleCards.map((c) => c.credential.id.toString())));
+  }
+
+  function handleDeselectAll() {
+    setSelectedIds(new Set());
+  }
+
+  function handleExitSelectMode() {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+  }
+
+  function handleBulkRevokeConfirm(ids: bigint[]) {
+    setCards((prev) =>
+      prev.map((card) =>
+        ids.some((id) => id === card.credential.id)
+          ? { ...card, credential: { ...card.credential, revoked: true } }
+          : card,
+      ),
+    );
+    setSelectedIds(new Set());
+    setShowBulkRevoke(false);
+  }
 
   const fetchCredentials = useCallback(async (walletAddress: string) => {
     setLoading(true);
@@ -81,7 +144,6 @@ export default function Dashboard() {
 
             return { credential, attested, slice, expired, sliceError, credError: null };
           } catch (err) {
-            // Per-card error — return a placeholder so the grid still renders
             const msg = err instanceof Error ? err.message : 'Failed to load credential';
             return {
               credential: {
@@ -139,19 +201,28 @@ export default function Dashboard() {
           </div>
           <div style={{ display: 'flex', gap: '12px', alignItems: 'flex-start' }}>
             <span
-              className={`badge badge--${realtimeStatus === 'connected' ? 'green' : realtimeStatus === 'polling' ? 'gray' : 'gray'}`}
+              className={`badge badge--${realtimeStatus === 'connected' ? 'green' : 'gray'}`}
               title={`Real-time status: ${realtimeStatus}`}
               style={{ alignSelf: 'center' }}
             >
               {realtimeStatus === 'connected' ? '🟢 Live' : realtimeStatus === 'polling' ? '🔄 Polling' : '⚪ Offline'}
             </span>
-            {cards.length > 0 && (
-              <button
-                className="btn btn--primary btn--sm"
-                onClick={() => setShowExportDialog(true)}
-              >
-                📥 Export
-              </button>
+            {!selectMode && cards.length > 0 && (
+              <>
+                <button
+                  className="btn btn--ghost btn--sm"
+                  onClick={toggleSelectMode}
+                  title="Enter selection mode to perform bulk actions"
+                >
+                  ☑ Select
+                </button>
+                <button
+                  className="btn btn--primary btn--sm"
+                  onClick={() => setShowExportDialog(true)}
+                >
+                  📥 Export
+                </button>
+              </>
             )}
             <button
               className="btn btn--ghost btn--sm"
@@ -231,6 +302,9 @@ export default function Dashboard() {
                   key={card.credential.id.toString()}
                   data={card}
                   sliceId={sliceId}
+                  selectable={selectMode}
+                  selected={selectedIds.has(card.credential.id.toString())}
+                  onToggle={handleToggleCard}
                 />
               ))}
             </div>
@@ -255,10 +329,51 @@ export default function Dashboard() {
         </div>
       </footer>
 
+      {/* Bulk actions bar — visible in select mode */}
+      {selectMode && (
+        <BulkActionsBar
+          selectedCount={selectedIds.size}
+          totalCount={visibleCards.length}
+          canRevoke={canRevoke}
+          onSelectAll={handleSelectAll}
+          onDeselectAll={handleDeselectAll}
+          onExport={() => setShowBulkExport(true)}
+          onShare={() => setShowBulkShare(true)}
+          onRevoke={() => setShowBulkRevoke(true)}
+          onExit={handleExitSelectMode}
+        />
+      )}
+
+      {/* All-credentials export dialog */}
       {showExportDialog && (
         <ExportCredentialsDialog
           credentials={cards.map(c => c.credential)}
           onClose={() => setShowExportDialog(false)}
+        />
+      )}
+
+      {/* Bulk export — only selected credentials */}
+      {showBulkExport && (
+        <ExportCredentialsDialog
+          credentials={selectedCards.map(c => c.credential)}
+          onClose={() => setShowBulkExport(false)}
+        />
+      )}
+
+      {/* Bulk share */}
+      {showBulkShare && (
+        <BulkShareDialog
+          credentials={selectedCards.map(c => c.credential)}
+          onClose={() => setShowBulkShare(false)}
+        />
+      )}
+
+      {/* Bulk revoke */}
+      {showBulkRevoke && (
+        <BulkRevokeDialog
+          credentials={selectedCards.map(c => c.credential)}
+          onConfirm={handleBulkRevokeConfirm}
+          onClose={() => setShowBulkRevoke(false)}
         />
       )}
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2387,3 +2387,177 @@ textarea {
     grid-template-columns: 1fr;
   }
 }
+
+/* ── Bulk Selection ───────────────────────────────────────────────────────────── */
+
+/* Card selection states */
+.cred-card--selectable {
+  position: relative;
+  user-select: none;
+}
+
+.cred-card--selected {
+  border-color: var(--accent-primary) !important;
+  box-shadow: 0 0 0 2px var(--accent-glow), var(--shadow-card) !important;
+}
+
+.cred-card--selectable:hover {
+  border-color: rgba(99, 102, 241, 0.4);
+}
+
+.cred-card__checkbox {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  border: 2px solid var(--text-muted);
+  background: var(--bg-input);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  color: #fff;
+  transition: border-color var(--transition), background var(--transition);
+  z-index: 1;
+  pointer-events: none;
+}
+
+.cred-card__checkbox--checked {
+  border-color: var(--accent-primary);
+  background: var(--accent-primary);
+}
+
+/* Danger button variant */
+.btn--danger {
+  background: var(--red);
+  color: #fff;
+  border: 1px solid transparent;
+  border-radius: var(--radius-full);
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity var(--transition), transform var(--transition);
+}
+
+.btn--danger:hover { opacity: 0.85; }
+.btn--danger:active { transform: translateY(1px); }
+.btn--danger:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* ── Bulk Actions Bar ────────────────────────────────────────────────────────── */
+
+.bulk-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 24px;
+  background: rgba(17, 18, 24, 0.95);
+  backdrop-filter: blur(12px);
+  border-top: 1px solid var(--border-active);
+  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.5);
+}
+
+.bulk-bar__left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.bulk-bar__count {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  min-width: 100px;
+}
+
+.bulk-bar__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ── Bulk Revoke Dialog ───────────────────────────────────────────────────────── */
+
+.bulk-revoke-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 240px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.bulk-revoke-list__item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  background: var(--bg-input);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+}
+
+/* ── Bulk Share Dialog ────────────────────────────────────────────────────────── */
+
+.bulk-share-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 320px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.bulk-share-list__item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  background: var(--bg-input);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+}
+
+.bulk-share-list__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.bulk-share-list__link {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.bulk-share-list__url {
+  flex: 1;
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 600px) {
+  .bulk-bar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+    padding: 12px 16px;
+  }
+
+  .bulk-bar__actions {
+    flex-wrap: wrap;
+  }
+}


### PR DESCRIPTION
…revoke

Users can now enter a selection mode on the Dashboard to manage multiple credentials at once instead of being limited to one credential at a time.

- Add Select mode toggle on the Dashboard header; clicking it activates per-card checkboxes and disables the normal navigate-on-click behavior
- BulkActionsBar: fixed bottom toolbar showing selected count, Select All / Clear controls, and Export / Share / Revoke action buttons (Revoke only shown when at least one selected credential is not already revoked)
- BulkRevokeDialog: confirmation dialog that lists credentials to be revoked, warns the operation is irreversible, skips already-revoked items, and applies an optimistic local-state update on confirm
- BulkShareDialog: generates a public on-chain verification URL for each selected credential with individual copy buttons and a Copy All N Links shortcut
- Bulk Export: reuses ExportCredentialsDialog scoped to the selected subset, supporting JSON / CSV / PDF formats
- CredentialCard: extended with optional selectable / selected / onToggle props; in selection mode the card renders a checkbox badge and a View details button so navigation is still accessible
- styles.css: new utility classes for cred-card--selectable, --selected, the checkbox badge, btn--danger, the bulk-bar fixed toolbar, bulk-revoke and bulk-share list layouts, and a responsive mobile stack for the bar

closes #943 