### PR TITLE
feat(#946): Slice Simulation/Preview Mode

### DIFF
--- a/frontend/src/__tests__/SliceSimulator.test.tsx
+++ b/frontend/src/__tests__/SliceSimulator.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * SliceSimulator.test.tsx
+ * Tests for slice simulation/preview mode — issue #946.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import type { AttestorEntry } from '../lib/sliceBuilderUtils';
+import {
+  signedWeight,
+  evaluateScenario,
+  scenarioStats,
+  faultTolerance,
+  minimalWinningCoalitions,
+} from '../lib/sliceSimulator';
+import { SliceSimulator } from '../components/SliceSimulator';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function attestor(id: string, weight: number, role = 'University'): AttestorEntry {
+  return { id, address: `G${id.toUpperCase().padEnd(55, 'A')}`, role, weight };
+}
+
+const TWO_EQUAL: AttestorEntry[] = [attestor('a', 2), attestor('b', 2)];
+
+// ── Pure logic ────────────────────────────────────────────────────────────────
+
+describe('signedWeight', () => {
+  it('sums only the signing attestors', () => {
+    expect(signedWeight(TWO_EQUAL, new Set(['a']))).toBe(2);
+    expect(signedWeight(TWO_EQUAL, new Set(['a', 'b']))).toBe(4);
+    expect(signedWeight(TWO_EQUAL, new Set())).toBe(0);
+  });
+});
+
+describe('evaluateScenario', () => {
+  it('reports success with surplus when threshold met', () => {
+    const r = evaluateScenario(TWO_EQUAL, 3, new Set(['a', 'b']));
+    expect(r.success).toBe(true);
+    expect(r.signedWeight).toBe(4);
+    expect(r.surplus).toBe(1);
+    expect(r.deficit).toBe(0);
+  });
+
+  it('reports failure with deficit when threshold unmet', () => {
+    const r = evaluateScenario(TWO_EQUAL, 3, new Set(['a']));
+    expect(r.success).toBe(false);
+    expect(r.deficit).toBe(1);
+    expect(r.surplus).toBe(0);
+    expect(r.percentOfThreshold).toBe(67);
+  });
+
+  it('treats an empty slice as failure', () => {
+    expect(evaluateScenario([], 1, new Set()).success).toBe(false);
+  });
+});
+
+describe('scenarioStats', () => {
+  it('counts winning subsets across all combinations', () => {
+    // subsets of {2,2} vs threshold 3: only {a,b}=4 wins.
+    const s = scenarioStats(TWO_EQUAL, 3);
+    expect(s.enumerated).toBe(true);
+    expect(s.totalScenarios).toBe(4);
+    expect(s.winningScenarios).toBe(1);
+    expect(s.winRatePct).toBe(25);
+  });
+
+  it('flags configurations too large to enumerate', () => {
+    const many = Array.from({ length: 17 }, (_, i) => attestor(`n${i}`, 1));
+    expect(scenarioStats(many, 5).enumerated).toBe(false);
+  });
+});
+
+describe('faultTolerance', () => {
+  it('is zero when losing any top-weight attestor breaks consensus', () => {
+    // weights [3,3,2,1] tw=9, threshold 7 → 9-3=6 < 7, none can drop.
+    const a = [attestor('a', 3), attestor('b', 3), attestor('c', 2), attestor('d', 1)];
+    expect(faultTolerance(a, 7)).toBe(0);
+  });
+
+  it('counts how many top-weight attestors can drop', () => {
+    // tw=9, threshold 5 → drop a 3 (remaining 6 >=5), then 6-3=3 < 5 stop → 1.
+    const a = [attestor('a', 3), attestor('b', 3), attestor('c', 2), attestor('d', 1)];
+    expect(faultTolerance(a, 5)).toBe(1);
+  });
+
+  it('is zero for an unreachable threshold', () => {
+    expect(faultTolerance(TWO_EQUAL, 99)).toBe(0);
+  });
+});
+
+describe('minimalWinningCoalitions', () => {
+  it('returns just-sufficient signer sets', () => {
+    const c = minimalWinningCoalitions(TWO_EQUAL, 3);
+    expect(c).toHaveLength(1);
+    expect(c[0].map((a) => a.id).sort()).toEqual(['a', 'b']);
+  });
+
+  it('returns nothing for an unreachable threshold', () => {
+    expect(minimalWinningCoalitions(TWO_EQUAL, 99)).toEqual([]);
+  });
+});
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+describe('<SliceSimulator />', () => {
+  it('prompts when there are no attestors', () => {
+    render(<SliceSimulator attestors={[]} threshold={1} />);
+    expect(screen.getByText(/add attestors to simulate/i)).toBeInTheDocument();
+  });
+
+  it('shows consensus reached when everyone signs and the threshold is reachable', () => {
+    render(<SliceSimulator attestors={TWO_EQUAL} threshold={3} />);
+    expect(screen.getByText(/consensus reached/i)).toBeInTheDocument();
+  });
+
+  it('flips to not reached when no one signs', () => {
+    render(<SliceSimulator attestors={TWO_EQUAL} threshold={3} />);
+    fireEvent.click(screen.getByRole('button', { name: /none sign/i }));
+    expect(screen.getByText(/consensus not reached/i)).toBeInTheDocument();
+  });
+
+  it('updates the outcome when an attestor is toggled off', () => {
+    render(<SliceSimulator attestors={TWO_EQUAL} threshold={3} />);
+    expect(screen.getByText(/consensus reached/i)).toBeInTheDocument();
+    // Untick the first attestor: signed weight drops to 2 < 3.
+    const list = screen.getByLabelText(/toggle which attestors sign/i);
+    const firstCheckbox = within(list).getAllByRole('checkbox')[0];
+    fireEvent.click(firstCheckbox);
+    expect(screen.getByText(/consensus not reached/i)).toBeInTheDocument();
+  });
+
+  it('"Minimum to pass" selects a sufficient signer set', () => {
+    render(<SliceSimulator attestors={TWO_EQUAL} threshold={3} />);
+    fireEvent.click(screen.getByRole('button', { name: /none sign/i }));
+    expect(screen.getByText(/consensus not reached/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /minimum to pass/i }));
+    expect(screen.getByText(/consensus reached/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/QuorumSliceBuilder.tsx
+++ b/frontend/src/components/QuorumSliceBuilder.tsx
@@ -13,6 +13,7 @@ import {
   consensusSummary,
 } from '../lib/sliceBuilderUtils';
 import type { AttestorEntry } from '../lib/sliceBuilderUtils';
+import { SliceSimulator } from './SliceSimulator';
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -209,6 +210,7 @@ export function QuorumSliceBuilder({ creatorAddress, initialAttestors, initialTh
   const [submitError, setSubmitError] = useState('');
   const [success, setSuccess] = useState<{ sliceId: bigint } | null>(null);
   const [copied, setCopied] = useState(false);
+  const [showSim, setShowSim] = useState(false);
 
   // ── Auto-save draft ────────────────────────────────────────────────────────
   useEffect(() => {
@@ -514,6 +516,32 @@ export function QuorumSliceBuilder({ creatorAddress, initialAttestors, initialTh
       </section>
 
       <div className="divider" />
+
+      {/* ── Simulate / Preview ── */}
+      {attestors.length > 0 && (
+        <section className="qsb__section" aria-label="Simulate attestation scenarios">
+          <div className="qsb__section-header">
+            <span className="detail-card__title">Simulate / Preview</span>
+            <Tooltip text="Preview which signing scenarios would reach consensus, and how resilient the slice is, before you create it." />
+          </div>
+          <button
+            type="button"
+            className="btn btn--ghost btn--sm"
+            style={{ width: '100%' }}
+            aria-expanded={showSim}
+            onClick={() => setShowSim((s) => !s)}
+          >
+            {showSim ? 'Hide simulator' : '🧪 Preview attestation outcomes'}
+          </button>
+          {showSim && (
+            <div style={{ marginTop: 16 }}>
+              <SliceSimulator attestors={attestors} threshold={threshold} />
+            </div>
+          )}
+        </section>
+      )}
+
+      {attestors.length > 0 && <div className="divider" />}
 
       {/* ── Share ── */}
       {attestors.length > 0 && (

--- a/frontend/src/components/SliceSimulator.tsx
+++ b/frontend/src/components/SliceSimulator.tsx
@@ -1,0 +1,185 @@
+import { useMemo, useState } from 'react';
+import type { AttestorEntry } from '../lib/sliceBuilderUtils';
+import { consensusSummary } from '../lib/sliceBuilderUtils';
+import {
+  evaluateScenario,
+  scenarioStats,
+  faultTolerance,
+  minimalWinningCoalitions,
+  MAX_ENUM_ATTESTORS,
+} from '../lib/sliceSimulator';
+
+function fmt(addr: string) {
+  return addr ? addr.slice(0, 8) + '…' + addr.slice(-6) : '(no address)';
+}
+
+export interface SliceSimulatorProps {
+  attestors: AttestorEntry[];
+  threshold: number;
+}
+
+/**
+ * Interactive preview of attestation outcomes. The user toggles which attestors
+ * sign and immediately sees whether the slice would reach consensus, alongside
+ * resilience stats for the configuration as a whole.
+ */
+export function SliceSimulator({ attestors, threshold }: SliceSimulatorProps) {
+  // Track who is explicitly *not* signing; everyone signs by default, so newly
+  // added attestors are included automatically.
+  const [unsigned, setUnsigned] = useState<Set<string>>(() => new Set());
+
+  const signedIds = useMemo(() => {
+    const s = new Set<string>();
+    for (const a of attestors) if (!unsigned.has(a.id)) s.add(a.id);
+    return s;
+  }, [attestors, unsigned]);
+
+  const result = useMemo(
+    () => evaluateScenario(attestors, threshold, signedIds),
+    [attestors, threshold, signedIds],
+  );
+  const stats = useMemo(() => scenarioStats(attestors, threshold), [attestors, threshold]);
+  const tolerance = useMemo(() => faultTolerance(attestors, threshold), [attestors, threshold]);
+  const { minSigners } = useMemo(
+    () => consensusSummary(threshold, attestors),
+    [threshold, attestors],
+  );
+  const minimal = useMemo(
+    () => minimalWinningCoalitions(attestors, threshold),
+    [attestors, threshold],
+  );
+
+  function toggle(id: string) {
+    setUnsigned((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+  function allSign() {
+    setUnsigned(new Set());
+  }
+  function noneSign() {
+    setUnsigned(new Set(attestors.map((a) => a.id)));
+  }
+  function minimalSign() {
+    const coalition = minimal[0];
+    if (!coalition) return;
+    const keep = new Set(coalition.map((a) => a.id));
+    setUnsigned(new Set(attestors.filter((a) => !keep.has(a.id)).map((a) => a.id)));
+  }
+
+  if (attestors.length === 0) {
+    return <p className="qsb__empty">Add attestors to simulate attestation scenarios.</p>;
+  }
+
+  const bannerClass = result.success ? 'status-banner--valid' : 'status-banner--revoked';
+
+  return (
+    <div className="qsb__sim" aria-label="Attestation scenario simulator">
+      {/* Outcome */}
+      <div className={`status-banner ${bannerClass}`} role="status" aria-live="polite">
+        <div className="status-banner__icon">{result.success ? '✅' : '❌'}</div>
+        <div>
+          <div className="status-banner__title">
+            {result.success ? 'Consensus Reached' : 'Consensus Not Reached'}
+          </div>
+          <div className="status-banner__sub">
+            Signed weight {result.signedWeight} / {result.threshold} required ({result.percentOfThreshold}%).{' '}
+            {result.success
+              ? result.surplus > 0
+                ? `${result.surplus} weight to spare.`
+                : 'Exactly at threshold.'
+              : `${result.deficit} more weight needed.`}
+          </div>
+        </div>
+      </div>
+
+      {/* Quick scenarios */}
+      <div className="qsb__sim-actions" role="group" aria-label="Quick scenarios">
+        <button type="button" className="btn btn--ghost btn--sm" onClick={allSign}>
+          All sign
+        </button>
+        <button type="button" className="btn btn--ghost btn--sm" onClick={noneSign}>
+          None sign
+        </button>
+        <button
+          type="button"
+          className="btn btn--ghost btn--sm"
+          onClick={minimalSign}
+          disabled={minimal.length === 0}
+          title={
+            minimal.length === 0
+              ? 'No combination of signers can reach this threshold.'
+              : 'Select a smallest sufficient set of signers.'
+          }
+        >
+          Minimum to pass
+        </button>
+      </div>
+
+      {/* Per-attestor signing toggles */}
+      <ul className="qsb__sim-list" aria-label="Toggle which attestors sign">
+        {attestors.map((a) => {
+          const isSigned = !unsigned.has(a.id);
+          return (
+            <li key={a.id} className="qsb__sim-item">
+              <label className="qsb__sim-toggle">
+                <input
+                  type="checkbox"
+                  checked={isSigned}
+                  onChange={() => toggle(a.id)}
+                  aria-label={`${a.role} ${fmt(a.address)} signs (weight ${a.weight})`}
+                />
+                <span className="qsb__sim-item__addr mono" title={a.address}>
+                  {fmt(a.address)}
+                </span>
+                <span className="qsb__sim-item__role">{a.role}</span>
+                <span className="qsb__sim-item__weight" aria-hidden="true">
+                  ⚖️ {a.weight}
+                </span>
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+
+      {/* Resilience stats */}
+      <div className="qsb__sim-stats" aria-label="Configuration resilience">
+        <div className="qsb__sim-stat">
+          <span className="qsb__sim-stat__value">{minSigners}</span>
+          <span className="qsb__sim-stat__label">Min. signers to pass</span>
+        </div>
+        <div className="qsb__sim-stat">
+          <span className="qsb__sim-stat__value">{tolerance}</span>
+          <span className="qsb__sim-stat__label">Attestors that can drop</span>
+        </div>
+        <div className="qsb__sim-stat">
+          <span className="qsb__sim-stat__value">
+            {stats.enumerated ? `${stats.winningScenarios}/${stats.totalScenarios}` : '—'}
+          </span>
+          <span className="qsb__sim-stat__label">
+            {stats.enumerated
+              ? `Winning combinations (${stats.winRatePct}%)`
+              : `Too many to enumerate (>${MAX_ENUM_ATTESTORS})`}
+          </span>
+        </div>
+      </div>
+
+      {/* Minimal winning coalitions */}
+      {minimal.length > 0 && (
+        <div className="qsb__sim-coalitions">
+          <p className="qsb__sim-coalitions__title">Smallest sufficient signer sets</p>
+          <ul aria-label="Minimal winning coalitions">
+            {minimal.slice(0, 6).map((coalition, idx) => (
+              <li key={idx} className="qsb__sim-coalition">
+                {coalition.map((a) => `${a.role} (${a.weight})`).join(' + ')}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/sliceSimulator.ts
+++ b/frontend/src/lib/sliceSimulator.ts
@@ -1,0 +1,172 @@
+import type { AttestorEntry } from './sliceBuilderUtils';
+import { totalWeight } from './sliceBuilderUtils';
+
+/**
+ * Slice simulation logic.
+ *
+ * A quorum slice reaches consensus when the combined weight of the attestors
+ * that actually sign meets or exceeds the configured threshold. These pure
+ * helpers let the UI preview the outcome of a given signing scenario and
+ * summarise how robust a slice configuration is, before it is created on-chain.
+ */
+
+/** Above this attestor count, exhaustive 2^n enumeration is skipped. */
+export const MAX_ENUM_ATTESTORS = 16;
+
+export interface ScenarioResult {
+  signedWeight: number;
+  totalWeight: number;
+  threshold: number;
+  /** True when the signed weight meets the threshold for a non-empty slice. */
+  success: boolean;
+  /** Weight still required to reach the threshold (0 once met). */
+  deficit: number;
+  /** Weight signed beyond the threshold (0 while unmet). */
+  surplus: number;
+  /** Signed weight as a percentage of the threshold. */
+  percentOfThreshold: number;
+}
+
+/** Combined weight of the attestors whose ids are in `signed`. */
+export function signedWeight(attestors: AttestorEntry[], signed: ReadonlySet<string>): number {
+  return attestors.reduce((sum, a) => (signed.has(a.id) ? sum + a.weight : sum), 0);
+}
+
+/** Evaluate a single signing scenario against the threshold. */
+export function evaluateScenario(
+  attestors: AttestorEntry[],
+  threshold: number,
+  signed: ReadonlySet<string>,
+): ScenarioResult {
+  const sw = signedWeight(attestors, signed);
+  const tw = totalWeight(attestors);
+  const success = attestors.length > 0 && threshold >= 1 && sw >= threshold;
+  return {
+    signedWeight: sw,
+    totalWeight: tw,
+    threshold,
+    success,
+    deficit: success ? 0 : Math.max(0, threshold - sw),
+    surplus: success ? sw - threshold : 0,
+    percentOfThreshold: threshold > 0 ? Math.round((sw / threshold) * 100) : 0,
+  };
+}
+
+export interface ScenarioStats {
+  /** Number of distinct signing combinations considered (2^n, includes empty). */
+  totalScenarios: number;
+  /** Combinations whose signed weight meets the threshold. */
+  winningScenarios: number;
+  losingScenarios: number;
+  /** Winning combinations as a percentage of all combinations. */
+  winRatePct: number;
+  /** False when the slice has too many attestors to enumerate exhaustively. */
+  enumerated: boolean;
+}
+
+/**
+ * Enumerate every subset of attestors (each either signs or does not) and count
+ * how many combinations reach consensus. Gives a quick sense of how forgiving a
+ * configuration is. Skipped above {@link MAX_ENUM_ATTESTORS}.
+ */
+export function scenarioStats(attestors: AttestorEntry[], threshold: number): ScenarioStats {
+  const n = attestors.length;
+  if (n === 0 || threshold < 1) {
+    return {
+      totalScenarios: n === 0 ? 0 : 1 << n,
+      winningScenarios: 0,
+      losingScenarios: n === 0 ? 0 : 1 << n,
+      winRatePct: 0,
+      enumerated: n <= MAX_ENUM_ATTESTORS,
+    };
+  }
+  if (n > MAX_ENUM_ATTESTORS) {
+    return {
+      totalScenarios: 0,
+      winningScenarios: 0,
+      losingScenarios: 0,
+      winRatePct: 0,
+      enumerated: false,
+    };
+  }
+
+  const total = 1 << n;
+  let winning = 0;
+  for (let mask = 0; mask < total; mask++) {
+    let weight = 0;
+    for (let i = 0; i < n; i++) {
+      if (mask & (1 << i)) weight += attestors[i].weight;
+    }
+    if (weight >= threshold) winning++;
+  }
+  return {
+    totalScenarios: total,
+    winningScenarios: winning,
+    losingScenarios: total - winning,
+    winRatePct: Math.round((winning / total) * 100),
+    enumerated: true,
+  };
+}
+
+/**
+ * Maximum number of attestors that can be unavailable while the remaining set
+ * can still reach the threshold, assuming the most impactful (highest-weight)
+ * attestors are the ones lost. A higher number means a more resilient slice.
+ */
+export function faultTolerance(attestors: AttestorEntry[], threshold: number): number {
+  const tw = totalWeight(attestors);
+  if (attestors.length === 0 || threshold < 1 || tw < threshold) return 0;
+
+  const byWeightDesc = [...attestors].sort((a, b) => b.weight - a.weight);
+  let removed = 0;
+  let remaining = tw;
+  for (const a of byWeightDesc) {
+    if (remaining - a.weight >= threshold) {
+      remaining -= a.weight;
+      removed++;
+    } else {
+      break;
+    }
+  }
+  return removed;
+}
+
+/**
+ * Minimal winning coalitions: signer sets that reach the threshold but where
+ * dropping any single member would fall short. These are the "just enough"
+ * scenarios worth previewing. Capped to keep the list readable, and skipped
+ * above {@link MAX_ENUM_ATTESTORS}.
+ */
+export function minimalWinningCoalitions(
+  attestors: AttestorEntry[],
+  threshold: number,
+  cap = 20,
+): AttestorEntry[][] {
+  const n = attestors.length;
+  if (n === 0 || threshold < 1 || n > MAX_ENUM_ATTESTORS) return [];
+
+  const result: AttestorEntry[][] = [];
+  for (let mask = 1; mask < 1 << n && result.length < cap; mask++) {
+    let weight = 0;
+    for (let i = 0; i < n; i++) {
+      if (mask & (1 << i)) weight += attestors[i].weight;
+    }
+    if (weight < threshold) continue;
+
+    let minimal = true;
+    for (let i = 0; i < n; i++) {
+      if (mask & (1 << i) && weight - attestors[i].weight >= threshold) {
+        minimal = false;
+        break;
+      }
+    }
+    if (minimal) {
+      const members: AttestorEntry[] = [];
+      for (let i = 0; i < n; i++) {
+        if (mask & (1 << i)) members.push(attestors[i]);
+      }
+      result.push(members);
+    }
+  }
+  return result;
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2561,3 +2561,102 @@ textarea {
     flex-wrap: wrap;
   }
 }
+
+/* ── Slice Simulator (issue #946) ─────────────────────────────────────────── */
+.qsb__sim {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.qsb__sim-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.qsb__sim-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.qsb__sim-item {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-surface);
+}
+.qsb__sim-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+.qsb__sim-toggle input {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  accent-color: var(--green);
+}
+.qsb__sim-item__addr {
+  font-size: 13px;
+  color: var(--text-primary);
+}
+.qsb__sim-item__role {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.qsb__sim-item__weight {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.qsb__sim-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+.qsb__sim-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 4px;
+  padding: 12px 8px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-surface);
+}
+.qsb__sim-stat__value {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.qsb__sim-stat__label {
+  font-size: 11px;
+  color: var(--text-secondary);
+  line-height: 1.3;
+}
+.qsb__sim-coalitions__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin: 0 0 6px;
+}
+.qsb__sim-coalitions ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.qsb__sim-coalition {
+  font-size: 12px;
+  color: var(--text-primary);
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: var(--green-subtle);
+}


### PR DESCRIPTION
Closes #946

---

## Summary

Implements **#946 — Slice Simulation / Preview Mode**. Users can now preview attestation outcomes for different threshold/weight combinations *before* creating a slice, directly in the Quorum Slice Builder.

### What's added
- **`src/lib/sliceSimulator.ts`** — pure, framework-free logic:
  - `evaluateScenario` — for a given set of signers, returns success/failure vs the threshold with the exact deficit or surplus weight.
  - `scenarioStats` — enumerates all `2^n` sign/don't-sign combinations and reports how many reach consensus (a quick "how forgiving is this config" measure). Capped at 16 attestors.
  - `faultTolerance` — how many of the highest-weight attestors can drop out while the rest can still reach consensus.
  - `minimalWinningCoalitions` — the "just enough" signer sets.
- **`src/components/SliceSimulator.tsx`** — interactive preview:
  - Per-attestor sign/don't-sign toggles with a live **Consensus Reached / Not Reached** banner (signed weight vs threshold, %, deficit/surplus).
  - Quick scenarios: **All sign**, **None sign**, **Minimum to pass**.
  - Resilience stats: minimum signers, drop-out tolerance, winning-combination count/rate.
  - Reuses the existing slice domain helpers (`totalWeight`, `consensusSummary`) and design tokens / `status-banner` styles.
- **`QuorumSliceBuilder`** — a collapsible **Simulate / Preview** section wiring the simulator to the live attestor list and threshold.
- Simulator styles appended to `styles.css` using existing CSS variables.

### Testing
`src/__tests__/SliceSimulator.test.tsx` — 16 tests covering the pure logic (signed weight, success/deficit/surplus, subset enumeration counts, fault tolerance, minimal coalitions) and component interactions (outcome flips on toggle, All/None/Minimum buttons). All pass under `vitest`, and the existing `QuorumSlice` page tests still pass (20 total green).

## ⚠️ Note on the build

`tsc -b` currently reports **~172 pre-existing TypeScript errors** across unrelated files (`App.tsx`, `Wallet*`, `config/env.ts`, missing CSS-module declarations, `verbatimModuleSyntax` type-import rules, unused-symbol strictness, etc.), so `npm run build` is red on `main` independent of this change — **CI on this PR will reflect that.** The files added here are clean (**0 `tsc` errors in them**) and fully covered by passing `vitest` tests. Happy to follow up separately on the broader type-check cleanup if useful.
