### PR TITLE
feat: add issuer performance metrics endpoint

### DIFF
--- a/api-server/src/routes/analytics.ts
+++ b/api-server/src/routes/analytics.ts
@@ -7,6 +7,7 @@ import {
   buildAnomalyQuery,
   type AnomalyDetectionResult,
   type DailyMetrics,
+  type IssuerMetrics,
 } from '../services/metrics.js';
 import { validate, schemas } from '../middleware/validate.js';
 
@@ -104,6 +105,27 @@ export function createAnalyticsRouter(soroban: SorobanClient) {
       const message = err instanceof Error ? err.message : 'Invalid query parameters';
       res.status(400).json({ error: message });
     }
+  });
+
+  // GET /api/analytics/issuer/:address
+  // Query params: period_days (default 30)
+  router.get('/issuer/:address', (req: Request, res: Response) => {
+    const { address } = req.params;
+    const periodDays = req.query.period_days
+      ? parseInt(req.query.period_days as string, 10)
+      : 30;
+
+    if (!address) {
+      res.status(400).json({ error: 'address parameter required' });
+      return;
+    }
+    if (isNaN(periodDays) || periodDays < 1 || periodDays > 365) {
+      res.status(400).json({ error: 'period_days must be between 1 and 365' });
+      return;
+    }
+
+    const metrics = metricsStore.getIssuerMetrics(address, periodDays);
+    res.json(metrics);
   });
 
   router.get('/summary', (req: Request, res: Response) => {

--- a/api-server/src/routes/attestor.ts
+++ b/api-server/src/routes/attestor.ts
@@ -65,7 +65,7 @@ router.get('/reputation/:address', async (req: Request, res: Response) => {
       return d.toISOString().split('T')[0];
     })();
 
-    const events = metricsStore.getEventLog(startDate, endDate);
+    const events = metricsStore.getEventLog({ startDate, endDate });
     const myEvents = events.filter((e) => e.attestor === address);
     const attestedCount = myEvents.filter((e) => e.type === 'attested').length;
     const totalActivity = myEvents.length;

--- a/api-server/src/services/metrics.ts
+++ b/api-server/src/services/metrics.ts
@@ -1,11 +1,22 @@
 export interface CredentialEvent {
-  type: 'issued' | 'attested' | 'revoked' | 'suspended' | 'verified';
+  type: 'issued' | 'attested' | 'revoked' | 'suspended' | 'verified' | 'disputed';
   credential_id: string;
   timestamp: string;
   issuer?: string;
   subject?: string;
   attestor?: string;
+  /** For 'attested' events paired with a prior 'issued': ms elapsed since issuance */
+  attestation_duration_ms?: number;
   metadata?: Record<string, unknown>;
+}
+
+export interface IssuerMetrics {
+  issuer: string;
+  period_days: number;
+  credentials_issued: number;
+  avg_attestation_time_ms: number | null;
+  dispute_rate: number;
+  reputation_trend: { date: string; issued: number; disputed: number }[];
 }
 
 export interface HourlyMetrics {
@@ -141,7 +152,7 @@ function normalizeDateInput(input: string): string | null {
 }
 
 function isValidEventType(type: string): boolean {
-  return ['issued', 'attested', 'revoked', 'suspended', 'verified'].includes(type);
+  return ['issued', 'attested', 'revoked', 'suspended', 'verified', 'disputed'].includes(type);
 }
 
 class MetricsStore {
@@ -351,6 +362,47 @@ class MetricsStore {
       total_events: this.eventLog.length,
       total_days: this.dailyMetrics.size,
       retention_days: RETENTION_DAYS,
+    };
+  }
+
+  getIssuerMetrics(issuer: string, periodDays = 30): IssuerMetrics {
+    const now = Date.now();
+    const windowStart = now - periodDays * 24 * 60 * 60 * 1000;
+
+    const issuerEvents = this.eventLog.filter(
+      (e) => new Date(e.timestamp).getTime() >= windowStart && e.issuer === issuer
+    );
+
+    const credentials_issued = issuerEvents.filter((e) => e.type === 'issued').length;
+    const disputes = issuerEvents.filter((e) => e.type === 'disputed').length;
+    const dispute_rate = credentials_issued > 0 ? disputes / credentials_issued : 0;
+
+    // Compute avg attestation time from events that carry attestation_duration_ms
+    const durations = issuerEvents
+      .filter((e) => e.type === 'attested' && e.attestation_duration_ms != null)
+      .map((e) => e.attestation_duration_ms as number);
+    const avg_attestation_time_ms =
+      durations.length > 0 ? durations.reduce((s, d) => s + d, 0) / durations.length : null;
+
+    // Daily reputation trend: group issued/disputed by date
+    const byDate: Record<string, { issued: number; disputed: number }> = {};
+    for (const e of issuerEvents) {
+      const date = e.timestamp.slice(0, 10);
+      if (!byDate[date]) byDate[date] = { issued: 0, disputed: 0 };
+      if (e.type === 'issued') byDate[date].issued++;
+      if (e.type === 'disputed') byDate[date].disputed++;
+    }
+    const reputation_trend = Object.entries(byDate)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, counts]) => ({ date, ...counts }));
+
+    return {
+      issuer,
+      period_days: periodDays,
+      credentials_issued,
+      avg_attestation_time_ms,
+      dispute_rate,
+      reputation_trend,
     };
   }
 

--- a/api-server/tests/issuer-metrics.test.ts
+++ b/api-server/tests/issuer-metrics.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createAnalyticsRouter } from '../src/routes/analytics.js';
+import { metricsStore, type CredentialEvent } from '../src/services/metrics.js';
+
+const mockSoroban = {
+  simulateCall: async () => null,
+  u64Val: (n: number | bigint) => n as unknown,
+  u32Val: (n: number) => n,
+  addressVal: (a: string) => a,
+};
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/analytics', createAnalyticsRouter(mockSoroban));
+  return app;
+}
+
+const app = createTestApp();
+const ISSUER = 'GABC1234ISSUER';
+const OTHER_ISSUER = 'GXYZ9999OTHER';
+
+describe('GET /api/analytics/issuer/:address', () => {
+  beforeEach(() => {
+    metricsStore.reset();
+  });
+
+  it('returns zero metrics when no events exist', async () => {
+    const res = await request(app).get(`/api/analytics/issuer/${ISSUER}`);
+    expect(res.status).toBe(200);
+    expect(res.body.issuer).toBe(ISSUER);
+    expect(res.body.credentials_issued).toBe(0);
+    expect(res.body.avg_attestation_time_ms).toBeNull();
+    expect(res.body.dispute_rate).toBe(0);
+    expect(res.body.reputation_trend).toEqual([]);
+  });
+
+  it('counts credentials issued by this issuer only', async () => {
+    const now = new Date().toISOString();
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c1', timestamp: now, issuer: ISSUER });
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c2', timestamp: now, issuer: ISSUER });
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c3', timestamp: now, issuer: OTHER_ISSUER });
+
+    const res = await request(app).get(`/api/analytics/issuer/${ISSUER}`);
+    expect(res.status).toBe(200);
+    expect(res.body.credentials_issued).toBe(2);
+  });
+
+  it('calculates dispute_rate correctly', async () => {
+    const now = new Date().toISOString();
+    // 4 issued, 1 disputed → rate = 0.25
+    for (let i = 0; i < 4; i++) {
+      metricsStore.recordEvent({ type: 'issued', credential_id: `c${i}`, timestamp: now, issuer: ISSUER });
+    }
+    metricsStore.recordEvent({ type: 'disputed', credential_id: 'c0', timestamp: now, issuer: ISSUER });
+
+    const res = await request(app).get(`/api/analytics/issuer/${ISSUER}`);
+    expect(res.status).toBe(200);
+    expect(res.body.dispute_rate).toBeCloseTo(0.25);
+  });
+
+  it('returns null avg_attestation_time_ms when no duration data present', async () => {
+    const now = new Date().toISOString();
+    metricsStore.recordEvent({ type: 'attested', credential_id: 'c1', timestamp: now, issuer: ISSUER });
+
+    const res = await request(app).get(`/api/analytics/issuer/${ISSUER}`);
+    expect(res.status).toBe(200);
+    expect(res.body.avg_attestation_time_ms).toBeNull();
+  });
+
+  it('calculates avg_attestation_time_ms from attestation_duration_ms', async () => {
+    const now = new Date().toISOString();
+    const attestEvents: CredentialEvent[] = [
+      { type: 'attested', credential_id: 'c1', timestamp: now, issuer: ISSUER, attestation_duration_ms: 1000 },
+      { type: 'attested', credential_id: 'c2', timestamp: now, issuer: ISSUER, attestation_duration_ms: 3000 },
+    ];
+    attestEvents.forEach((e) => metricsStore.recordEvent(e));
+
+    const res = await request(app).get(`/api/analytics/issuer/${ISSUER}`);
+    expect(res.status).toBe(200);
+    expect(res.body.avg_attestation_time_ms).toBeCloseTo(2000);
+  });
+
+  it('builds reputation_trend grouped by day', async () => {
+    const day1 = '2026-06-27T10:00:00.000Z';
+    const day2 = '2026-06-28T10:00:00.000Z';
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c1', timestamp: day1, issuer: ISSUER });
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c2', timestamp: day1, issuer: ISSUER });
+    metricsStore.recordEvent({ type: 'disputed', credential_id: 'c1', timestamp: day1, issuer: ISSUER });
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c3', timestamp: day2, issuer: ISSUER });
+
+    const res = await request(app).get(`/api/analytics/issuer/${ISSUER}`);
+    expect(res.status).toBe(200);
+
+    const trend: { date: string; issued: number; disputed: number }[] = res.body.reputation_trend;
+    const d1 = trend.find((t) => t.date === '2026-06-27');
+    const d2 = trend.find((t) => t.date === '2026-06-28');
+    expect(d1).toBeDefined();
+    expect(d1!.issued).toBe(2);
+    expect(d1!.disputed).toBe(1);
+    expect(d2!.issued).toBe(1);
+    expect(d2!.disputed).toBe(0);
+  });
+
+  it('includes period_days in response', async () => {
+    const res = await request(app).get(`/api/analytics/issuer/${ISSUER}?period_days=7`);
+    expect(res.status).toBe(200);
+    expect(res.body.period_days).toBe(7);
+  });
+
+  it('rejects invalid period_days', async () => {
+    const res = await request(app).get(`/api/analytics/issuer/${ISSUER}?period_days=0`);
+    expect(res.status).toBe(400);
+  });
+
+  it('excludes events outside the period window', async () => {
+    // Event 60 days ago — outside a 30-day window
+    const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+    const recent = new Date().toISOString();
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'old', timestamp: old, issuer: ISSUER });
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'new', timestamp: recent, issuer: ISSUER });
+
+    const res = await request(app).get(`/api/analytics/issuer/${ISSUER}?period_days=30`);
+    expect(res.status).toBe(200);
+    expect(res.body.credentials_issued).toBe(1);
+  });
+});


### PR DESCRIPTION
- Add GET /api/analytics/issuer/:address with avg attestation time, credentials issued, dispute rate, and reputation trend over time
- Add 'disputed' event type and attestation_duration_ms to CredentialEvent
- Add IssuerMetrics interface and getIssuerMetrics() to MetricsStore
- Fix getEventLog() call in attestor.ts (wrong arg signature)
- Add 9 tests covering all new metrics logic

closes #959 