### PR TITLE
Add Cache-Control headers to GET API responses

### DIFF
--- a/api-server/src/index.ts
+++ b/api-server/src/index.ts
@@ -8,6 +8,7 @@ import notificationsRouter from './routes/notifications.js';
 import analyticsRouter from './routes/analytics.js';
 import attestorRouter from './routes/attestor.js';
 import recoveryRouter from './routes/recovery.js';
+import { cacheControl } from './middleware/cacheControl.js';
 import { createRateLimiter } from './middleware/rateLimiter.js';
 import { rbac } from './middleware/rbac.js';
 import { createDDoSProtection } from './middleware/ddosProtection.js';
@@ -41,6 +42,7 @@ const apiRateLimiter = createRateLimiter({
 });
 
 app.use('/api', apiRateLimiter);
+app.use(cacheControl);
 
 app.use((req, _res, next) => {
   console.log(JSON.stringify({

--- a/api-server/src/middleware/cacheControl.ts
+++ b/api-server/src/middleware/cacheControl.ts
@@ -1,0 +1,10 @@
+import { Request, Response, NextFunction } from 'express';
+
+const CACHE_CONTROL_VALUE = 'private, max-age=30, must-revalidate';
+
+export function cacheControl(req: Request, res: Response, next: NextFunction): void {
+  if (req.method === 'GET' && !res.getHeader('Cache-Control')) {
+    res.setHeader('Cache-Control', CACHE_CONTROL_VALUE);
+  }
+  next();
+}

--- a/api-server/tests/cacheControl.test.ts
+++ b/api-server/tests/cacheControl.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { cacheControl } from '../src/middleware/cacheControl.js';
+
+function createTestApp() {
+  const app = express();
+  app.use(cacheControl);
+  app.get('/api/test', (_req, res) => res.json({ ok: true }));
+  app.post('/api/test', (_req, res) => res.json({ ok: true }));
+  app.get('/api/custom', (_req, res) => {
+    res.setHeader('Cache-Control', 'no-store');
+    res.json({ ok: true });
+  });
+  return app;
+}
+
+describe('Cache Control Middleware', () => {
+  it('sets Cache-Control on GET responses', async () => {
+    const res = await request(createTestApp()).get('/api/test');
+
+    expect(res.headers['cache-control']).toBe('private, max-age=30, must-revalidate');
+  });
+
+  it('sets an ETag header on GET responses', async () => {
+    const res = await request(createTestApp()).get('/api/test');
+
+    expect(res.headers['etag']).toBeDefined();
+  });
+
+  it('does not override a Cache-Control header set by a route', async () => {
+    const res = await request(createTestApp()).get('/api/custom');
+
+    expect(res.headers['cache-control']).toBe('no-store');
+  });
+
+  it('does not set Cache-Control on non-GET requests', async () => {
+    const res = await request(createTestApp()).post('/api/test');
+
+    expect(res.headers['cache-control']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a `cacheControl` middleware that sets a `Cache-Control: private, max-age=30, must-revalidate` header on GET responses (only if a route hasn't already set its own), so clients can cache and revalidate responses.
- Express already issues weak `ETag` headers automatically for JSON responses, so no extra ETag logic was needed.

Closes #929

## Test plan
- [x] Added `tests/cacheControl.test.ts` covering: header set on GET, ETag present, route-level Cache-Control not overridden, no header on non-GET requests.
- [x] `npx vitest run tests/cacheControl.test.ts` passes.
- [x] Confirmed pre-existing failures in the broader suite (`search-ranking.test.ts`, etc.) are unrelated and present on `main` as well.