### PR TITLE
feat: add WebSocket-driven real-time credential issuance dashboard

### DIFF
--- a/api-server/src/routes/attestor.ts
+++ b/api-server/src/routes/attestor.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { simulateCall, u64Val, addressVal } from '../soroban.js';
 import { metricsStore } from '../services/metrics.js';
+import { liveDashboard } from '../services/liveDashboard.js';
 
 const router = Router();
 
@@ -136,6 +137,7 @@ router.post('/batch-attest', async (req: Request, res: Response) => {
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Attestation failed';
       results.push({ credential_id: credId, success: false, error: msg });
+      liveDashboard.recordAttestation(false);
     }
   }
 

--- a/api-server/src/services/liveDashboard.ts
+++ b/api-server/src/services/liveDashboard.ts
@@ -1,0 +1,95 @@
+/** Sliding-window per-minute metrics for the real-time credential issuance dashboard. */
+
+const WINDOW_MINUTES = 60;
+
+interface MinuteBucket {
+  minute: number;
+  issued: number;
+  attested: number;
+  attestation_errors: number;
+  api_errors: number;
+}
+
+export interface LiveDashboardStats {
+  /** 60-element array of issuance counts, index 0 = oldest minute, index 59 = current minute. */
+  issuances_per_minute: number[];
+  /** Attestation success rate over the last 5 minutes, null when no data. */
+  attestation_success_rate: number | null;
+  /** Total errors (API + attestation) recorded in the current minute. */
+  errors_last_minute: number;
+  timestamp: string;
+}
+
+class LiveDashboardStore {
+  private readonly buckets = new Map<number, MinuteBucket>();
+
+  private nowMinute(): number {
+    return Math.floor(Date.now() / 60_000);
+  }
+
+  private getBucket(minute: number): MinuteBucket {
+    if (!this.buckets.has(minute)) {
+      this.buckets.set(minute, { minute, issued: 0, attested: 0, attestation_errors: 0, api_errors: 0 });
+      this.evict(minute);
+    }
+    return this.buckets.get(minute)!;
+  }
+
+  private evict(now: number): void {
+    const cutoff = now - WINDOW_MINUTES;
+    for (const k of this.buckets.keys()) {
+      if (k < cutoff) this.buckets.delete(k);
+    }
+  }
+
+  recordIssuance(): void {
+    this.getBucket(this.nowMinute()).issued++;
+  }
+
+  recordAttestation(success: boolean): void {
+    const b = this.getBucket(this.nowMinute());
+    if (success) b.attested++;
+    else b.attestation_errors++;
+  }
+
+  recordApiError(): void {
+    this.getBucket(this.nowMinute()).api_errors++;
+  }
+
+  getStats(): LiveDashboardStats {
+    const now = this.nowMinute();
+
+    const issuances_per_minute: number[] = [];
+    for (let i = WINDOW_MINUTES - 1; i >= 0; i--) {
+      issuances_per_minute.push(this.buckets.get(now - i)?.issued ?? 0);
+    }
+
+    let totalAttested = 0;
+    let totalAttestErrors = 0;
+    for (let i = 4; i >= 0; i--) {
+      const b = this.buckets.get(now - i);
+      if (b) {
+        totalAttested += b.attested;
+        totalAttestErrors += b.attestation_errors;
+      }
+    }
+    const attestationTotal = totalAttested + totalAttestErrors;
+    const attestation_success_rate = attestationTotal > 0 ? totalAttested / attestationTotal : null;
+
+    const cur = this.buckets.get(now);
+    const errors_last_minute = (cur?.api_errors ?? 0) + (cur?.attestation_errors ?? 0);
+
+    return {
+      issuances_per_minute,
+      attestation_success_rate,
+      errors_last_minute,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  reset(): void {
+    this.buckets.clear();
+  }
+}
+
+export const liveDashboard = new LiveDashboardStore();

--- a/api-server/src/services/metrics.ts
+++ b/api-server/src/services/metrics.ts
@@ -1,3 +1,5 @@
+import { liveDashboard } from './liveDashboard.js';
+
 export interface CredentialEvent {
   type: 'issued' | 'attested' | 'revoked' | 'suspended' | 'verified';
   credential_id: string;
@@ -152,6 +154,8 @@ class MetricsStore {
   recordEvent(event: CredentialEvent): void {
     this.eventLog.push(event);
     this.aggregateToHourly(event);
+    if (event.type === 'issued') liveDashboard.recordIssuance();
+    else if (event.type === 'attested') liveDashboard.recordAttestation(true);
   }
 
   private aggregateToHourly(event: CredentialEvent): void {

--- a/api-server/src/ws/server.ts
+++ b/api-server/src/ws/server.ts
@@ -34,9 +34,13 @@ import {
   removeConnection,
   getMatchingSubscribers,
   getSubscriberCount,
+  addDashboardSubscriber,
+  removeDashboardSubscriber,
+  getDashboardSubscribers,
   type SubscriptionFilter,
   type WsBroadcastEvent,
 } from './subscriptions.js';
+import { liveDashboard } from '../services/liveDashboard.js';
 import {
   incrementConnections,
   decrementConnections,
@@ -49,11 +53,12 @@ import {
 } from './metrics.js';
 
 interface WsClientMessage {
-  type: 'subscribe' | 'unsubscribe' | 'ping';
+  type: 'subscribe' | 'unsubscribe' | 'ping' | 'subscribe_dashboard' | 'unsubscribe_dashboard';
   filters?: SubscriptionFilter[];
 }
 
 const PING_INTERVAL_MS = 30_000;
+const DASHBOARD_BROADCAST_INTERVAL_MS = 5_000;
 
 function createMessage(type: string, data: Record<string, unknown>) {
   return JSON.stringify({ type, data });
@@ -61,6 +66,7 @@ function createMessage(type: string, data: Record<string, unknown>) {
 
 let wss: WebSocketServer | null = null;
 let pingTimer: ReturnType<typeof setInterval> | null = null;
+let dashboardTimer: ReturnType<typeof setInterval> | null = null;
 
 export function createWsServer(server: HttpServer, path = '/ws'): WebSocketServer {
   wss = new WebSocketServer({ server, path });
@@ -111,6 +117,22 @@ export function createWsServer(server: HttpServer, path = '/ws'): WebSocketServe
             break;
           }
 
+          case 'subscribe_dashboard': {
+            addDashboardSubscriber(ws);
+            const initialStats = liveDashboard.getStats() as unknown as Record<string, unknown>;
+            ws.send(createMessage('dashboard_subscribed', { ts: new Date().toISOString() }));
+            ws.send(createMessage('dashboard_stats', initialStats));
+            recordMessageSent(Buffer.byteLength('dashboard_subscribed') + Buffer.byteLength('dashboard_stats'));
+            break;
+          }
+
+          case 'unsubscribe_dashboard': {
+            removeDashboardSubscriber(ws);
+            ws.send(createMessage('dashboard_unsubscribed', {}));
+            recordMessageSent(Buffer.byteLength('dashboard_unsubscribed'));
+            break;
+          }
+
           default:
             ws.send(createMessage('error', {
               message: `Unknown message type: ${(msg as any).type ?? 'undefined'}`,
@@ -156,10 +178,26 @@ export function createWsServer(server: HttpServer, path = '/ws'): WebSocketServe
     });
   }, PING_INTERVAL_MS);
 
+  dashboardTimer = setInterval(() => {
+    const subscribers = getDashboardSubscribers();
+    if (subscribers.length === 0) return;
+    const stats = liveDashboard.getStats() as unknown as Record<string, unknown>;
+    const message = createMessage('dashboard_stats', stats);
+    const bytes = Buffer.byteLength(message);
+    for (const client of subscribers) {
+      client.send(message);
+      recordMessageSent(bytes);
+    }
+  }, DASHBOARD_BROADCAST_INTERVAL_MS);
+
   wss.on('close', () => {
     if (pingTimer) {
       clearInterval(pingTimer);
       pingTimer = null;
+    }
+    if (dashboardTimer) {
+      clearInterval(dashboardTimer);
+      dashboardTimer = null;
     }
   });
 
@@ -227,6 +265,10 @@ export function closeWsServer(): void {
   if (pingTimer) {
     clearInterval(pingTimer);
     pingTimer = null;
+  }
+  if (dashboardTimer) {
+    clearInterval(dashboardTimer);
+    dashboardTimer = null;
   }
   wss?.close();
   wss = null;

--- a/api-server/src/ws/subscriptions.ts
+++ b/api-server/src/ws/subscriptions.ts
@@ -83,6 +83,7 @@ export function removeSubscriber(ws: WebSocket, filters?: SubscriptionFilter[]):
 
 export function removeConnection(ws: WebSocket): void {
   subscriptions.delete(ws);
+  dashboardSubscribers.delete(ws);
 }
 
 export function getSubscriberCount(): number {
@@ -107,4 +108,28 @@ export function getMatchingSubscribers(event: WsBroadcastEvent): WebSocket[] {
 
 export function getSubscriptions(): Map<WebSocket, ClientSubscription> {
   return new Map(subscriptions);
+}
+
+// --- Dashboard subscribers ---
+
+const dashboardSubscribers = new Set<WebSocket>();
+
+export function addDashboardSubscriber(ws: WebSocket): void {
+  dashboardSubscribers.add(ws);
+}
+
+export function removeDashboardSubscriber(ws: WebSocket): void {
+  dashboardSubscribers.delete(ws);
+}
+
+export function getDashboardSubscribers(): WebSocket[] {
+  const open: WebSocket[] = [];
+  for (const ws of dashboardSubscribers) {
+    if (ws.readyState === WebSocket.OPEN) {
+      open.push(ws);
+    } else {
+      dashboardSubscribers.delete(ws);
+    }
+  }
+  return open;
 }

--- a/dashboard/src/App.css
+++ b/dashboard/src/App.css
@@ -31,6 +31,176 @@
   padding: 3rem 2rem;
 }
 
+/* Live Dashboard */
+.live-dashboard-section {
+  margin-bottom: 2.5rem;
+}
+
+:root {
+  --ld-accent: #818cf8;
+  --ld-success: #34d399;
+  --ld-warn: #fbbf24;
+  --ld-error: #f87171;
+  --ld-muted: #9ca3af;
+  --ld-bg: rgba(255, 255, 255, 0.08);
+  --ld-border: rgba(255, 255, 255, 0.15);
+  --ld-text: #f3f4f6;
+  --ld-sub: rgba(243, 244, 246, 0.6);
+}
+
+.live-dashboard {
+  background: var(--ld-bg);
+  border: 1px solid var(--ld-border);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  color: var(--ld-text);
+  backdrop-filter: blur(8px);
+}
+
+.live-dashboard__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.live-dashboard__title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0;
+  color: var(--ld-text);
+}
+
+.live-dashboard__status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+}
+
+.live-dashboard__dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.live-dashboard__dot--connected {
+  background: var(--ld-success);
+  box-shadow: 0 0 6px var(--ld-success);
+  animation: ld-pulse 2s ease-in-out infinite;
+}
+
+.live-dashboard__dot--connecting {
+  background: var(--ld-warn);
+}
+
+.live-dashboard__dot--disconnected {
+  background: var(--ld-error);
+}
+
+@keyframes ld-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.live-dashboard__status-text {
+  color: var(--ld-sub);
+  text-transform: capitalize;
+}
+
+.live-dashboard__updated {
+  color: var(--ld-sub);
+  font-size: 0.75rem;
+  padding-left: 0.5rem;
+  border-left: 1px solid var(--ld-border);
+}
+
+.live-dashboard__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.live-dashboard__card {
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--ld-border);
+  border-radius: 0.75rem;
+  padding: 1.25rem 1.25rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.live-dashboard__card-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ld-sub);
+  margin: 0;
+}
+
+.live-dashboard__card-value {
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1;
+  margin: 0.25rem 0 0.5rem;
+  color: var(--ld-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.live-dashboard__card-sub {
+  font-size: 0.75rem;
+  color: var(--ld-sub);
+  margin: 0.25rem 0 0;
+}
+
+.live-dashboard__sparkline {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.live-dashboard__rate-bar-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  margin: 0.25rem 0;
+}
+
+.live-dashboard__rate-bar {
+  flex: 1;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 99px;
+  overflow: hidden;
+}
+
+.live-dashboard__rate-bar-fill {
+  height: 100%;
+  border-radius: 99px;
+  transition: width 0.4s ease;
+}
+
+.live-dashboard__rate-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  min-width: 3rem;
+  text-align: right;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ld-bg: rgba(15, 23, 42, 0.6);
+    --ld-border: rgba(255, 255, 255, 0.1);
+  }
+}
+
 .credentials-section {
   margin-bottom: 3rem;
 }

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { CredentialCard } from './components/CredentialCard'
 import { AttestationPanel } from './components/AttestationPanel'
+import { LiveDashboard } from './components/LiveDashboard'
 import { Credential } from './types/credential'
 import { Attestor } from './types/attestor'
 import './App.css'
@@ -108,6 +109,10 @@ function App() {
       </header>
 
       <main className="app-main">
+        <section className="live-dashboard-section">
+          <LiveDashboard />
+        </section>
+
         <section className="credentials-section">
           <h2>Your Credentials</h2>
           {selectedId && (

--- a/dashboard/src/components/LiveDashboard.tsx
+++ b/dashboard/src/components/LiveDashboard.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useRef, useState } from 'react'
+
+interface DashboardStats {
+  issuances_per_minute: number[]
+  attestation_success_rate: number | null
+  errors_last_minute: number
+  timestamp: string
+}
+
+const WS_URL = (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_WS_URL) || 'ws://localhost:3000/ws'
+const RECONNECT_DELAY_MS = 3000
+
+type ConnectionState = 'connecting' | 'connected' | 'disconnected'
+
+function Sparkline({ values, width = 240, height = 56 }: { values: number[]; width?: number; height?: number }) {
+  if (values.length === 0) return null
+  const max = Math.max(...values, 1)
+  const pts = values.map((v, i) => {
+    const x = (i / (values.length - 1)) * width
+    const y = height - (v / max) * (height - 4)
+    return `${x.toFixed(1)},${y.toFixed(1)}`
+  })
+  const fillPath =
+    `M0,${height} L` +
+    pts.join(' L') +
+    ` L${width},${height} Z`
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      width={width}
+      height={height}
+      className="live-dashboard__sparkline"
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient id="spark-fill" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="var(--ld-accent)" stopOpacity="0.35" />
+          <stop offset="100%" stopColor="var(--ld-accent)" stopOpacity="0.03" />
+        </linearGradient>
+      </defs>
+      <path d={fillPath} fill="url(#spark-fill)" />
+      <polyline
+        points={pts.join(' ')}
+        fill="none"
+        stroke="var(--ld-accent)"
+        strokeWidth="2"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
+function RateBar({ value }: { value: number | null }) {
+  const pct = value === null ? null : Math.round(value * 100)
+  const color =
+    pct === null ? 'var(--ld-muted)' :
+    pct >= 95 ? 'var(--ld-success)' :
+    pct >= 80 ? 'var(--ld-warn)' : 'var(--ld-error)'
+
+  return (
+    <div className="live-dashboard__rate-bar-wrap">
+      <div
+        className="live-dashboard__rate-bar"
+        role="progressbar"
+        aria-valuenow={pct ?? 0}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label="Attestation success rate"
+      >
+        <div
+          className="live-dashboard__rate-bar-fill"
+          style={{ width: `${pct ?? 0}%`, background: color }}
+        />
+      </div>
+      <span className="live-dashboard__rate-label" style={{ color }}>
+        {pct === null ? '—' : `${pct}%`}
+      </span>
+    </div>
+  )
+}
+
+function StatusDot({ state }: { state: ConnectionState }) {
+  return (
+    <span
+      className={`live-dashboard__dot live-dashboard__dot--${state}`}
+      aria-label={state}
+      title={state}
+    />
+  )
+}
+
+export function LiveDashboard() {
+  const [stats, setStats] = useState<DashboardStats | null>(null)
+  const [connState, setConnState] = useState<ConnectionState>('connecting')
+  const wsRef = useRef<WebSocket | null>(null)
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const unmounted = useRef(false)
+
+  function connect() {
+    if (unmounted.current) return
+    setConnState('connecting')
+    const ws = new WebSocket(WS_URL)
+    wsRef.current = ws
+
+    ws.onopen = () => {
+      setConnState('connected')
+      ws.send(JSON.stringify({ type: 'subscribe_dashboard' }))
+    }
+
+    ws.onmessage = (ev) => {
+      try {
+        const msg = JSON.parse(ev.data as string)
+        if (msg.type === 'dashboard_stats') {
+          setStats(msg.data as DashboardStats)
+        }
+      } catch {
+        // ignore malformed frames
+      }
+    }
+
+    ws.onclose = () => {
+      if (unmounted.current) return
+      setConnState('disconnected')
+      reconnectTimer.current = setTimeout(connect, RECONNECT_DELAY_MS)
+    }
+
+    ws.onerror = () => {
+      ws.close()
+    }
+  }
+
+  useEffect(() => {
+    connect()
+    return () => {
+      unmounted.current = true
+      if (reconnectTimer.current) clearTimeout(reconnectTimer.current)
+      wsRef.current?.close()
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const currentIssuanceRate = stats ? stats.issuances_per_minute[stats.issuances_per_minute.length - 1] : 0
+  const lastUpdated = stats ? new Date(stats.timestamp).toLocaleTimeString() : '—'
+
+  return (
+    <div className="live-dashboard" aria-label="Live credential issuance dashboard">
+      <div className="live-dashboard__header">
+        <h2 className="live-dashboard__title">Live Dashboard</h2>
+        <div className="live-dashboard__status">
+          <StatusDot state={connState} />
+          <span className="live-dashboard__status-text">{connState}</span>
+          {stats && <span className="live-dashboard__updated">updated {lastUpdated}</span>}
+        </div>
+      </div>
+
+      <div className="live-dashboard__grid">
+        {/* Issuances per minute */}
+        <div className="live-dashboard__card">
+          <p className="live-dashboard__card-label">Issuances / min</p>
+          <p className="live-dashboard__card-value" aria-live="polite">
+            {currentIssuanceRate}
+          </p>
+          <Sparkline values={stats?.issuances_per_minute ?? Array(60).fill(0)} />
+          <p className="live-dashboard__card-sub">last 60 minutes</p>
+        </div>
+
+        {/* Attestation success rate */}
+        <div className="live-dashboard__card">
+          <p className="live-dashboard__card-label">Attestation success rate</p>
+          <p className="live-dashboard__card-value" aria-live="polite">
+            {stats?.attestation_success_rate === null || stats?.attestation_success_rate === undefined
+              ? '—'
+              : `${Math.round(stats.attestation_success_rate * 100)}%`}
+          </p>
+          <RateBar value={stats?.attestation_success_rate ?? null} />
+          <p className="live-dashboard__card-sub">last 5 minutes</p>
+        </div>
+
+        {/* Error rate */}
+        <div className="live-dashboard__card">
+          <p className="live-dashboard__card-label">Errors / min</p>
+          <p
+            className="live-dashboard__card-value"
+            style={{ color: (stats?.errors_last_minute ?? 0) > 0 ? 'var(--ld-error)' : undefined }}
+            aria-live="polite"
+          >
+            {stats?.errors_last_minute ?? 0}
+          </p>
+          <p className="live-dashboard__card-sub">current minute</p>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Replaces batch-only analytics with a live dashboard broadcasting per-minute issuances, attestation success rate (5-min window), and error rates over WebSocket.

- liveDashboard.ts: 60-bucket sliding window store for per-minute metrics
- metrics.ts: hooks recordEvent to update live window on issued/attested events
- attestor.ts: records failed attestations into the live error/rate counters
- ws/subscriptions.ts: adds dashboard subscriber set with lifecycle cleanup
- ws/server.ts: subscribe_dashboard / unsubscribe_dashboard handlers + 5s broadcast interval
- LiveDashboard.tsx: React component with SVG sparkline, rate progress bar, error counter, and auto-reconnect
- App.tsx / App.css: mounts LiveDashboard above the credential grid with full dark-mode support

closes #921 