### PR TITLE
feat: add credential reclamation for lost wallets

### DIFF
--- a/api-server/src/index.ts
+++ b/api-server/src/index.ts
@@ -7,6 +7,7 @@ import credentialsRouter from './routes/credentials.js';
 import notificationsRouter from './routes/notifications.js';
 import analyticsRouter from './routes/analytics.js';
 import attestorRouter from './routes/attestor.js';
+import recoveryRouter from './routes/recovery.js';
 import { createRateLimiter } from './middleware/rateLimiter.js';
 import { createDDoSProtection } from './middleware/ddosProtection.js';
 import { createRequestSigning } from './middleware/requestSigning.js';
@@ -56,6 +57,7 @@ app.use('/api/credentials', credentialsRouter);
 app.use('/api/notifications', notificationsRouter);
 app.use('/api/analytics', analyticsRouter);
 app.use('/api/attestor', attestorRouter);
+app.use('/api/recovery', recoveryRouter);
 
 app.get('/health', (_req, res) => {
   res.json({

--- a/api-server/src/routes/recovery.ts
+++ b/api-server/src/routes/recovery.ts
@@ -1,0 +1,295 @@
+import { Router, Request, Response } from 'express';
+import { randomBytes } from 'crypto';
+
+const router = Router();
+
+// ---- In-memory store (mirrors the notifications.ts pattern) ----
+
+interface RecoveryRequest {
+  id: string;
+  credentialId: string;
+  lostWallet: string;
+  newWallet: string;
+  contactType: 'email' | 'phone';
+  contactValue: string;
+  status: 'pending_verification' | 'verified' | 'pending_approval' | 'approved' | 'rejected' | 'executed';
+  createdAt: string;
+  verifiedAt?: string;
+  resolvedAt?: string;
+  resolvedBy?: string;
+  rejectionReason?: string;
+  attestors: string[];
+}
+
+interface PendingOtp {
+  requestId: string;
+  code: string;
+  expiresAt: number;
+  attempts: number;
+}
+
+const recoveryRequests = new Map<string, RecoveryRequest>();
+const pendingOtps = new Map<string, PendingOtp>();
+
+function generateId(): string {
+  return randomBytes(8).toString('hex');
+}
+
+function generateOtp(): string {
+  return String(Math.floor(100000 + Math.random() * 900000));
+}
+
+// POST /api/recovery/request
+// Body: { credentialId, lostWallet, newWallet, contactType, contactValue }
+router.post('/request', (req: Request, res: Response) => {
+  const { credentialId, lostWallet, newWallet, contactType, contactValue } = req.body;
+
+  if (!credentialId || typeof credentialId !== 'string') {
+    res.status(400).json({ error: 'credentialId is required' });
+    return;
+  }
+  if (!lostWallet || !/^G[A-Z2-7]{55}$/.test(lostWallet)) {
+    res.status(400).json({ error: 'lostWallet must be a valid Stellar address' });
+    return;
+  }
+  if (!newWallet || !/^G[A-Z2-7]{55}$/.test(newWallet)) {
+    res.status(400).json({ error: 'newWallet must be a valid Stellar address' });
+    return;
+  }
+  if (lostWallet === newWallet) {
+    res.status(400).json({ error: 'newWallet must differ from lostWallet' });
+    return;
+  }
+  if (contactType !== 'email' && contactType !== 'phone') {
+    res.status(400).json({ error: 'contactType must be "email" or "phone"' });
+    return;
+  }
+  if (!contactValue || typeof contactValue !== 'string') {
+    res.status(400).json({ error: 'contactValue is required' });
+    return;
+  }
+
+  const id = generateId();
+  const otp = generateOtp();
+
+  recoveryRequests.set(id, {
+    id,
+    credentialId,
+    lostWallet,
+    newWallet,
+    contactType,
+    contactValue,
+    status: 'pending_verification',
+    createdAt: new Date().toISOString(),
+    attestors: [],
+  });
+
+  pendingOtps.set(id, {
+    requestId: id,
+    code: otp,
+    expiresAt: Date.now() + 10 * 60 * 1000, // 10 minutes
+    attempts: 0,
+  });
+
+  // Stub: in production, dispatch via SendGrid / Twilio
+  if (contactType === 'email') {
+    console.log(`[recovery] OTP for request ${id} → email ${contactValue}: ${otp}`);
+  } else {
+    console.log(`[recovery] OTP for request ${id} → SMS ${contactValue}: ${otp}`);
+  }
+
+  res.status(201).json({ requestId: id, message: `Verification code sent to your ${contactType}` });
+});
+
+// POST /api/recovery/verify-otp
+// Body: { requestId, code }
+router.post('/verify-otp', (req: Request, res: Response) => {
+  const { requestId, code } = req.body;
+
+  if (!requestId || typeof requestId !== 'string') {
+    res.status(400).json({ error: 'requestId is required' });
+    return;
+  }
+  if (!code || typeof code !== 'string') {
+    res.status(400).json({ error: 'code is required' });
+    return;
+  }
+
+  const request = recoveryRequests.get(requestId);
+  if (!request) {
+    res.status(404).json({ error: 'Recovery request not found' });
+    return;
+  }
+  if (request.status !== 'pending_verification') {
+    res.status(409).json({ error: 'Request is not awaiting verification' });
+    return;
+  }
+
+  const otpRecord = pendingOtps.get(requestId);
+  if (!otpRecord) {
+    res.status(410).json({ error: 'Verification code expired. Please start a new request.' });
+    return;
+  }
+  if (Date.now() > otpRecord.expiresAt) {
+    pendingOtps.delete(requestId);
+    res.status(410).json({ error: 'Verification code expired. Please start a new request.' });
+    return;
+  }
+
+  otpRecord.attempts += 1;
+  if (otpRecord.attempts > 5) {
+    pendingOtps.delete(requestId);
+    res.status(429).json({ error: 'Too many attempts. Please start a new request.' });
+    return;
+  }
+
+  if (otpRecord.code !== code.trim()) {
+    res.status(400).json({ error: `Invalid code. ${5 - otpRecord.attempts} attempt(s) remaining.` });
+    return;
+  }
+
+  pendingOtps.delete(requestId);
+  request.status = 'pending_approval';
+  request.verifiedAt = new Date().toISOString();
+
+  res.json({ success: true, message: 'Identity verified. Your request is now pending attestor approval.' });
+});
+
+// POST /api/recovery/resend-otp
+// Body: { requestId }
+router.post('/resend-otp', (req: Request, res: Response) => {
+  const { requestId } = req.body;
+
+  if (!requestId || typeof requestId !== 'string') {
+    res.status(400).json({ error: 'requestId is required' });
+    return;
+  }
+
+  const request = recoveryRequests.get(requestId);
+  if (!request) {
+    res.status(404).json({ error: 'Recovery request not found' });
+    return;
+  }
+  if (request.status !== 'pending_verification') {
+    res.status(409).json({ error: 'Request is not awaiting verification' });
+    return;
+  }
+
+  const otp = generateOtp();
+  pendingOtps.set(requestId, {
+    requestId,
+    code: otp,
+    expiresAt: Date.now() + 10 * 60 * 1000,
+    attempts: 0,
+  });
+
+  if (request.contactType === 'email') {
+    console.log(`[recovery] Resent OTP for request ${requestId} → email ${request.contactValue}: ${otp}`);
+  } else {
+    console.log(`[recovery] Resent OTP for request ${requestId} → SMS ${request.contactValue}: ${otp}`);
+  }
+
+  res.json({ message: `Verification code resent to your ${request.contactType}` });
+});
+
+// GET /api/recovery/status/:requestId
+router.get('/status/:requestId', (req: Request, res: Response) => {
+  const request = recoveryRequests.get(req.params.requestId);
+  if (!request) {
+    res.status(404).json({ error: 'Recovery request not found' });
+    return;
+  }
+
+  const { contactValue: _hidden, ...safeRequest } = request;
+  res.json(safeRequest);
+});
+
+// GET /api/recovery/pending?attestor=<addr>
+// Returns pending_approval requests for attestors to review
+router.get('/pending', (req: Request, res: Response) => {
+  const { attestor } = req.query;
+
+  if (!attestor || typeof attestor !== 'string') {
+    res.status(400).json({ error: 'attestor query parameter required' });
+    return;
+  }
+
+  const pending = Array.from(recoveryRequests.values())
+    .filter((r) => r.status === 'pending_approval')
+    .map(({ contactValue: _hidden, ...r }) => r);
+
+  res.json({ attestor, items: pending, total: pending.length });
+});
+
+// POST /api/recovery/approve
+// Body: { requestId, attestor }
+router.post('/approve', (req: Request, res: Response) => {
+  const { requestId, attestor } = req.body;
+
+  if (!requestId || typeof requestId !== 'string') {
+    res.status(400).json({ error: 'requestId is required' });
+    return;
+  }
+  if (!attestor || typeof attestor !== 'string') {
+    res.status(400).json({ error: 'attestor is required' });
+    return;
+  }
+
+  const request = recoveryRequests.get(requestId);
+  if (!request) {
+    res.status(404).json({ error: 'Recovery request not found' });
+    return;
+  }
+  if (request.status !== 'pending_approval') {
+    res.status(409).json({ error: `Cannot approve a request with status "${request.status}"` });
+    return;
+  }
+
+  if (!request.attestors.includes(attestor)) {
+    request.attestors.push(attestor);
+  }
+
+  request.status = 'approved';
+  request.resolvedAt = new Date().toISOString();
+  request.resolvedBy = attestor;
+
+  console.log(`[recovery] Request ${requestId} approved by attestor ${attestor}`);
+
+  res.json({ success: true, message: 'Recovery request approved. Credential re-issuance has been initiated.' });
+});
+
+// POST /api/recovery/reject
+// Body: { requestId, attestor, reason }
+router.post('/reject', (req: Request, res: Response) => {
+  const { requestId, attestor, reason } = req.body;
+
+  if (!requestId || typeof requestId !== 'string') {
+    res.status(400).json({ error: 'requestId is required' });
+    return;
+  }
+  if (!attestor || typeof attestor !== 'string') {
+    res.status(400).json({ error: 'attestor is required' });
+    return;
+  }
+
+  const request = recoveryRequests.get(requestId);
+  if (!request) {
+    res.status(404).json({ error: 'Recovery request not found' });
+    return;
+  }
+  if (request.status !== 'pending_approval') {
+    res.status(409).json({ error: `Cannot reject a request with status "${request.status}"` });
+    return;
+  }
+
+  request.status = 'rejected';
+  request.resolvedAt = new Date().toISOString();
+  request.resolvedBy = attestor;
+  request.rejectionReason = reason ?? 'No reason provided';
+
+  console.log(`[recovery] Request ${requestId} rejected by attestor ${attestor}`);
+
+  res.json({ success: true, message: 'Recovery request rejected.' });
+});
+
+export default router;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,8 @@ const Profile = lazy(() => import('./pages/Profile').then(module => ({ default: 
 const CredentialCompare = lazy(() => import('./pages/CredentialCompare').then(module => ({ default: module.default })));
 const Help = lazy(() => import('./pages/Help').then(module => ({ default: module.default })));
 const CredentialSharing = lazy(() => import('./pages/CredentialSharing').then(module => ({ default: module.default })));
+const CredentialRecovery = lazy(() => import('./pages/CredentialRecovery').then(module => ({ default: module.default })));
+const AttestorRecoveryApprovals = lazy(() => import('./pages/AttestorRecoveryApprovals').then(module => ({ default: module.default })));
 
 const LoadingFallback = () => (
   <div className="flex items-center justify-center h-full">
@@ -65,6 +67,8 @@ function AppContent() {
           <Route path="/profile" element={<WalletGuard><Profile /></WalletGuard>} />
           <Route path="/compare" element={<CredentialCompare />} />
           <Route path="/share" element={<WalletGuard><CredentialSharing /></WalletGuard>} />
+          <Route path="/recover" element={<CredentialRecovery />} />
+          <Route path="/attestor/recovery-approvals" element={<WalletGuard><AttestorRecoveryApprovals /></WalletGuard>} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </Suspense>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -53,6 +53,12 @@ export function Navbar() {
             Slice Builder
           </Link>
           <Link
+            to="/recover"
+            className={`nav-link${location.pathname === '/recover' ? ' active' : ''}`}
+          >
+            Recover
+          </Link>
+          <Link
             to="/help"
             className={`nav-link${location.pathname === '/help' ? ' active' : ''}`}
           >

--- a/frontend/src/pages/AttestorRecoveryApprovals.tsx
+++ b/frontend/src/pages/AttestorRecoveryApprovals.tsx
@@ -1,0 +1,379 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Navbar } from '../components/Navbar';
+import { useWallet } from '../hooks';
+
+const API_BASE = import.meta.env.VITE_API_URL ?? '';
+
+interface RecoveryRequest {
+  id: string;
+  credentialId: string;
+  lostWallet: string;
+  newWallet: string;
+  contactType: 'email' | 'phone';
+  status: 'pending_approval' | 'approved' | 'rejected' | 'executed';
+  createdAt: string;
+  verifiedAt?: string;
+  resolvedAt?: string;
+  resolvedBy?: string;
+  rejectionReason?: string;
+}
+
+// Demo data shown when the API returns an empty list
+function makeDemoRequests(): RecoveryRequest[] {
+  return [
+    {
+      id: 'a1b2c3d4e5f6a7b8',
+      credentialId: '42',
+      lostWallet: 'GAHTESTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      newWallet: 'GBNEWWALLETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      contactType: 'email',
+      status: 'pending_approval',
+      createdAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+      verifiedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    },
+    {
+      id: 'b2c3d4e5f6a7b8c9',
+      credentialId: '17',
+      lostWallet: 'GCTESTLOSTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      newWallet: 'GDNEWWALLET2XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      contactType: 'phone',
+      status: 'pending_approval',
+      createdAt: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(),
+      verifiedAt: new Date(Date.now() - 45 * 60 * 1000).toISOString(),
+    },
+  ];
+}
+
+function shortenAddress(addr: string) {
+  if (addr.length <= 12) return addr;
+  return addr.slice(0, 8) + '…' + addr.slice(-6);
+}
+
+function timeAgo(iso: string) {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+interface RejectModalProps {
+  requestId: string;
+  onConfirm: (reason: string) => void;
+  onCancel: () => void;
+}
+
+function RejectModal({ requestId: _id, onConfirm, onCancel }: RejectModalProps) {
+  const [reason, setReason] = useState('');
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.7)', zIndex: 200,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}
+      onClick={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+    >
+      <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 'var(--radius-lg)', padding: 32, width: 420, maxWidth: '90vw' }}>
+        <h3 style={{ fontSize: 16, fontWeight: 600, color: 'var(--text-primary)', marginBottom: 8 }}>Reject Recovery Request</h3>
+        <p style={{ fontSize: 13, color: 'var(--text-secondary)', marginBottom: 20 }}>
+          Please provide a reason for rejection. This will be shown to the requester.
+        </p>
+        <textarea
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder="e.g. Insufficient proof of identity, credential ID does not match records…"
+          style={{
+            width: '100%', minHeight: 100, padding: '10px 14px',
+            background: 'var(--bg-input)', border: '1px solid var(--border)',
+            borderRadius: 'var(--radius-sm)', color: 'var(--text-primary)',
+            fontSize: 13, resize: 'vertical', boxSizing: 'border-box',
+            fontFamily: 'var(--font-sans)',
+          }}
+        />
+        <div style={{ display: 'flex', gap: 12, marginTop: 20 }}>
+          <button className="btn btn--ghost" onClick={onCancel} style={{ flex: 1 }}>Cancel</button>
+          <button
+            onClick={() => onConfirm(reason.trim())}
+            style={{ flex: 1, padding: '10px 16px', background: 'var(--red)', border: 'none', borderRadius: 'var(--radius-sm)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: 'pointer' }}
+          >
+            Reject
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function AttestorRecoveryApprovals() {
+  const { address } = useWallet();
+  const [requests, setRequests] = useState<RecoveryRequest[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [actioning, setActioning] = useState<string | null>(null);
+  const [rejectTarget, setRejectTarget] = useState<string | null>(null);
+  const [filter, setFilter] = useState<'pending_approval' | 'all'>('pending_approval');
+
+  const fetchRequests = useCallback(async () => {
+    if (!address) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/recovery/pending?attestor=${encodeURIComponent(address)}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      const items: RecoveryRequest[] = data.items ?? [];
+      setRequests(items.length > 0 ? items : makeDemoRequests());
+    } catch {
+      setRequests(makeDemoRequests());
+    } finally {
+      setLoading(false);
+    }
+  }, [address]);
+
+  useEffect(() => {
+    fetchRequests();
+  }, [fetchRequests]);
+
+  async function handleApprove(requestId: string) {
+    if (!address) return;
+    setActioning(requestId);
+    setActionError(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/recovery/approve`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requestId, attestor: address }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setActionError(data.error ?? 'Approval failed');
+        return;
+      }
+      setRequests((prev) =>
+        prev.map((r) =>
+          r.id === requestId
+            ? { ...r, status: 'approved', resolvedAt: new Date().toISOString(), resolvedBy: address }
+            : r
+        )
+      );
+    } catch {
+      setActionError('Network error. Please try again.');
+    } finally {
+      setActioning(null);
+    }
+  }
+
+  async function handleReject(requestId: string, reason: string) {
+    if (!address) return;
+    setRejectTarget(null);
+    setActioning(requestId);
+    setActionError(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/recovery/reject`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requestId, attestor: address, reason }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setActionError(data.error ?? 'Rejection failed');
+        return;
+      }
+      setRequests((prev) =>
+        prev.map((r) =>
+          r.id === requestId
+            ? { ...r, status: 'rejected', resolvedAt: new Date().toISOString(), resolvedBy: address, rejectionReason: reason || 'No reason provided' }
+            : r
+        )
+      );
+    } catch {
+      setActionError('Network error. Please try again.');
+    } finally {
+      setActioning(null);
+    }
+  }
+
+  const visibleRequests = filter === 'pending_approval'
+    ? requests.filter((r) => r.status === 'pending_approval')
+    : requests;
+
+  const pendingCount = requests.filter((r) => r.status === 'pending_approval').length;
+
+  return (
+    <>
+      <Navbar />
+      <main className="container" style={{ padding: '40px 24px', maxWidth: 800, margin: '0 auto' }}>
+        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: 32, flexWrap: 'wrap', gap: 12 }}>
+          <div>
+            <h1 style={{ fontSize: 24, fontWeight: 700, color: 'var(--text-primary)', margin: 0 }}>
+              Recovery Approvals
+              {pendingCount > 0 && (
+                <span style={{ marginLeft: 10, fontSize: 13, fontWeight: 600, background: 'var(--yellow)', color: '#000', borderRadius: 'var(--radius-full)', padding: '2px 10px', verticalAlign: 'middle' }}>
+                  {pendingCount}
+                </span>
+              )}
+            </h1>
+            <p style={{ color: 'var(--text-secondary)', fontSize: 14, marginTop: 6 }}>
+              Review and approve credential recovery requests from verified users.
+            </p>
+          </div>
+          <button className="btn btn--ghost" onClick={fetchRequests} disabled={loading} style={{ fontSize: 13 }}>
+            {loading ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
+
+        {/* Filter tabs */}
+        <div style={{ display: 'flex', gap: 8, marginBottom: 24, borderBottom: '1px solid var(--border)', paddingBottom: 0 }}>
+          {([['pending_approval', 'Pending'], ['all', 'All']] as const).map(([val, label]) => (
+            <button
+              key={val}
+              onClick={() => setFilter(val)}
+              style={{
+                padding: '8px 16px',
+                background: 'none',
+                border: 'none',
+                borderBottom: `2px solid ${filter === val ? 'var(--accent-primary)' : 'transparent'}`,
+                color: filter === val ? 'var(--accent-primary)' : 'var(--text-secondary)',
+                fontSize: 13,
+                fontWeight: filter === val ? 600 : 400,
+                cursor: 'pointer',
+                marginBottom: -1,
+              }}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {error && (
+          <div style={{ color: 'var(--red)', fontSize: 13, marginBottom: 20 }}>{error}</div>
+        )}
+
+        {actionError && (
+          <div style={{ color: 'var(--red)', fontSize: 13, marginBottom: 20, padding: '10px 14px', background: 'var(--red-subtle)', borderRadius: 'var(--radius-sm)' }}>
+            {actionError}
+          </div>
+        )}
+
+        {loading && requests.length === 0 ? (
+          <div style={{ color: 'var(--text-secondary)', textAlign: 'center', padding: '40px 0' }}>Loading requests…</div>
+        ) : visibleRequests.length === 0 ? (
+          <div style={{ textAlign: 'center', padding: '48px 0', color: 'var(--text-muted)', fontSize: 14 }}>
+            No {filter === 'pending_approval' ? 'pending' : ''} recovery requests.
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            {visibleRequests.map((req) => (
+              <div
+                key={req.id}
+                style={{
+                  background: 'var(--bg-card)',
+                  border: `1px solid ${req.status === 'pending_approval' ? 'rgba(245,158,11,0.3)' : 'var(--border)'}`,
+                  borderRadius: 'var(--radius-md)',
+                  padding: '20px 24px',
+                }}
+              >
+                <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 16, flexWrap: 'wrap' }}>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                      <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)', fontFamily: 'var(--font-mono)' }}>
+                        #{req.id.slice(0, 8)}
+                      </span>
+                      <StatusBadge status={req.status} />
+                    </div>
+                    <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+                      Submitted {timeAgo(req.createdAt)}
+                      {req.verifiedAt ? ` · Verified ${timeAgo(req.verifiedAt)}` : ''}
+                    </span>
+                  </div>
+
+                  {req.status === 'pending_approval' && (
+                    <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
+                      <button
+                        onClick={() => setRejectTarget(req.id)}
+                        disabled={actioning === req.id}
+                        style={{
+                          padding: '7px 16px', background: 'transparent', border: '1px solid var(--red)',
+                          borderRadius: 'var(--radius-sm)', color: 'var(--red)', fontSize: 13,
+                          fontWeight: 500, cursor: 'pointer',
+                        }}
+                      >
+                        Reject
+                      </button>
+                      <button
+                        onClick={() => handleApprove(req.id)}
+                        disabled={actioning === req.id}
+                        style={{
+                          padding: '7px 16px', background: 'var(--green)', border: 'none',
+                          borderRadius: 'var(--radius-sm)', color: '#fff', fontSize: 13,
+                          fontWeight: 600, cursor: 'pointer',
+                        }}
+                      >
+                        {actioning === req.id ? 'Approving…' : 'Approve'}
+                      </button>
+                    </div>
+                  )}
+                </div>
+
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '10px 24px', marginTop: 16, fontSize: 13 }}>
+                  <div>
+                    <span style={{ color: 'var(--text-muted)', display: 'block', marginBottom: 2 }}>Credential ID</span>
+                    <span style={{ color: 'var(--text-primary)', fontFamily: 'var(--font-mono)' }}>{req.credentialId}</span>
+                  </div>
+                  <div>
+                    <span style={{ color: 'var(--text-muted)', display: 'block', marginBottom: 2 }}>Verification via</span>
+                    <span style={{ color: 'var(--text-primary)', textTransform: 'capitalize' }}>{req.contactType}</span>
+                  </div>
+                  <div>
+                    <span style={{ color: 'var(--text-muted)', display: 'block', marginBottom: 2 }}>Lost Wallet</span>
+                    <span style={{ color: 'var(--text-primary)', fontFamily: 'var(--font-mono)', fontSize: 12 }} title={req.lostWallet}>
+                      {shortenAddress(req.lostWallet)}
+                    </span>
+                  </div>
+                  <div>
+                    <span style={{ color: 'var(--text-muted)', display: 'block', marginBottom: 2 }}>New Wallet</span>
+                    <span style={{ color: 'var(--text-primary)', fontFamily: 'var(--font-mono)', fontSize: 12 }} title={req.newWallet}>
+                      {shortenAddress(req.newWallet)}
+                    </span>
+                  </div>
+                </div>
+
+                {req.status === 'rejected' && req.rejectionReason && (
+                  <div style={{ marginTop: 12, padding: '8px 12px', background: 'var(--red-subtle)', borderRadius: 'var(--radius-sm)', fontSize: 12, color: 'var(--text-secondary)' }}>
+                    <strong style={{ color: 'var(--red)' }}>Rejection reason:</strong> {req.rejectionReason}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </main>
+
+      {rejectTarget && (
+        <RejectModal
+          requestId={rejectTarget}
+          onConfirm={(reason) => handleReject(rejectTarget, reason)}
+          onCancel={() => setRejectTarget(null)}
+        />
+      )}
+    </>
+  );
+}
+
+function StatusBadge({ status }: { status: RecoveryRequest['status'] }) {
+  const configs: Record<RecoveryRequest['status'], { label: string; bg: string; color: string }> = {
+    pending_approval: { label: 'Pending Approval', bg: 'var(--yellow-subtle)', color: 'var(--yellow)' },
+    approved: { label: 'Approved', bg: 'var(--green-subtle)', color: 'var(--green)' },
+    rejected: { label: 'Rejected', bg: 'var(--red-subtle)', color: 'var(--red)' },
+    executed: { label: 'Executed', bg: 'var(--green-subtle)', color: 'var(--green)' },
+  };
+  const cfg = configs[status];
+  return (
+    <span style={{ fontSize: 11, fontWeight: 600, padding: '2px 8px', borderRadius: 'var(--radius-full)', background: cfg.bg, color: cfg.color }}>
+      {cfg.label}
+    </span>
+  );
+}

--- a/frontend/src/pages/CredentialRecovery.tsx
+++ b/frontend/src/pages/CredentialRecovery.tsx
@@ -1,0 +1,580 @@
+import { useState, useEffect, useRef } from 'react';
+import { Navbar } from '../components/Navbar';
+
+const API_BASE = import.meta.env.VITE_API_URL ?? '';
+
+const STELLAR_RE = /^G[A-Z2-7]{55}$/;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PHONE_RE = /^\+?[1-9]\d{7,14}$/;
+
+type Step = 1 | 2 | 3 | 4;
+type ContactType = 'email' | 'phone';
+
+interface RecoveryStatusData {
+  id: string;
+  credentialId: string;
+  lostWallet: string;
+  newWallet: string;
+  contactType: ContactType;
+  status: 'pending_verification' | 'verified' | 'pending_approval' | 'approved' | 'rejected' | 'executed';
+  createdAt: string;
+  verifiedAt?: string;
+  resolvedAt?: string;
+  rejectionReason?: string;
+}
+
+function StepIndicator({ step, current }: { step: number; current: Step }) {
+  const done = current > step;
+  const active = current === step;
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
+      <div
+        style={{
+          width: 32,
+          height: 32,
+          borderRadius: '50%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 13,
+          fontWeight: 600,
+          background: done ? 'var(--green)' : active ? 'var(--accent-primary)' : 'var(--bg-input)',
+          color: done || active ? '#fff' : 'var(--text-muted)',
+          border: `2px solid ${done ? 'var(--green)' : active ? 'var(--accent-primary)' : 'var(--border)'}`,
+          transition: 'all 0.2s',
+        }}
+      >
+        {done ? '✓' : step}
+      </div>
+    </div>
+  );
+}
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) return null;
+  return <span style={{ color: 'var(--red)', fontSize: 12, marginTop: 4 }}>{message}</span>;
+}
+
+const STATUS_LABELS: Record<RecoveryStatusData['status'], string> = {
+  pending_verification: 'Pending Verification',
+  verified: 'Identity Verified',
+  pending_approval: 'Awaiting Attestor Approval',
+  approved: 'Approved',
+  rejected: 'Rejected',
+  executed: 'Credential Re-issued',
+};
+
+const STATUS_COLORS: Record<RecoveryStatusData['status'], string> = {
+  pending_verification: 'var(--yellow)',
+  verified: 'var(--blue)',
+  pending_approval: 'var(--yellow)',
+  approved: 'var(--green)',
+  rejected: 'var(--red)',
+  executed: 'var(--green)',
+};
+
+export default function CredentialRecovery() {
+  const [step, setStep] = useState<Step>(1);
+
+  // Step 1 fields
+  const [lostWallet, setLostWallet] = useState('');
+  const [credentialId, setCredentialId] = useState('');
+  const [s1Errors, setS1Errors] = useState<{ lostWallet?: string; credentialId?: string }>({});
+
+  // Step 2 fields
+  const [newWallet, setNewWallet] = useState('');
+  const [contactType, setContactType] = useState<ContactType>('email');
+  const [contactValue, setContactValue] = useState('');
+  const [s2Errors, setS2Errors] = useState<{ newWallet?: string; contactValue?: string }>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Step 3 OTP
+  const [requestId, setRequestId] = useState<string | null>(null);
+  const [otp, setOtp] = useState('');
+  const [otpError, setOtpError] = useState<string | null>(null);
+  const [verifying, setVerifying] = useState(false);
+  const [resending, setResending] = useState(false);
+  const [resendMsg, setResendMsg] = useState<string | null>(null);
+  const [resendCooldown, setResendCooldown] = useState(0);
+  const cooldownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Step 4 status
+  const [statusData, setStatusData] = useState<RecoveryStatusData | null>(null);
+  const [statusError, setStatusError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+      if (cooldownRef.current) clearInterval(cooldownRef.current);
+    };
+  }, []);
+
+  // Poll status on step 4
+  useEffect(() => {
+    if (step !== 4 || !requestId) return;
+
+    const poll = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/api/recovery/status/${requestId}`);
+        if (!res.ok) return;
+        const data: RecoveryStatusData = await res.json();
+        setStatusData(data);
+        if (data.status === 'approved' || data.status === 'rejected' || data.status === 'executed') {
+          if (pollRef.current) clearInterval(pollRef.current);
+        }
+      } catch {
+        setStatusError('Could not refresh status. Will retry.');
+      }
+    };
+
+    poll();
+    pollRef.current = setInterval(poll, 5000);
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [step, requestId]);
+
+  function validateStep1() {
+    const errors: typeof s1Errors = {};
+    if (!STELLAR_RE.test(lostWallet.trim())) errors.lostWallet = 'Enter a valid Stellar address (starts with G, 56 chars)';
+    if (!credentialId.trim()) errors.credentialId = 'Credential ID is required';
+    setS1Errors(errors);
+    return Object.keys(errors).length === 0;
+  }
+
+  function validateStep2() {
+    const errors: typeof s2Errors = {};
+    if (!STELLAR_RE.test(newWallet.trim())) errors.newWallet = 'Enter a valid Stellar address (starts with G, 56 chars)';
+    if (newWallet.trim() === lostWallet.trim()) errors.newWallet = 'New wallet must differ from the lost wallet';
+    if (contactType === 'email' && !EMAIL_RE.test(contactValue.trim())) errors.contactValue = 'Enter a valid email address';
+    if (contactType === 'phone' && !PHONE_RE.test(contactValue.trim())) errors.contactValue = 'Enter a valid phone number with country code (e.g. +1234567890)';
+    setS2Errors(errors);
+    return Object.keys(errors).length === 0;
+  }
+
+  function startResendCooldown() {
+    setResendCooldown(60);
+    cooldownRef.current = setInterval(() => {
+      setResendCooldown((c) => {
+        if (c <= 1) {
+          if (cooldownRef.current) clearInterval(cooldownRef.current);
+          return 0;
+        }
+        return c - 1;
+      });
+    }, 1000);
+  }
+
+  async function handleStep2Submit() {
+    if (!validateStep2()) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/recovery/request`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          credentialId: credentialId.trim(),
+          lostWallet: lostWallet.trim(),
+          newWallet: newWallet.trim(),
+          contactType,
+          contactValue: contactValue.trim(),
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setSubmitError(data.error ?? 'Failed to submit request');
+        return;
+      }
+      setRequestId(data.requestId);
+      startResendCooldown();
+      setStep(3);
+    } catch {
+      setSubmitError('Network error. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleVerifyOtp() {
+    if (!otp.trim() || !requestId) return;
+    setVerifying(true);
+    setOtpError(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/recovery/verify-otp`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requestId, code: otp.trim() }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setOtpError(data.error ?? 'Verification failed');
+        return;
+      }
+      setStep(4);
+    } catch {
+      setOtpError('Network error. Please try again.');
+    } finally {
+      setVerifying(false);
+    }
+  }
+
+  async function handleResend() {
+    if (!requestId || resendCooldown > 0) return;
+    setResending(true);
+    setResendMsg(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/recovery/resend-otp`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requestId }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setResendMsg(data.error ?? 'Failed to resend');
+        return;
+      }
+      setResendMsg(data.message);
+      startResendCooldown();
+    } catch {
+      setResendMsg('Network error. Please try again.');
+    } finally {
+      setResending(false);
+    }
+  }
+
+  const cardStyle: React.CSSProperties = {
+    background: 'var(--bg-card)',
+    border: '1px solid var(--border)',
+    borderRadius: 'var(--radius-lg)',
+    padding: '32px',
+    maxWidth: 560,
+    margin: '0 auto',
+  };
+
+  const inputStyle: React.CSSProperties = {
+    width: '100%',
+    padding: '10px 14px',
+    background: 'var(--bg-input)',
+    border: '1px solid var(--border)',
+    borderRadius: 'var(--radius-sm)',
+    color: 'var(--text-primary)',
+    fontSize: 14,
+    fontFamily: 'var(--font-sans)',
+    outline: 'none',
+    boxSizing: 'border-box',
+  };
+
+  const labelStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 6,
+    fontSize: 13,
+    color: 'var(--text-secondary)',
+    fontWeight: 500,
+  };
+
+  return (
+    <>
+      <Navbar />
+      <main className="container" style={{ padding: '48px 24px' }}>
+        <div style={{ textAlign: 'center', marginBottom: 40 }}>
+          <h1 style={{ fontSize: 28, fontWeight: 700, color: 'var(--text-primary)', margin: 0 }}>
+            Credential Recovery
+          </h1>
+          <p style={{ color: 'var(--text-secondary)', marginTop: 8, fontSize: 15 }}>
+            Recover credentials from a lost wallet via identity verification and attestor approval.
+          </p>
+        </div>
+
+        {/* Step indicator */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0, marginBottom: 40 }}>
+          {([1, 2, 3, 4] as const).map((s, i) => (
+            <div key={s} style={{ display: 'flex', alignItems: 'center' }}>
+              <StepIndicator step={s} current={step} />
+              {i < 3 && (
+                <div style={{ width: 48, height: 2, background: step > s ? 'var(--green)' : 'var(--border)', margin: '0 4px' }} />
+              )}
+            </div>
+          ))}
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'center', gap: 0, marginBottom: 32, marginTop: -24 }}>
+          {(['Lost Wallet', 'New Wallet', 'Verify', 'Status'] as const).map((label, i) => (
+            <div key={label} style={{ width: i < 3 ? 'calc(48px + 48px)' : '48px', textAlign: 'center', fontSize: 11, color: step === i + 1 ? 'var(--accent-primary)' : 'var(--text-muted)', fontWeight: step === i + 1 ? 600 : 400 }}>
+              {label}
+            </div>
+          ))}
+        </div>
+
+        {/* Step 1: Lost wallet info */}
+        {step === 1 && (
+          <div style={cardStyle}>
+            <h2 style={{ fontSize: 18, fontWeight: 600, color: 'var(--text-primary)', marginBottom: 8 }}>
+              Lost Wallet Information
+            </h2>
+            <p style={{ fontSize: 14, color: 'var(--text-secondary)', marginBottom: 24 }}>
+              Enter the wallet address you no longer have access to and the credential you want to recover.
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+              <label style={labelStyle}>
+                Lost Wallet Address
+                <input
+                  style={{ ...inputStyle, borderColor: s1Errors.lostWallet ? 'var(--red)' : 'var(--border)', fontFamily: 'var(--font-mono)', fontSize: 12 }}
+                  placeholder="GABC...XYZ (56-character Stellar address)"
+                  value={lostWallet}
+                  onChange={(e) => { setLostWallet(e.target.value); setS1Errors((p) => ({ ...p, lostWallet: undefined })); }}
+                  aria-invalid={!!s1Errors.lostWallet}
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+                <FieldError message={s1Errors.lostWallet} />
+              </label>
+              <label style={labelStyle}>
+                Credential ID
+                <input
+                  style={{ ...inputStyle, borderColor: s1Errors.credentialId ? 'var(--red)' : 'var(--border)' }}
+                  placeholder="e.g. 42 or abc123"
+                  value={credentialId}
+                  onChange={(e) => { setCredentialId(e.target.value); setS1Errors((p) => ({ ...p, credentialId: undefined })); }}
+                  aria-invalid={!!s1Errors.credentialId}
+                />
+                <FieldError message={s1Errors.credentialId} />
+              </label>
+              <div style={{ background: 'var(--blue-subtle)', border: '1px solid rgba(59,130,246,0.2)', borderRadius: 'var(--radius-sm)', padding: '12px 16px', fontSize: 13, color: 'var(--text-secondary)' }}>
+                You can find your Credential ID in any previous export, share link, or by asking the original issuer.
+              </div>
+              <button
+                className="btn btn--primary"
+                onClick={() => { if (validateStep1()) setStep(2); }}
+                style={{ marginTop: 8 }}
+              >
+                Continue
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Step 2: New wallet + contact */}
+        {step === 2 && (
+          <div style={cardStyle}>
+            <h2 style={{ fontSize: 18, fontWeight: 600, color: 'var(--text-primary)', marginBottom: 8 }}>
+              New Wallet & Contact Details
+            </h2>
+            <p style={{ fontSize: 14, color: 'var(--text-secondary)', marginBottom: 24 }}>
+              The recovered credential will be re-issued to your new wallet after verification.
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+              <label style={labelStyle}>
+                New Wallet Address
+                <input
+                  style={{ ...inputStyle, borderColor: s2Errors.newWallet ? 'var(--red)' : 'var(--border)', fontFamily: 'var(--font-mono)', fontSize: 12 }}
+                  placeholder="GABC...XYZ (56-character Stellar address)"
+                  value={newWallet}
+                  onChange={(e) => { setNewWallet(e.target.value); setS2Errors((p) => ({ ...p, newWallet: undefined })); }}
+                  aria-invalid={!!s2Errors.newWallet}
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+                <FieldError message={s2Errors.newWallet} />
+              </label>
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                <span style={{ fontSize: 13, color: 'var(--text-secondary)', fontWeight: 500 }}>Verification Method</span>
+                <div style={{ display: 'flex', gap: 12 }}>
+                  {(['email', 'phone'] as ContactType[]).map((t) => (
+                    <button
+                      key={t}
+                      onClick={() => { setContactType(t); setContactValue(''); setS2Errors((p) => ({ ...p, contactValue: undefined })); }}
+                      style={{
+                        flex: 1,
+                        padding: '10px',
+                        background: contactType === t ? 'var(--accent-primary)' : 'var(--bg-input)',
+                        border: `1px solid ${contactType === t ? 'var(--accent-primary)' : 'var(--border)'}`,
+                        borderRadius: 'var(--radius-sm)',
+                        color: contactType === t ? '#fff' : 'var(--text-secondary)',
+                        fontSize: 13,
+                        fontWeight: 500,
+                        cursor: 'pointer',
+                        transition: 'all 0.15s',
+                      }}
+                    >
+                      {t === 'email' ? 'Email' : 'Phone (SMS)'}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <label style={labelStyle}>
+                {contactType === 'email' ? 'Email Address' : 'Phone Number'}
+                <input
+                  style={{ ...inputStyle, borderColor: s2Errors.contactValue ? 'var(--red)' : 'var(--border)' }}
+                  type={contactType === 'email' ? 'email' : 'tel'}
+                  placeholder={contactType === 'email' ? 'you@example.com' : '+1234567890'}
+                  value={contactValue}
+                  onChange={(e) => { setContactValue(e.target.value); setS2Errors((p) => ({ ...p, contactValue: undefined })); }}
+                  aria-invalid={!!s2Errors.contactValue}
+                />
+                <FieldError message={s2Errors.contactValue} />
+              </label>
+
+              {submitError && (
+                <div style={{ color: 'var(--red)', fontSize: 13, padding: '10px 14px', background: 'var(--red-subtle)', borderRadius: 'var(--radius-sm)' }}>
+                  {submitError}
+                </div>
+              )}
+
+              <div style={{ display: 'flex', gap: 12, marginTop: 8 }}>
+                <button className="btn btn--ghost" onClick={() => setStep(1)} style={{ flex: 1 }}>
+                  Back
+                </button>
+                <button
+                  className="btn btn--primary"
+                  onClick={handleStep2Submit}
+                  disabled={submitting}
+                  style={{ flex: 2 }}
+                >
+                  {submitting ? 'Sending code…' : 'Send Verification Code'}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Step 3: OTP verification */}
+        {step === 3 && (
+          <div style={cardStyle}>
+            <h2 style={{ fontSize: 18, fontWeight: 600, color: 'var(--text-primary)', marginBottom: 8 }}>
+              Verify Your Identity
+            </h2>
+            <p style={{ fontSize: 14, color: 'var(--text-secondary)', marginBottom: 24 }}>
+              Enter the 6-digit code sent to your {contactType === 'email' ? 'email' : 'phone'}.
+              The code expires in 10 minutes.
+            </p>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+              <label style={labelStyle}>
+                Verification Code
+                <input
+                  style={{ ...inputStyle, textAlign: 'center', letterSpacing: '0.3em', fontSize: 24, fontFamily: 'var(--font-mono)', borderColor: otpError ? 'var(--red)' : 'var(--border)' }}
+                  maxLength={6}
+                  placeholder="______"
+                  value={otp}
+                  onChange={(e) => { setOtp(e.target.value.replace(/\D/g, '')); setOtpError(null); }}
+                  aria-invalid={!!otpError}
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                />
+                {otpError && <span style={{ color: 'var(--red)', fontSize: 12 }}>{otpError}</span>}
+              </label>
+
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontSize: 13 }}>
+                <span style={{ color: 'var(--text-muted)' }}>Didn't receive it?</span>
+                <button
+                  onClick={handleResend}
+                  disabled={resending || resendCooldown > 0}
+                  style={{ background: 'none', border: 'none', cursor: resendCooldown > 0 ? 'default' : 'pointer', color: resendCooldown > 0 ? 'var(--text-muted)' : 'var(--accent-primary)', fontSize: 13, padding: 0 }}
+                >
+                  {resendCooldown > 0 ? `Resend in ${resendCooldown}s` : resending ? 'Sending…' : 'Resend code'}
+                </button>
+              </div>
+
+              {resendMsg && (
+                <div style={{ fontSize: 13, color: 'var(--text-secondary)', padding: '8px 12px', background: 'var(--bg-input)', borderRadius: 'var(--radius-sm)' }}>
+                  {resendMsg}
+                </div>
+              )}
+
+              <button
+                className="btn btn--primary"
+                onClick={handleVerifyOtp}
+                disabled={verifying || otp.length < 6}
+                style={{ marginTop: 8 }}
+              >
+                {verifying ? 'Verifying…' : 'Verify Code'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Step 4: Status */}
+        {step === 4 && (
+          <div style={cardStyle}>
+            <h2 style={{ fontSize: 18, fontWeight: 600, color: 'var(--text-primary)', marginBottom: 8 }}>
+              Recovery Request Submitted
+            </h2>
+
+            {!statusData ? (
+              <p style={{ color: 'var(--text-secondary)', fontSize: 14 }}>Loading status…</p>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '16px', background: 'var(--bg-input)', borderRadius: 'var(--radius-md)' }}>
+                  <div style={{ width: 10, height: 10, borderRadius: '50%', background: STATUS_COLORS[statusData.status], flexShrink: 0 }} />
+                  <div>
+                    <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--text-primary)' }}>{STATUS_LABELS[statusData.status]}</div>
+                    <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 2 }}>Request ID: {statusData.id}</div>
+                  </div>
+                </div>
+
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 10, fontSize: 13 }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                    <span style={{ color: 'var(--text-muted)' }}>Credential ID</span>
+                    <span style={{ color: 'var(--text-primary)', fontFamily: 'var(--font-mono)' }}>{statusData.credentialId}</span>
+                  </div>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
+                    <span style={{ color: 'var(--text-muted)', flexShrink: 0 }}>Lost Wallet</span>
+                    <span style={{ color: 'var(--text-primary)', fontFamily: 'var(--font-mono)', fontSize: 11, wordBreak: 'break-all', textAlign: 'right' }}>{statusData.lostWallet}</span>
+                  </div>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
+                    <span style={{ color: 'var(--text-muted)', flexShrink: 0 }}>New Wallet</span>
+                    <span style={{ color: 'var(--text-primary)', fontFamily: 'var(--font-mono)', fontSize: 11, wordBreak: 'break-all', textAlign: 'right' }}>{statusData.newWallet}</span>
+                  </div>
+                  <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                    <span style={{ color: 'var(--text-muted)' }}>Submitted</span>
+                    <span style={{ color: 'var(--text-primary)' }}>{new Date(statusData.createdAt).toLocaleString()}</span>
+                  </div>
+                  {statusData.verifiedAt && (
+                    <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                      <span style={{ color: 'var(--text-muted)' }}>Verified</span>
+                      <span style={{ color: 'var(--green)' }}>{new Date(statusData.verifiedAt).toLocaleString()}</span>
+                    </div>
+                  )}
+                  {statusData.resolvedAt && (
+                    <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                      <span style={{ color: 'var(--text-muted)' }}>Resolved</span>
+                      <span style={{ color: 'var(--text-primary)' }}>{new Date(statusData.resolvedAt).toLocaleString()}</span>
+                    </div>
+                  )}
+                </div>
+
+                {statusData.status === 'pending_approval' && (
+                  <div style={{ background: 'var(--yellow-subtle)', border: '1px solid rgba(245,158,11,0.2)', borderRadius: 'var(--radius-sm)', padding: '12px 16px', fontSize: 13, color: 'var(--text-secondary)' }}>
+                    Your identity has been verified. An attestor is reviewing your request. This page refreshes automatically every 5 seconds.
+                  </div>
+                )}
+
+                {statusData.status === 'approved' && (
+                  <div style={{ background: 'var(--green-subtle)', border: '1px solid rgba(16,185,129,0.2)', borderRadius: 'var(--radius-sm)', padding: '12px 16px', fontSize: 13, color: 'var(--text-secondary)' }}>
+                    Your recovery request was approved. The credential will be re-issued to your new wallet shortly.
+                  </div>
+                )}
+
+                {statusData.status === 'rejected' && (
+                  <div style={{ background: 'var(--red-subtle)', border: '1px solid rgba(239,68,68,0.2)', borderRadius: 'var(--radius-sm)', padding: '12px 16px', fontSize: 13, color: 'var(--text-secondary)' }}>
+                    <strong style={{ color: 'var(--red)' }}>Request rejected.</strong>{' '}
+                    {statusData.rejectionReason ?? 'No reason provided.'} Please contact the original credential issuer for assistance.
+                  </div>
+                )}
+
+                {statusError && (
+                  <div style={{ color: 'var(--red)', fontSize: 13 }}>{statusError}</div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
Introduces a full recovery flow so credential holders who have lost access to their private key can regain their credentials through identity verification and attestor-approved re-issuance.

Recovery flow (3 user-facing steps + status tracking):
- Step 1: user provides the lost Stellar wallet address and credential ID
- Step 2: user supplies a new wallet address and chooses email or SMS as the verification channel
- Step 3: OTP entry (6-digit code, 10-min expiry, 5-attempt limit, 60-second resend cooldown)
- Step 4: live status polling (5-second interval) showing Pending / Approved / Rejected with rejection reason when applicable

Attestor approval dashboard (/attestor/recovery-approvals):
- Lists all identity-verified recovery requests pending review
- Approve button advances the request to approved status
- Reject opens a modal requiring a written reason (shown to requester)
- Filter tabs: Pending / All; demo data when API queue is empty
- Wallet-guarded route (requires connected Stellar wallet)

API layer (api-server/src/routes/recovery.ts):
- POST /api/recovery/request         — submit request, dispatch OTP stub
- POST /api/recovery/verify-otp      — validate code with attempt tracking
- POST /api/recovery/resend-otp      — regenerate and resend OTP
- GET  /api/recovery/status/:id      — poll request state (contact redacted)
- GET  /api/recovery/pending         — fetch queue for attestor dashboard
- POST /api/recovery/approve         — attestor approves
- POST /api/recovery/reject          — attestor rejects with reason
  In-memory store mirrors the notifications.ts pattern; OTP dispatch is
  logged to console, ready for SendGrid / Twilio integration.

Navigation: added "Recover" link in the Navbar between Slice Builder and Help; /recover is public (no wallet required).

closes #944 