### PR TITLE
feat: RPC connection pooling, time-lock attestations, upgrade history, attestor availability status

### DIFF
--- a/api-server/src/routes/attestor.ts
+++ b/api-server/src/routes/attestor.ts
@@ -87,6 +87,47 @@ router.get('/reputation/:address', async (req: Request, res: Response) => {
   }
 });
 
+// GET /api/attestor/status/:address
+router.get('/status/:address', (req: Request, res: Response) => {
+  const { address } = req.params;
+
+  if (!address) {
+    res.status(400).json({ error: 'address parameter required' });
+    return;
+  }
+
+  const stats = metricsStore.getAttestorStats(address);
+
+  if (!stats) {
+    res.json({
+      address,
+      first_seen: null,
+      last_seen: null,
+      uptime_ms: null,
+      avg_response_ms: null,
+      active_credential_count: 0,
+      total_attestations: 0,
+    });
+    return;
+  }
+
+  const uptimeMs = new Date().getTime() - new Date(stats.first_seen).getTime();
+  const avgResponseMs =
+    stats.response_count > 0
+      ? Math.round(stats.total_response_ms / stats.response_count)
+      : null;
+
+  res.json({
+    address,
+    first_seen: stats.first_seen,
+    last_seen: stats.last_seen,
+    uptime_ms: uptimeMs,
+    avg_response_ms: avgResponseMs,
+    active_credential_count: stats.active_credentials.size,
+    total_attestations: stats.total_attestations,
+  });
+});
+
 // POST /api/attestor/batch-attest
 // Body: { attestor: string; credential_ids: string[]; slice_id: string }
 router.post('/batch-attest', async (req: Request, res: Response) => {
@@ -105,12 +146,14 @@ router.post('/batch-attest', async (req: Request, res: Response) => {
   const results: { credential_id: string; success: boolean; error?: string }[] = [];
 
   for (const credId of credential_ids) {
+    const start = Date.now();
     try {
       await simulateCall('attest_credential', [
         u64Val(BigInt(credId)),
         u64Val(BigInt(slice_id)),
         addressVal(attestor),
       ]);
+      const responseMs = Date.now() - start;
       results.push({ credential_id: credId, success: true });
 
       metricsStore.recordEvent({
@@ -119,6 +162,7 @@ router.post('/batch-attest', async (req: Request, res: Response) => {
         timestamp: new Date().toISOString(),
         attestor,
       });
+      metricsStore.recordAttestorResponseTime(attestor, responseMs);
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Attestation failed';
       results.push({ credential_id: credId, success: false, error: msg });

--- a/api-server/src/services/metrics.ts
+++ b/api-server/src/services/metrics.ts
@@ -144,14 +144,62 @@ function isValidEventType(type: string): boolean {
   return ['issued', 'attested', 'revoked', 'suspended', 'verified'].includes(type);
 }
 
+export interface AttestorStats {
+  first_seen: string;
+  last_seen: string;
+  total_attestations: number;
+  total_response_ms: number;
+  response_count: number;
+  active_credentials: Set<string>;
+}
+
 class MetricsStore {
   private hourlyMetrics: Map<string, HourlyMetrics> = new Map();
   private dailyMetrics: Map<string, DailyMetrics> = new Map();
   private eventLog: CredentialEvent[] = [];
+  private attestorStats: Map<string, AttestorStats> = new Map();
 
   recordEvent(event: CredentialEvent): void {
     this.eventLog.push(event);
     this.aggregateToHourly(event);
+    if (event.attestor) {
+      this.updateAttestorStats(event);
+    }
+  }
+
+  private updateAttestorStats(event: CredentialEvent): void {
+    const addr = event.attestor!;
+    const existing = this.attestorStats.get(addr);
+    if (!existing) {
+      this.attestorStats.set(addr, {
+        first_seen: event.timestamp,
+        last_seen: event.timestamp,
+        total_attestations: event.type === 'attested' ? 1 : 0,
+        total_response_ms: 0,
+        response_count: 0,
+        active_credentials: new Set(event.type === 'attested' ? [event.credential_id] : []),
+      });
+      return;
+    }
+    existing.last_seen = event.timestamp;
+    if (event.type === 'attested') {
+      existing.total_attestations++;
+      existing.active_credentials.add(event.credential_id);
+    } else if (event.type === 'revoked') {
+      existing.active_credentials.delete(event.credential_id);
+    }
+  }
+
+  recordAttestorResponseTime(address: string, responseMs: number): void {
+    const stats = this.attestorStats.get(address);
+    if (stats) {
+      stats.total_response_ms += responseMs;
+      stats.response_count++;
+    }
+  }
+
+  getAttestorStats(address: string): AttestorStats | undefined {
+    return this.attestorStats.get(address);
   }
 
   private aggregateToHourly(event: CredentialEvent): void {

--- a/api-server/src/soroban.ts
+++ b/api-server/src/soroban.ts
@@ -13,6 +13,7 @@ import {
 const RPC_URL = process.env.STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org';
 const NETWORK = (process.env.STELLAR_NETWORK ?? 'testnet') as keyof typeof PASSPHRASES;
 const CONTRACT_ID = process.env.CONTRACT_QUORUM_PROOF ?? '';
+const RPC_POOL_SIZE = parseInt(process.env.RPC_POOL_SIZE ?? '5', 10);
 
 const PASSPHRASES = {
   testnet: Networks.TESTNET,
@@ -20,13 +21,31 @@ const PASSPHRASES = {
   futurenet: Networks.FUTURENET,
 };
 
-const server = new StellarRpc.Server(RPC_URL);
 const networkPassphrase = PASSPHRASES[NETWORK] ?? Networks.TESTNET;
+
+/** Round-robin pool of RPC server instances to reuse connections across requests. */
+class RpcConnectionPool {
+  private readonly pool: StellarRpc.Server[];
+  private index = 0;
+
+  constructor(url: string, size: number) {
+    this.pool = Array.from({ length: size }, () => new StellarRpc.Server(url));
+  }
+
+  acquire(): StellarRpc.Server {
+    const server = this.pool[this.index];
+    this.index = (this.index + 1) % this.pool.length;
+    return server;
+  }
+}
+
+const rpcPool = new RpcConnectionPool(RPC_URL, RPC_POOL_SIZE);
 
 /** Simulate a read-only contract call and return the native JS value. */
 export async function simulateCall(method: string, args: ReturnType<typeof nativeToScVal>[] = []) {
   if (!CONTRACT_ID) throw new Error('CONTRACT_QUORUM_PROOF env var not set');
 
+  const server = rpcPool.acquire();
   const contract = new Contract(CONTRACT_ID);
   const dummyKeypair = Keypair.random();
   const dummyAccount = new Account(dummyKeypair.publicKey(), '0');

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -891,6 +891,58 @@ pub enum DataKey7 {
     DidMethod,
 }
 
+/// Storage keys for upgrade history and credential time locks (issues #874, #872).
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey8 {
+    /// Ordered list of all contract upgrade records (issue #874).
+    UpgradeHistory,
+    /// Time-lock entry keyed by credential ID (issue #872).
+    TimeLockEntry(u64),
+}
+
+/// A record of a single contract upgrade, stored for governance auditing (issue #874).
+#[contracttype]
+#[derive(Clone)]
+pub struct UpgradeRecord {
+    pub wasm_hash: soroban_sdk::BytesN<32>,
+    pub upgraded_by: Address,
+    pub timestamp: u64,
+}
+
+/// Status of a credential time lock (issue #872).
+#[contracttype]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(u32)]
+pub enum TimeLockStatus {
+    /// Waiting for the delay period or required confirmations.
+    Pending = 0,
+    /// All conditions met; attestation is now active.
+    Active = 1,
+    /// Cancelled before conditions were met.
+    Cancelled = 2,
+}
+
+/// An optional time-lock on a credential attestation (issue #872).
+///
+/// The attestation becomes active when EITHER:
+/// - `env.ledger().timestamp() >= unlock_at` (when `unlock_at > 0`), OR
+/// - `confirmation_count >= required_confirmations` (when `required_confirmations > 0`).
+#[contracttype]
+#[derive(Clone)]
+pub struct CredentialTimeLock {
+    pub credential_id: u64,
+    /// Unix timestamp after which the attestation is automatically active (0 = disabled).
+    pub unlock_at: u64,
+    /// Number of additional attestor confirmations required (0 = disabled).
+    pub required_confirmations: u32,
+    pub confirmation_count: u32,
+    pub confirmations: Vec<Address>,
+    pub created_by: Address,
+    pub created_at: u64,
+    pub status: TimeLockStatus,
+}
+
 #[contracttype]
 #[derive(Clone)]
 pub struct CredentialTypeDef {
@@ -8639,7 +8691,29 @@ impl QuorumProofContract {
             .expect("not initialized");
         assert!(stored == admin, "unauthorized");
         Self::validate_upgrade(env.clone(), new_wasm_hash.clone());
+
+        // Record this upgrade in the history before applying (issue #874).
+        let mut history: Vec<UpgradeRecord> = env
+            .storage()
+            .instance()
+            .get(&DataKey8::UpgradeHistory)
+            .unwrap_or(Vec::new(&env));
+        history.push_back(UpgradeRecord {
+            wasm_hash: new_wasm_hash.clone(),
+            upgraded_by: admin,
+            timestamp: env.ledger().timestamp(),
+        });
+        env.storage().instance().set(&DataKey8::UpgradeHistory, &history);
+
         env.deployer().update_current_contract_wasm(new_wasm_hash);
+    }
+
+    /// Return the full upgrade history for governance auditing (issue #874).
+    pub fn get_upgrade_history(env: Env) -> Vec<UpgradeRecord> {
+        env.storage()
+            .instance()
+            .get(&DataKey8::UpgradeHistory)
+            .unwrap_or(Vec::new(&env))
     }
 
     /// Validate that a new WASM hash is safe to upgrade to.
@@ -11888,6 +11962,123 @@ impl QuorumProofContract {
 
         env.storage().instance().extend_ttl(STANDARD_TTL, EXTENDED_TTL);
         processed
+    }
+
+    // ── Time-Locked Credential Approval (Issue #872) ──────────────────────────
+
+    /// Create a time-lock on a credential's attestation.
+    ///
+    /// The attestation becomes active once EITHER condition is satisfied:
+    /// - The ledger timestamp reaches `unlock_at` (set to 0 to disable).
+    /// - `required_confirmations` additional attestors confirm via `confirm_time_lock`
+    ///   (set to 0 to disable).
+    ///
+    /// Only one active time lock may exist per credential at a time.
+    pub fn set_credential_time_lock(
+        env: Env,
+        issuer: Address,
+        credential_id: u64,
+        unlock_at: u64,
+        required_confirmations: u32,
+    ) {
+        issuer.require_auth();
+        Self::require_not_paused(&env);
+
+        assert!(
+            unlock_at > 0 || required_confirmations > 0,
+            "at least one condition (unlock_at or required_confirmations) must be non-zero"
+        );
+
+        let existing: Option<CredentialTimeLock> = env
+            .storage()
+            .instance()
+            .get(&DataKey8::TimeLockEntry(credential_id));
+        assert!(
+            existing
+                .as_ref()
+                .map(|e: &CredentialTimeLock| e.status != TimeLockStatus::Pending)
+                .unwrap_or(true),
+            "a pending time lock already exists for this credential"
+        );
+
+        let entry = CredentialTimeLock {
+            credential_id,
+            unlock_at,
+            required_confirmations,
+            confirmation_count: 0,
+            confirmations: Vec::new(&env),
+            created_by: issuer,
+            created_at: env.ledger().timestamp(),
+            status: TimeLockStatus::Pending,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey8::TimeLockEntry(credential_id), &entry);
+        env.storage().instance().extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+    }
+
+    /// Confirm a pending time lock for a credential.
+    ///
+    /// Each attestor may confirm at most once. If the confirmation threshold is
+    /// reached the lock transitions to `Active` automatically.
+    pub fn confirm_time_lock(env: Env, attestor: Address, credential_id: u64) {
+        attestor.require_auth();
+        Self::require_not_paused(&env);
+
+        let mut entry: CredentialTimeLock = env
+            .storage()
+            .instance()
+            .get(&DataKey8::TimeLockEntry(credential_id))
+            .expect("no time lock exists for this credential");
+
+        assert!(
+            entry.status == TimeLockStatus::Pending,
+            "time lock is not pending"
+        );
+
+        // Prevent duplicate confirmations from the same attestor.
+        for existing in entry.confirmations.iter() {
+            assert!(existing != attestor, "attestor has already confirmed");
+        }
+
+        entry.confirmations.push_back(attestor);
+        entry.confirmation_count += 1;
+
+        if entry.required_confirmations > 0
+            && entry.confirmation_count >= entry.required_confirmations
+        {
+            entry.status = TimeLockStatus::Active;
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey8::TimeLockEntry(credential_id), &entry);
+        env.storage().instance().extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+    }
+
+    /// Query the time lock for a credential, returning `None` if none exists.
+    pub fn get_credential_time_lock(env: Env, credential_id: u64) -> Option<CredentialTimeLock> {
+        let mut entry: CredentialTimeLock = match env
+            .storage()
+            .instance()
+            .get(&DataKey8::TimeLockEntry(credential_id))
+        {
+            Some(e) => e,
+            None => return None,
+        };
+
+        // Lazily activate if the time-delay condition is now met.
+        if entry.status == TimeLockStatus::Pending
+            && entry.unlock_at > 0
+            && env.ledger().timestamp() >= entry.unlock_at
+        {
+            entry.status = TimeLockStatus::Active;
+            env.storage()
+                .instance()
+                .set(&DataKey8::TimeLockEntry(credential_id), &entry);
+        }
+
+        Some(entry)
     }
 }
 


### PR DESCRIPTION
## Summary


### closes #870 — RPC Connection Pooling

Replaces the single `StellarRpc.Server` instance in `soroban.ts` with a `RpcConnectionPool` that maintains a configurable number of server instances (default 5, controlled by the `RPC_POOL_SIZE` env var) and distributes calls across them using round-robin selection. This allows concurrent requests to reuse pre-established connections rather than serialising through a single object.

### closes #872 — Time-Locked Credential Approval

Adds optional time-locking to credential attestations in the smart contract. An issuer can call `set_credential_time_lock(credential_id, unlock_at, required_confirmations)` to place a pending window on a credential before it becomes active. The lock resolves when either:
- the ledger timestamp reaches `unlock_at`, or
- `required_confirmations` additional attestors call `confirm_time_lock`.

New contract functions: `set_credential_time_lock`, `confirm_time_lock`, `get_credential_time_lock`.  
New types: `CredentialTimeLock`, `TimeLockStatus`, `DataKey8::TimeLockEntry`.

### closes #874 — Smart Contract Upgrade History

The `upgrade()` function now appends an `UpgradeRecord` (wasm hash, upgrader address, ledger timestamp) to `DataKey8::UpgradeHistory` before applying each upgrade. A new read-only function `get_upgrade_history()` exposes the full ordered list for governance auditing.

### closes #875 — Attestor Availability Status

Adds `GET /api/attestor/status/:address` to the API server. The endpoint returns:
- `first_seen` / `last_seen` — ISO timestamps derived from the event log
- `uptime_ms` — milliseconds since first attestation event
- `avg_response_ms` — mean duration of batch-attest calls (measured per credential, accumulated in `MetricsStore`)
- `active_credential_count` — credentials currently attested (attested minus revoked)
- `total_attestations` — lifetime count

Response time tracking is wired into the existing `batch-attest` route and stored in a new per-attestor stats map inside `MetricsStore`.

## Test plan

- [ ] Start API server and call `GET /api/attestor/status/<address>` for an unknown address — expect `{ active_credential_count: 0, uptime_ms: null, ... }`
- [ ] POST to `/api/attestor/batch-attest`, then re-call the status endpoint — confirm `total_attestations` increments and `avg_response_ms` is populated
- [ ] Verify existing test suite still passes (`npm test` in `api-server/`)
- [ ] Review the diff in `contracts/quorum_proof/src/lib.rs` for the three new contract entry points and the modified `upgrade()` function