### PR TITLE
feat: add slice template library (#945)

### DIFF
--- a/frontend/src/components/QuorumSliceBuilder.tsx
+++ b/frontend/src/components/QuorumSliceBuilder.tsx
@@ -3,7 +3,6 @@ import type { ChangeEvent, FormEvent, KeyboardEvent } from 'react';
 import { createSlice } from '../lib/contracts/quorumProof';
 import { useToast } from '../context/ToastContext';
 import {
-  PRESETS,
   saveDraft,
   loadDraft,
   clearDraft,
@@ -13,6 +12,7 @@ import {
   consensusSummary,
 } from '../lib/sliceBuilderUtils';
 import type { AttestorEntry } from '../lib/sliceBuilderUtils';
+import { SliceTemplateLibrary } from './SliceTemplateLibrary';
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -209,6 +209,18 @@ export function QuorumSliceBuilder({ creatorAddress, initialAttestors, initialTh
   const [submitError, setSubmitError] = useState('');
   const [success, setSuccess] = useState<{ sliceId: bigint } | null>(null);
   const [copied, setCopied] = useState(false);
+  const [showTemplates, setShowTemplates] = useState(false);
+
+  const handleApplyTemplate = useCallback(
+    (templateAttestors: Omit<AttestorEntry, 'id'>[], templateThreshold: number) => {
+      setAttestors(templateAttestors.map((a) => ({ ...a, id: crypto.randomUUID() })));
+      setThreshold(templateThreshold);
+      setAddrError('');
+      setThresholdError('');
+      setShowTemplates(false);
+    },
+    [],
+  );
 
   // ── Auto-save draft ────────────────────────────────────────────────────────
   useEffect(() => {
@@ -260,15 +272,6 @@ export function QuorumSliceBuilder({ creatorAddress, initialAttestors, initialTh
       if (threshold > newTw && newTw > 0) setThreshold(newTw);
       return next;
     });
-  }
-
-  function handlePreset(presetId: string) {
-    const preset = PRESETS.find((p) => p.id === presetId);
-    if (!preset) return;
-    setAttestors(preset.attestors.map((a) => ({ ...a, id: crypto.randomUUID() })));
-    setThreshold(preset.threshold);
-    setAddrError('');
-    setThresholdError('');
   }
 
   function handleCopyUrl() {
@@ -331,26 +334,27 @@ export function QuorumSliceBuilder({ creatorAddress, initialAttestors, initialTh
   return (
     <div className="qsb">
 
-      {/* ── Presets ── */}
-      <section className="qsb__section" aria-label="Preset templates">
+      {/* ── Template Library ── */}
+      <section className="qsb__section" aria-label="Slice template library">
         <div className="qsb__section-header">
-          <span className="detail-card__title">Preset Templates</span>
-          <Tooltip text="Start with a recommended configuration for common trust scenarios." />
+          <span className="detail-card__title">Templates</span>
+          <Tooltip text="Browse pre-built slice configurations and apply one as your starting point." />
         </div>
-        <div className="qsb__presets">
-          {PRESETS.map((p) => (
-            <button
-              key={p.id}
-              type="button"
-              className="qsb__preset-btn"
-              onClick={() => handlePreset(p.id)}
-              title={p.description}
-              aria-label={`Apply preset: ${p.label}`}
-            >
-              {p.label}
-            </button>
-          ))}
-        </div>
+        <button
+          type="button"
+          className="btn btn--ghost btn--sm"
+          style={{ width: '100%', marginBottom: showTemplates ? 16 : 0 }}
+          onClick={() => setShowTemplates((v) => !v)}
+          aria-expanded={showTemplates}
+          aria-controls="stl-panel"
+        >
+          {showTemplates ? '▲ Hide Templates' : '▼ Browse Templates'}
+        </button>
+        {showTemplates && (
+          <div id="stl-panel">
+            <SliceTemplateLibrary onApply={handleApplyTemplate} />
+          </div>
+        )}
       </section>
 
       <div className="divider" />

--- a/frontend/src/components/SliceTemplateLibrary.tsx
+++ b/frontend/src/components/SliceTemplateLibrary.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import {
+  SLICE_TEMPLATES,
+  TEMPLATE_CATEGORIES,
+  filterByCategory,
+} from '../lib/sliceTemplates';
+import type { SliceTemplate, TemplateCategory } from '../lib/sliceTemplates';
+import type { AttestorEntry } from '../lib/sliceBuilderUtils';
+
+export interface SliceTemplateLibraryProps {
+  /** Called when the user clicks "Use Template" on a card. */
+  onApply: (attestors: Omit<AttestorEntry, 'id'>[], threshold: number) => void;
+}
+
+function TemplateCard({
+  template,
+  onApply,
+}: {
+  template: SliceTemplate;
+  onApply: SliceTemplateLibraryProps['onApply'];
+}) {
+  const totalWeight = template.attestors.reduce((s, a) => s + a.weight, 0);
+  const pct = totalWeight > 0 ? Math.round((template.threshold / totalWeight) * 100) : 0;
+
+  // Summarise attestors by role
+  const roleSummary = template.attestors.reduce<Record<string, number>>((acc, a) => {
+    acc[a.role] = (acc[a.role] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  return (
+    <div className="stl-card" role="article" aria-label={template.label}>
+      <div className="stl-card__header">
+        <span className="stl-card__title">{template.label}</span>
+        <span className="stl-card__badge">{template.category}</span>
+      </div>
+      <p className="stl-card__desc">{template.description}</p>
+
+      {/* Attestor role summary */}
+      <ul className="stl-card__roles" aria-label="Attestor roles in template">
+        {Object.entries(roleSummary).map(([role, count]) => (
+          <li key={role} className="stl-card__role-item">
+            {count > 1 ? `${count}× ` : ''}{role}
+          </li>
+        ))}
+      </ul>
+
+      {/* Threshold info */}
+      <div className="stl-card__threshold" aria-label={`Threshold: ${template.threshold} of ${totalWeight} weight (${pct}%)`}>
+        <span>Threshold</span>
+        <span>{template.threshold} / {totalWeight} ({pct}%)</span>
+      </div>
+
+      <button
+        type="button"
+        className="btn btn--ghost btn--sm stl-card__apply"
+        onClick={() => onApply(template.attestors, template.threshold)}
+        aria-label={`Use template: ${template.label}`}
+      >
+        Use Template
+      </button>
+    </div>
+  );
+}
+
+export function SliceTemplateLibrary({ onApply }: SliceTemplateLibraryProps) {
+  const [activeCategory, setActiveCategory] = useState<TemplateCategory | undefined>(undefined);
+  const visible = filterByCategory(SLICE_TEMPLATES, activeCategory);
+
+  return (
+    <div className="stl" role="region" aria-label="Slice template library">
+      {/* Category tabs */}
+      <div className="stl__tabs" role="tablist" aria-label="Template categories">
+        <button
+          type="button"
+          role="tab"
+          className={`stl__tab${activeCategory === undefined ? ' stl__tab--active' : ''}`}
+          aria-selected={activeCategory === undefined}
+          onClick={() => setActiveCategory(undefined)}
+        >
+          All
+        </button>
+        {TEMPLATE_CATEGORIES.map((cat) => (
+          <button
+            key={cat}
+            type="button"
+            role="tab"
+            className={`stl__tab${activeCategory === cat ? ' stl__tab--active' : ''}`}
+            aria-selected={activeCategory === cat}
+            onClick={() => setActiveCategory(cat)}
+          >
+            {cat}
+          </button>
+        ))}
+      </div>
+
+      {/* Template cards */}
+      <div className="stl__grid" role="list">
+        {visible.map((template) => (
+          <TemplateCard key={template.id} template={template} onApply={onApply} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/SliceTemplateLibrary.test.tsx
+++ b/frontend/src/components/__tests__/SliceTemplateLibrary.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  SLICE_TEMPLATES,
+  TEMPLATE_CATEGORIES,
+  filterByCategory,
+} from '../../lib/sliceTemplates';
+import type { TemplateCategory } from '../../lib/sliceTemplates';
+import { SliceTemplateLibrary } from '../SliceTemplateLibrary';
+
+// ── sliceTemplates data ───────────────────────────────────────────────────────
+
+describe('SLICE_TEMPLATES catalogue', () => {
+  it('contains at least one template per category', () => {
+    for (const category of TEMPLATE_CATEGORIES) {
+      const found = SLICE_TEMPLATES.filter((t) => t.category === category);
+      expect(found.length, `No templates in category "${category}"`).toBeGreaterThan(0);
+    }
+  });
+
+  it('every template has a unique id', () => {
+    const ids = SLICE_TEMPLATES.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every template threshold is within its total weight', () => {
+    for (const t of SLICE_TEMPLATES) {
+      const tw = t.attestors.reduce((s, a) => s + a.weight, 0);
+      expect(t.threshold, `"${t.id}" threshold < 1`).toBeGreaterThanOrEqual(1);
+      expect(t.threshold, `"${t.id}" threshold > total weight`).toBeLessThanOrEqual(tw);
+    }
+  });
+
+  it('every template has at least one attestor', () => {
+    for (const t of SLICE_TEMPLATES) {
+      expect(t.attestors.length, `"${t.id}" has no attestors`).toBeGreaterThan(0);
+    }
+  });
+
+  it('every attestor weight is between 1 and 10', () => {
+    for (const t of SLICE_TEMPLATES) {
+      for (const a of t.attestors) {
+        expect(a.weight).toBeGreaterThanOrEqual(1);
+        expect(a.weight).toBeLessThanOrEqual(10);
+      }
+    }
+  });
+
+  it('TEMPLATE_CATEGORIES lists all categories present', () => {
+    const inData = new Set(SLICE_TEMPLATES.map((t) => t.category));
+    for (const cat of TEMPLATE_CATEGORIES) {
+      expect(inData.has(cat)).toBe(true);
+    }
+  });
+});
+
+describe('filterByCategory', () => {
+  it('returns all templates when category is undefined', () => {
+    expect(filterByCategory(SLICE_TEMPLATES, undefined)).toHaveLength(SLICE_TEMPLATES.length);
+  });
+
+  it('returns only matching templates for a given category', () => {
+    const result = filterByCategory(SLICE_TEMPLATES, 'Academic');
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.every((t) => t.category === 'Academic')).toBe(true);
+  });
+
+  it('returns an empty array for a category with no templates', () => {
+    const empty = filterByCategory(SLICE_TEMPLATES, 'NonExistent' as TemplateCategory);
+    expect(empty).toHaveLength(0);
+  });
+});
+
+// ── SliceTemplateLibrary component ────────────────────────────────────────────
+
+describe('SliceTemplateLibrary', () => {
+  it('renders the "All" tab and all category tabs', () => {
+    render(<SliceTemplateLibrary onApply={vi.fn()} />);
+    expect(screen.getByRole('tab', { name: 'All' })).toBeInTheDocument();
+    for (const cat of TEMPLATE_CATEGORIES) {
+      expect(screen.getByRole('tab', { name: cat })).toBeInTheDocument();
+    }
+  });
+
+  it('shows all templates by default (All tab active)', () => {
+    render(<SliceTemplateLibrary onApply={vi.fn()} />);
+    const cards = screen.getAllByRole('article');
+    expect(cards.length).toBe(SLICE_TEMPLATES.length);
+  });
+
+  it('filters templates when a category tab is clicked', () => {
+    render(<SliceTemplateLibrary onApply={vi.fn()} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Academic' }));
+    const expected = SLICE_TEMPLATES.filter((t) => t.category === 'Academic').length;
+    expect(screen.getAllByRole('article')).toHaveLength(expected);
+  });
+
+  it('returns to all templates when "All" tab is re-clicked', () => {
+    render(<SliceTemplateLibrary onApply={vi.fn()} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Minimal' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'All' }));
+    expect(screen.getAllByRole('article')).toHaveLength(SLICE_TEMPLATES.length);
+  });
+
+  it('calls onApply with correct attestors and threshold when "Use Template" is clicked', () => {
+    const onApply = vi.fn();
+    render(<SliceTemplateLibrary onApply={onApply} />);
+
+    // Click the first "Use Template" button
+    const buttons = screen.getAllByText('Use Template');
+    fireEvent.click(buttons[0]);
+
+    const firstTemplate = SLICE_TEMPLATES[0];
+    expect(onApply).toHaveBeenCalledOnce();
+    const [attestors, threshold] = onApply.mock.calls[0] as [typeof firstTemplate.attestors, number];
+    expect(threshold).toBe(firstTemplate.threshold);
+    expect(attestors).toHaveLength(firstTemplate.attestors.length);
+    expect(attestors[0].role).toBe(firstTemplate.attestors[0].role);
+    expect(attestors[0].weight).toBe(firstTemplate.attestors[0].weight);
+  });
+
+  it('marks the clicked category tab as selected', () => {
+    render(<SliceTemplateLibrary onApply={vi.fn()} />);
+    const profTab = screen.getByRole('tab', { name: 'Professional' });
+    fireEvent.click(profTab);
+    expect(profTab).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('"All" tab is selected by default', () => {
+    render(<SliceTemplateLibrary onApply={vi.fn()} />);
+    expect(screen.getByRole('tab', { name: 'All' })).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -25,3 +25,5 @@ export { ClaimProofGenerator } from './ClaimProofGenerator';
 export { CLAIM_TYPE_OPTIONS, findClaimTypeOption, encodeProofRequest, buildProofShareUrl } from '../lib/claimDisclosure';
 export type { ClaimTypeOption } from '../lib/claimDisclosure';
 export { CredentialVerificationDashboard } from './CredentialVerificationDashboard';
+export { SliceTemplateLibrary } from './SliceTemplateLibrary';
+export type { SliceTemplateLibraryProps } from './SliceTemplateLibrary';

--- a/frontend/src/lib/sliceTemplates.ts
+++ b/frontend/src/lib/sliceTemplates.ts
@@ -1,0 +1,236 @@
+/**
+ * Slice Template Library — pre-built QuorumSlice configurations.
+ *
+ * Each template is ready to apply: attestors carry placeholder addresses
+ * that the user replaces after loading the template, and a threshold that
+ * reflects a sensible default for the described trust scenario.
+ */
+
+export type TemplateCategory =
+  | 'Academic'
+  | 'Professional'
+  | 'Multi-Region'
+  | 'Minimal'
+  | 'Enterprise';
+
+export interface TemplateAttestor {
+  /** Placeholder address — user must fill in a real Stellar address. */
+  address: string;
+  role: string;
+  weight: number;
+}
+
+export interface SliceTemplate {
+  id: string;
+  label: string;
+  description: string;
+  category: TemplateCategory;
+  tags: string[];
+  attestors: TemplateAttestor[];
+  threshold: number;
+}
+
+/** Reusable blank placeholder per role (users replace before submitting). */
+const BLANK = '';
+
+export const SLICE_TEMPLATES: SliceTemplate[] = [
+  // ── Academic ───────────────────────────────────────────────────────────────
+
+  {
+    id: 'academic-basic',
+    label: '🎓 Academic Basic',
+    description: 'University + licensing body, both required. Ideal for single-country credential verification.',
+    category: 'Academic',
+    tags: ['university', 'license'],
+    attestors: [
+      { address: BLANK, role: 'University', weight: 2 },
+      { address: BLANK, role: 'Licensing Body', weight: 2 },
+    ],
+    threshold: 4,
+  },
+  {
+    id: 'academic-extended',
+    label: '🎓 Academic + Employer',
+    description: 'University, licensing body, and one employer — majority consensus required.',
+    category: 'Academic',
+    tags: ['university', 'license', 'employer'],
+    attestors: [
+      { address: BLANK, role: 'University', weight: 3 },
+      { address: BLANK, role: 'Licensing Body', weight: 3 },
+      { address: BLANK, role: 'Employer', weight: 2 },
+    ],
+    threshold: 6,
+  },
+  {
+    id: 'academic-dual-degree',
+    label: '🎓 Dual-Degree',
+    description: 'Two universities required alongside a licensing body — useful for double-degree holders.',
+    category: 'Academic',
+    tags: ['university', 'dual', 'license'],
+    attestors: [
+      { address: BLANK, role: 'University', weight: 2 },
+      { address: BLANK, role: 'University', weight: 2 },
+      { address: BLANK, role: 'Licensing Body', weight: 2 },
+    ],
+    threshold: 6,
+  },
+
+  // ── Professional ──────────────────────────────────────────────────────────
+
+  {
+    id: 'professional-basic',
+    label: '💼 Professional',
+    description: 'University + two employers. Any two of the three nodes can reach consensus.',
+    category: 'Professional',
+    tags: ['employer', 'university'],
+    attestors: [
+      { address: BLANK, role: 'University', weight: 2 },
+      { address: BLANK, role: 'Employer', weight: 1 },
+      { address: BLANK, role: 'Employer', weight: 1 },
+    ],
+    threshold: 3,
+  },
+  {
+    id: 'professional-full',
+    label: '🏛️ Full Trust',
+    description: 'All four node types — university, licensing body, employer, and other — with a supermajority threshold.',
+    category: 'Professional',
+    tags: ['university', 'license', 'employer', 'full'],
+    attestors: [
+      { address: BLANK, role: 'University', weight: 3 },
+      { address: BLANK, role: 'Licensing Body', weight: 3 },
+      { address: BLANK, role: 'Employer', weight: 2 },
+      { address: BLANK, role: 'Other', weight: 1 },
+    ],
+    threshold: 7,
+  },
+  {
+    id: 'professional-senior',
+    label: '💼 Senior Engineer',
+    description: 'Licensing body carries highest weight alongside multiple employers — suited for senior-level verification.',
+    category: 'Professional',
+    tags: ['license', 'employer', 'senior'],
+    attestors: [
+      { address: BLANK, role: 'Licensing Body', weight: 4 },
+      { address: BLANK, role: 'Employer', weight: 2 },
+      { address: BLANK, role: 'Employer', weight: 2 },
+    ],
+    threshold: 6,
+  },
+
+  // ── Multi-Region ──────────────────────────────────────────────────────────
+
+  {
+    id: 'multi-region-basic',
+    label: '🌍 Multi-Region Trust',
+    description: 'Two licensing bodies from different jurisdictions — either alone is insufficient; both required.',
+    category: 'Multi-Region',
+    tags: ['multi-region', 'license', 'international'],
+    attestors: [
+      { address: BLANK, role: 'Licensing Body', weight: 3 },
+      { address: BLANK, role: 'Licensing Body', weight: 3 },
+    ],
+    threshold: 6,
+  },
+  {
+    id: 'multi-region-employer',
+    label: '🌍 Multi-Region + Employer',
+    description: 'Two regional licensing bodies plus an employer. Licensing bodies form a majority even without the employer.',
+    category: 'Multi-Region',
+    tags: ['multi-region', 'license', 'employer', 'international'],
+    attestors: [
+      { address: BLANK, role: 'Licensing Body', weight: 3 },
+      { address: BLANK, role: 'Licensing Body', weight: 3 },
+      { address: BLANK, role: 'Employer', weight: 2 },
+    ],
+    threshold: 6,
+  },
+  {
+    id: 'multi-region-full',
+    label: '🌐 Global Credential',
+    description: 'University, two regional licensing bodies, and an employer — designed for maximum international portability.',
+    category: 'Multi-Region',
+    tags: ['multi-region', 'university', 'license', 'employer', 'international'],
+    attestors: [
+      { address: BLANK, role: 'University', weight: 2 },
+      { address: BLANK, role: 'Licensing Body', weight: 3 },
+      { address: BLANK, role: 'Licensing Body', weight: 3 },
+      { address: BLANK, role: 'Employer', weight: 2 },
+    ],
+    threshold: 8,
+  },
+
+  // ── Minimal ────────────────────────────────────────────────────────────────
+
+  {
+    id: 'minimal-university',
+    label: '📋 University Only',
+    description: 'Single university attestor — the simplest possible slice for degree-only verification.',
+    category: 'Minimal',
+    tags: ['university', 'minimal'],
+    attestors: [
+      { address: BLANK, role: 'University', weight: 1 },
+    ],
+    threshold: 1,
+  },
+  {
+    id: 'minimal-employer',
+    label: '📋 Employer Only',
+    description: 'Single employer attestor — fast setup for employment history verification.',
+    category: 'Minimal',
+    tags: ['employer', 'minimal'],
+    attestors: [
+      { address: BLANK, role: 'Employer', weight: 1 },
+    ],
+    threshold: 1,
+  },
+
+  // ── Enterprise ─────────────────────────────────────────────────────────────
+
+  {
+    id: 'enterprise-consortium',
+    label: '🏢 Enterprise Consortium',
+    description: 'Three employers with equal weight — at least two must co-sign. Suitable for industry consortiums.',
+    category: 'Enterprise',
+    tags: ['employer', 'consortium', 'enterprise'],
+    attestors: [
+      { address: BLANK, role: 'Employer', weight: 2 },
+      { address: BLANK, role: 'Employer', weight: 2 },
+      { address: BLANK, role: 'Employer', weight: 2 },
+    ],
+    threshold: 4,
+  },
+  {
+    id: 'enterprise-full',
+    label: '🏢 Enterprise Full Stack',
+    description: 'University + licensing body + three employers. Designed for large enterprise hiring pipelines.',
+    category: 'Enterprise',
+    tags: ['university', 'license', 'employer', 'enterprise'],
+    attestors: [
+      { address: BLANK, role: 'University', weight: 2 },
+      { address: BLANK, role: 'Licensing Body', weight: 3 },
+      { address: BLANK, role: 'Employer', weight: 2 },
+      { address: BLANK, role: 'Employer', weight: 2 },
+      { address: BLANK, role: 'Employer', weight: 1 },
+    ],
+    threshold: 8,
+  },
+];
+
+/** All distinct categories present in the catalogue. */
+export const TEMPLATE_CATEGORIES: TemplateCategory[] = [
+  'Academic',
+  'Professional',
+  'Multi-Region',
+  'Minimal',
+  'Enterprise',
+];
+
+/** Filter templates by category. Returns all if category is undefined. */
+export function filterByCategory(
+  templates: SliceTemplate[],
+  category: TemplateCategory | undefined,
+): SliceTemplate[] {
+  if (!category) return templates;
+  return templates.filter((t) => t.category === category);
+}


### PR DESCRIPTION
Add a browsable pre-built template picker for QuorumSlice configuration.

- Add sliceTemplates.ts with 12 templates across 5 categories (Academic, Professional, Multi-Region, Minimal, Enterprise)
- Add SliceTemplateLibrary component with category tabs and template cards showing role composition, threshold %, and a Use Template action
- Replace the sparse 3-button preset row in QuorumSliceBuilder with an expandable Browse Templates panel backed by the new library
- Export SliceTemplateLibrary from components/index.ts
- Add 16 tests covering catalogue integrity and component behaviour
closes #945 