### PR TITLE
feat: add dark mode with system preference detection and manual toggl…

### DIFF
--- a/frontend/src/dashboard.js
+++ b/frontend/src/dashboard.js
@@ -57,7 +57,10 @@ export function renderNavbar(activeRoute) {
           <a href="/dashboard" class="nav-link ${activeRoute === '/dashboard' ? 'active' : ''}" data-route="/dashboard">Dashboard</a>
           <a href="/verify" class="nav-link ${activeRoute === '/verify' ? 'active' : ''}" data-route="/verify">Verify</a>
         </div>
-        <div class="navbar__right">
+        <div class="navbar__right" style="display:flex;align-items:center;gap:12px;">
+          <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme" title="Toggle light/dark mode">
+            ${document.documentElement.dataset.theme === 'light' ? '🌙' : '☀️'}
+          </button>
           <span class="navbar__badge">${NETWORK}</span>
         </div>
       </div>
@@ -72,6 +75,18 @@ export function bindNavbarLinks(container) {
       e.preventDefault();
       navigateTo(link.dataset.route);
     });
+  });
+}
+
+export function bindThemeToggle(container) {
+  const btn = container.querySelector('#theme-toggle');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    const isLight = document.documentElement.dataset.theme === 'light';
+    const next = isLight ? 'dark' : 'light';
+    document.documentElement.dataset.theme = next;
+    localStorage.setItem('qp-theme', next);
+    btn.textContent = next === 'light' ? '🌙' : '☀️';
   });
 }
 
@@ -131,8 +146,7 @@ export function renderDashboardPage(container) {
   `;
 
   bindNavbarLinks(container);
-
-  const btnConnect = container.querySelector('#btn-connect');
+  bindThemeToggle(container);
   const btnDisconnect = container.querySelector('#btn-disconnect');
   const inputWallet = container.querySelector('#input-wallet');
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -10,6 +10,23 @@ import './styles.css';
 import { renderVerifyPage } from './verify.js';
 import { renderDashboardPage } from './dashboard.js';
 
+// ── Theme initialisation (run before first render to avoid flash) ─────────
+function initTheme() {
+  const stored = localStorage.getItem('qp-theme');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const theme = stored ?? (prefersDark ? 'dark' : 'light');
+  document.documentElement.dataset.theme = theme;
+
+  // Keep in sync when the OS preference changes (only if no manual override)
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+    if (!localStorage.getItem('qp-theme')) {
+      document.documentElement.dataset.theme = e.matches ? 'dark' : 'light';
+    }
+  });
+}
+
+initTheme();
+
 const app = document.getElementById('app');
 
 function route() {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -47,6 +47,62 @@
   --transition: 0.2s ease;
 }
 
+/* ---- Light Mode Overrides ---- */
+[data-theme="light"] {
+  --bg-base: #f4f5f7;
+  --bg-surface: #ffffff;
+  --bg-card: #ffffff;
+  --bg-glass: rgba(255, 255, 255, 0.8);
+  --bg-input: #f0f1f5;
+  --bg-hover: rgba(99, 102, 241, 0.06);
+
+  --text-primary: #0f1117;
+  --text-secondary: #52566b;
+  --text-muted: #9499b5;
+  --border: rgba(0, 0, 0, 0.09);
+  --border-active: rgba(99, 102, 241, 0.5);
+
+  --shadow-card: 0 4px 24px rgba(0, 0, 0, 0.08);
+  --shadow-glow: 0 0 40px rgba(99, 102, 241, 0.15);
+}
+
+[data-theme="light"] body::before {
+  background: radial-gradient(ellipse, rgba(99, 102, 241, 0.06) 0%, transparent 70%);
+}
+
+[data-theme="light"] .navbar {
+  background: rgba(244, 245, 247, 0.9);
+}
+
+[data-theme="light"] .verify-hero__title {
+  background: linear-gradient(135deg, #0f1117 0%, #52566b 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+[data-theme="light"] .skeleton-loader::after {
+  background: linear-gradient(90deg, transparent, rgba(0,0,0,0.04), transparent);
+}
+
+/* Theme toggle button */
+.theme-toggle {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 6px 8px;
+  transition: border-color var(--transition), color var(--transition), background var(--transition);
+}
+
+.theme-toggle:hover {
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+  background: var(--bg-hover);
+}
+
 /* ---- Reset ---- */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/frontend/src/verify.js
+++ b/frontend/src/verify.js
@@ -21,7 +21,7 @@ import {
   NETWORK,
 } from './stellar.js';
 
-import { renderNavbar, bindNavbarLinks } from './dashboard.js';
+import { renderNavbar, bindNavbarLinks, bindThemeToggle } from './dashboard.js';
 
 // ── Credential type labels ──────────────────────────────────────────────────
 const CREDENTIAL_TYPES = {
@@ -143,8 +143,7 @@ export function renderVerifyPage(container) {
   `;
 
   bindNavbarLinks(container);
-
-  // ── Wire up tabs ────────────────────────────────────────────────────────
+  bindThemeToggle(container);
   const tabId   = container.querySelector('#tab-id');
   const tabAddr = container.querySelector('#tab-addr');
   const panelId   = container.querySelector('#panel-id');


### PR DESCRIPTION
i Added dark mode support to the QuorumProof frontend across 4 files:
  
  - main.js — initTheme() reads localStorage for a saved preference, falls back to the OS
  prefers-color-scheme media query, and listens for system-level changes
  - styles.css — added [data-theme="light"] variable overrides for all surface/text/border colours, plus a
  .theme-toggle button style
  - dashboard.js — added a ☀️/🌙 toggle button to the navbar and a bindThemeToggle() function that flips
  data-theme on <html> and persists the choice to localStorage
  - verify.js — imported and called bindThemeToggle() so the toggle works on both pages

closes #949 