### PR TITLE
feat: implement slice recommendation engine (#947)

### DIFF
--- a/frontend/src/components/QuorumSliceBuilder.tsx
+++ b/frontend/src/components/QuorumSliceBuilder.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { ChangeEvent, FormEvent, KeyboardEvent } from 'react';
 import { createSlice } from '../lib/contracts/quorumProof';
+import { SliceRecommendationPanel } from './SliceRecommendationPanel';
+import type { RecommendationContext, SliceRecommendation } from '../lib/sliceRecommendation';
 import { useToast } from '../context/ToastContext';
 import {
   PRESETS,
@@ -35,6 +37,24 @@ const KNOWN_ATTESTORS = [
   { address: 'GABC5EMPLOYER555555555555555555555555555555555555555555E', role: 'Employer', label: 'Acme Corp' },
   { address: 'GABC6EMPLOYER666666666666666666666666666666666666666666F', role: 'Employer', label: 'GlobalTech Ltd' },
 ];
+
+/** Attestor candidates enriched with reputation for the recommendation engine */
+const RECOMMENDATION_CANDIDATES = KNOWN_ATTESTORS.map((a, i) => ({
+  address: a.address,
+  role: a.role,
+  reputationScore: [90, 85, 80, 75, 70, 65][i] ?? 60,
+  available: true,
+}));
+
+const CREDENTIAL_TYPE_OPTIONS = [
+  { value: 1, label: '🎓 Degree' },
+  { value: 2, label: '🏛️ License' },
+  { value: 3, label: '💼 Employment' },
+  { value: 4, label: '📜 Certification' },
+  { value: 5, label: '🔬 Research' },
+];
+
+const INDUSTRY_OPTIONS = ['civil', 'mechanical', 'electrical', 'software', 'biomedical', 'chemical', 'aerospace'];
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -210,6 +230,10 @@ export function QuorumSliceBuilder({ creatorAddress, initialAttestors, initialTh
   const [success, setSuccess] = useState<{ sliceId: bigint } | null>(null);
   const [copied, setCopied] = useState(false);
 
+  // ── Recommendation context ─────────────────────────────────────────────────
+  const [credentialType, setCredentialType] = useState<number | undefined>(undefined);
+  const [industry, setIndustry] = useState<string>('');
+
   // ── Auto-save draft ────────────────────────────────────────────────────────
   useEffect(() => {
     if (attestors.length > 0) saveDraft({ attestors, threshold });
@@ -307,6 +331,19 @@ export function QuorumSliceBuilder({ creatorAddress, initialAttestors, initialTh
     clearDraft();
   }
 
+  function handleAcceptRecommendation(rec: SliceRecommendation) {
+    const entries = rec.attestors.map((a) => ({
+      id: crypto.randomUUID(),
+      address: a.address,
+      role: a.role,
+      weight: 1,
+    }));
+    setAttestors(entries);
+    setThreshold(rec.threshold);
+    setAddrError('');
+    setThresholdError('');
+  }
+
   // ── Success screen ─────────────────────────────────────────────────────────
   if (success) {
     return (
@@ -351,6 +388,62 @@ export function QuorumSliceBuilder({ creatorAddress, initialAttestors, initialTh
             </button>
           ))}
         </div>
+      </section>
+
+      <div className="divider" />
+
+      {/* ── Smart Recommendations ── */}
+      <section className="qsb__section" aria-label="Smart recommendations">
+        <div className="qsb__section-header">
+          <span className="detail-card__title">Smart Recommendations</span>
+          <Tooltip text="Get a tailored slice suggestion based on your credential type, industry, and past attestation patterns." />
+        </div>
+        <div className="qsb__row2" style={{ marginBottom: 12 }}>
+          <div className="form-row" style={{ marginBottom: 0 }}>
+            <label htmlFor="qsb-cred-type" className="form-label">Credential Type</label>
+            <div className="input-wrap">
+              <select
+                id="qsb-cred-type"
+                value={credentialType ?? ''}
+                onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+                  setCredentialType(e.target.value ? Number(e.target.value) : undefined)
+                }
+                aria-label="Credential type for recommendation"
+              >
+                <option value="">Any</option>
+                {CREDENTIAL_TYPE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div className="form-row" style={{ marginBottom: 0 }}>
+            <label htmlFor="qsb-industry" className="form-label">Industry</label>
+            <div className="input-wrap">
+              <select
+                id="qsb-industry"
+                value={industry}
+                onChange={(e: ChangeEvent<HTMLSelectElement>) => setIndustry(e.target.value)}
+                aria-label="Industry for recommendation"
+              >
+                <option value="">Any</option>
+                {INDUSTRY_OPTIONS.map((ind) => (
+                  <option key={ind} value={ind}>{ind}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </div>
+        <SliceRecommendationPanel
+          candidates={RECOMMENDATION_CANDIDATES}
+          onAccept={handleAcceptRecommendation}
+          context={
+            {
+              credentialType: credentialType,
+              industry: industry || undefined,
+            } satisfies RecommendationContext
+          }
+        />
       </section>
 
       <div className="divider" />

--- a/frontend/src/components/SliceRecommendationPanel.tsx
+++ b/frontend/src/components/SliceRecommendationPanel.tsx
@@ -1,13 +1,33 @@
 import { useState } from 'react';
-import { recommendSlice, type AttestorCandidate, type SliceRecommendation } from '../lib/sliceRecommendation';
+import {
+  recommendSlice,
+  type AttestorCandidate,
+  type SliceRecommendation,
+  type RecommendationContext,
+} from '../lib/sliceRecommendation';
+
+const CREDENTIAL_TYPE_LABELS: Record<number, string> = {
+  1: '🎓 Degree',
+  2: '🏛️ License',
+  3: '💼 Employment',
+  4: '📜 Certification',
+  5: '🔬 Research',
+};
 
 interface SliceRecommendationPanelProps {
   candidates: AttestorCandidate[];
   onAccept: (recommendation: SliceRecommendation) => void;
+  context?: RecommendationContext;
 }
 
-export function SliceRecommendationPanel({ candidates, onAccept }: SliceRecommendationPanelProps) {
-  const [recommendation] = useState<SliceRecommendation | null>(() => recommendSlice(candidates));
+export function SliceRecommendationPanel({
+  candidates,
+  onAccept,
+  context = {},
+}: SliceRecommendationPanelProps) {
+  const [recommendation] = useState<SliceRecommendation | null>(
+    () => recommendSlice(candidates, 3, context)
+  );
   const [customized, setCustomized] = useState<SliceRecommendation | null>(null);
   const [accepted, setAccepted] = useState(false);
 
@@ -33,10 +53,13 @@ export function SliceRecommendationPanel({ candidates, onAccept }: SliceRecommen
     if (!active) return;
     const next = active.attestors.filter((a) => a.address !== address);
     if (next.length === 0) return;
+    const nextReasons = { ...active.reasons };
+    delete nextReasons[address];
     setCustomized({
       attestors: next,
       threshold: Math.min(active.threshold, next.length),
       score: Math.round(next.reduce((s, a) => s + a.reputationScore, 0) / next.length),
+      reasons: nextReasons,
     });
   }
 
@@ -44,6 +67,11 @@ export function SliceRecommendationPanel({ candidates, onAccept }: SliceRecommen
     onAccept(active!);
     setAccepted(true);
   }
+
+  const hasContext =
+    context.credentialType != null ||
+    !!context.industry ||
+    (context.history != null && Object.keys(context.history).length > 0);
 
   return (
     <div className="srp" data-testid="slice-recommendation-panel">
@@ -53,8 +81,32 @@ export function SliceRecommendationPanel({ candidates, onAccept }: SliceRecommen
           Score: {active.score}/100
         </span>
       </div>
+
+      {/* Context badges */}
+      {hasContext && (
+        <div className="srp__context" data-testid="srp-context">
+          {context.credentialType != null && (
+            <span className="srp__badge" data-testid="srp-badge-credtype">
+              {CREDENTIAL_TYPE_LABELS[context.credentialType] ?? `Type ${context.credentialType}`}
+            </span>
+          )}
+          {context.industry && (
+            <span className="srp__badge srp__badge--industry" data-testid="srp-badge-industry">
+              🏭 {context.industry}
+            </span>
+          )}
+          {context.history && Object.keys(context.history).length > 0 && (
+            <span className="srp__badge srp__badge--history" data-testid="srp-badge-history">
+              🕐 history-aware
+            </span>
+          )}
+        </div>
+      )}
+
       <p className="srp__desc">
-        Based on reputation and availability. You can remove attestors to customize.
+        {hasContext
+          ? 'Tailored to your credential type and industry. Remove attestors to customize.'
+          : 'Based on reputation and availability. Remove attestors to customize.'}
       </p>
 
       <ul className="srp__list" aria-label="Recommended attestors">
@@ -66,6 +118,11 @@ export function SliceRecommendationPanel({ candidates, onAccept }: SliceRecommen
               <span className="srp__rep">★ {a.reputationScore}</span>
               {!a.available && <span className="srp__unavailable">Unavailable</span>}
             </div>
+            {active.reasons[a.address] && (
+              <span className="srp__reason" data-testid={`rec-reason-${a.address.slice(0, 8)}`}>
+                {active.reasons[a.address]}
+              </span>
+            )}
             <button
               className="qsb__remove-btn"
               onClick={() => handleRemove(a.address)}
@@ -83,7 +140,11 @@ export function SliceRecommendationPanel({ candidates, onAccept }: SliceRecommen
       </div>
 
       <div className="srp__actions">
-        <button className="btn btn--primary btn--sm" onClick={handleAccept} data-testid="accept-recommendation">
+        <button
+          className="btn btn--primary btn--sm"
+          onClick={handleAccept}
+          data-testid="accept-recommendation"
+        >
           Accept Recommendation
         </button>
       </div>

--- a/frontend/src/components/__tests__/SliceRecommendationPanel.test.tsx
+++ b/frontend/src/components/__tests__/SliceRecommendationPanel.test.tsx
@@ -10,7 +10,9 @@ const candidates: AttestorCandidate[] = [
   { address: 'GEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE', role: 'Other', reputationScore: 80, available: true },
 ];
 
-describe('recommendSlice algorithm (#467)', () => {
+// ── recommendSlice algorithm ──────────────────────────────────────────────────
+
+describe('recommendSlice algorithm (#947)', () => {
   it('returns null for empty candidates', () => {
     expect(recommendSlice([])).toBeNull();
   });
@@ -26,26 +28,114 @@ describe('recommendSlice algorithm (#467)', () => {
     expect(unavailable.length).toBeLessThan(rec!.attestors.length);
   });
 
-  it('sorts available attestors by reputation descending', () => {
-    const rec = recommendSlice(candidates, 3);
-    const available = rec!.attestors.filter((a) => a.available);
-    for (let i = 1; i < available.length; i++) {
-      expect(available[i - 1].reputationScore).toBeGreaterThanOrEqual(available[i].reputationScore);
-    }
-  });
-
   it('sets threshold to ceil(n/2)', () => {
-    expect(recommendSlice(candidates, 3)!.threshold).toBe(2); // ceil(3/2)
-    expect(recommendSlice(candidates, 2)!.threshold).toBe(1); // ceil(2/2)
+    expect(recommendSlice(candidates, 3)!.threshold).toBe(2);
+    expect(recommendSlice(candidates, 2)!.threshold).toBe(1);
   });
 
   it('computes score as average reputation', () => {
     const rec = recommendSlice([candidates[0]], 1);
     expect(rec!.score).toBe(90);
   });
+
+  it('includes a reasons map with an entry per selected attestor', () => {
+    const rec = recommendSlice(candidates, 3)!;
+    for (const attestor of rec.attestors) {
+      expect(rec.reasons[attestor.address]).toBeDefined();
+      expect(typeof rec.reasons[attestor.address]).toBe('string');
+    }
+  });
+
+  // ── credential-type context ─────────────────────────────────────────────
+
+  it('boosts University for credential type 1 (Degree)', () => {
+    const pool: AttestorCandidate[] = [
+      { address: 'GAAA', role: 'University', reputationScore: 60, available: true },
+      { address: 'GBBB', role: 'Employer', reputationScore: 80, available: true },
+    ];
+    const rec = recommendSlice(pool, 2, { credentialType: 1 })!;
+    // University gets +30 bonus → 60+30=90 vs Employer 80
+    expect(rec.attestors[0].role).toBe('University');
+    expect(rec.reasons['GAAA']).toContain('Degree');
+  });
+
+  it('boosts Licensing Body for credential type 2 (License)', () => {
+    const pool: AttestorCandidate[] = [
+      { address: 'GAAA', role: 'Licensing Body', reputationScore: 60, available: true },
+      { address: 'GBBB', role: 'Employer', reputationScore: 85, available: true },
+    ];
+    const rec = recommendSlice(pool, 2, { credentialType: 2 })!;
+    expect(rec.attestors[0].role).toBe('Licensing Body');
+  });
+
+  // ── industry context ────────────────────────────────────────────────────
+
+  it('applies industry bonus for software industry (Employer top)', () => {
+    const pool: AttestorCandidate[] = [
+      { address: 'GAAA', role: 'Employer', reputationScore: 70, available: true },
+      { address: 'GBBB', role: 'Licensing Body', reputationScore: 80, available: true },
+    ];
+    const rec = recommendSlice(pool, 2, { industry: 'software' })!;
+    // Employer gets +25 in software → 95 vs Licensing Body 85
+    expect(rec.attestors[0].role).toBe('Employer');
+    expect(rec.reasons['GAAA']).toContain('software');
+  });
+
+  it('applies industry bonus for civil engineering (Licensing Body top)', () => {
+    const pool: AttestorCandidate[] = [
+      { address: 'GAAA', role: 'Licensing Body', reputationScore: 70, available: true },
+      { address: 'GBBB', role: 'Employer', reputationScore: 80, available: true },
+    ];
+    const rec = recommendSlice(pool, 2, { industry: 'civil' })!;
+    // Licensing Body gets +25 in civil → 95 vs Employer 90
+    expect(rec.attestors[0].role).toBe('Licensing Body');
+    expect(rec.reasons['GAAA']).toContain('civil');
+  });
+
+  // ── historical pattern context ──────────────────────────────────────────
+
+  it('boosts historically used attestors', () => {
+    const pool: AttestorCandidate[] = [
+      { address: 'GAAA', role: 'Employer', reputationScore: 60, available: true },
+      { address: 'GBBB', role: 'Employer', reputationScore: 70, available: true },
+    ];
+    const rec = recommendSlice(pool, 2, { history: { GAAA: 3 } })!;
+    // GAAA gets +15 history bonus → 75 vs GBBB 70
+    expect(rec.attestors[0].address).toBe('GAAA');
+    expect(rec.reasons['GAAA']).toContain('3× previously');
+  });
+
+  it('caps history bonus at +20', () => {
+    const pool: AttestorCandidate[] = [
+      { address: 'GAAA', role: 'Employer', reputationScore: 50, available: true },
+    ];
+    const rec = recommendSlice(pool, 1, { history: { GAAA: 100 } })!;
+    // capped at +20, no crash
+    expect(rec.attestors[0].address).toBe('GAAA');
+    expect(rec.reasons['GAAA']).toContain('previously');
+  });
+
+  // ── combined context ────────────────────────────────────────────────────
+
+  it('applies all context signals together', () => {
+    const pool: AttestorCandidate[] = [
+      { address: 'GAAA', role: 'Licensing Body', reputationScore: 55, available: true },
+      { address: 'GBBB', role: 'Employer', reputationScore: 90, available: true },
+    ];
+    // civil industry (+25 LicBody) + license type (+30 LicBody) + history on GAAA (+5)
+    // GAAA: 55+25+30+5=115 vs GBBB: 90
+    const rec = recommendSlice(pool, 2, {
+      credentialType: 2,
+      industry: 'civil',
+      history: { GAAA: 1 },
+    })!;
+    expect(rec.attestors[0].address).toBe('GAAA');
+  });
 });
 
-describe('SliceRecommendationPanel (#467)', () => {
+// ── SliceRecommendationPanel component ───────────────────────────────────────
+
+describe('SliceRecommendationPanel (#947)', () => {
   it('shows empty state when no candidates', () => {
     render(<SliceRecommendationPanel candidates={[]} onAccept={vi.fn()} />);
     expect(screen.getByTestId('srp-empty')).toBeInTheDocument();
@@ -77,5 +167,73 @@ describe('SliceRecommendationPanel (#467)', () => {
     const initialCount = screen.getAllByRole('listitem').length;
     fireEvent.click(removeButtons[0]);
     expect(screen.getAllByRole('listitem').length).toBe(initialCount - 1);
+  });
+
+  // ── context display ───────────────────────────────────────────────────────
+
+  it('shows no context badges when context is empty', () => {
+    render(<SliceRecommendationPanel candidates={candidates} onAccept={vi.fn()} />);
+    expect(screen.queryByTestId('srp-context')).not.toBeInTheDocument();
+  });
+
+  it('shows credential type badge when credentialType is provided', () => {
+    render(
+      <SliceRecommendationPanel
+        candidates={candidates}
+        onAccept={vi.fn()}
+        context={{ credentialType: 1 }}
+      />
+    );
+    expect(screen.getByTestId('srp-badge-credtype')).toHaveTextContent('Degree');
+  });
+
+  it('shows industry badge when industry is provided', () => {
+    render(
+      <SliceRecommendationPanel
+        candidates={candidates}
+        onAccept={vi.fn()}
+        context={{ industry: 'software' }}
+      />
+    );
+    expect(screen.getByTestId('srp-badge-industry')).toHaveTextContent('software');
+  });
+
+  it('shows history badge when history is provided', () => {
+    render(
+      <SliceRecommendationPanel
+        candidates={candidates}
+        onAccept={vi.fn()}
+        context={{ history: { [candidates[0].address]: 2 } }}
+      />
+    );
+    expect(screen.getByTestId('srp-badge-history')).toBeInTheDocument();
+  });
+
+  it('renders per-attestor reason tags', () => {
+    render(
+      <SliceRecommendationPanel
+        candidates={candidates}
+        onAccept={vi.fn()}
+        context={{ credentialType: 1 }}
+      />
+    );
+    const reasonTags = screen.getAllByTestId(/^rec-reason-/);
+    expect(reasonTags.length).toBeGreaterThan(0);
+  });
+
+  it('shows tailored description when context is provided', () => {
+    render(
+      <SliceRecommendationPanel
+        candidates={candidates}
+        onAccept={vi.fn()}
+        context={{ credentialType: 2, industry: 'civil' }}
+      />
+    );
+    expect(screen.getByText(/Tailored to your credential type/i)).toBeInTheDocument();
+  });
+
+  it('shows generic description when no context', () => {
+    render(<SliceRecommendationPanel candidates={candidates} onAccept={vi.fn()} />);
+    expect(screen.getByText(/Based on reputation and availability/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/lib/sliceRecommendation.ts
+++ b/frontend/src/lib/sliceRecommendation.ts
@@ -9,30 +9,146 @@ export interface SliceRecommendation {
   attestors: AttestorCandidate[];
   threshold: number;
   score: number; // overall recommendation score 0–100
+  reasons: Record<string, string>; // address → human-readable reason
 }
 
 /**
+ * Context that drives context-aware recommendations.
+ * All fields are optional — falls back to the basic reputation/availability ranking.
+ */
+export interface RecommendationContext {
+  /** Credential type ID matching CREDENTIAL_TYPES (1=Degree,2=License,3=Employment,4=Certification,5=Research) */
+  credentialType?: number;
+  /** Industry string, e.g. "civil", "mechanical", "software", "biomedical" */
+  industry?: string;
+  /** Historical attestor usage: address → number of prior attestations */
+  history?: Record<string, number>;
+}
+
+// ── Rules ────────────────────────────────────────────────────────────────────
+
+/**
+ * Required roles per credential type.
+ * An attestor whose role appears in the required list receives a bonus.
+ */
+const CREDENTIAL_TYPE_REQUIRED_ROLES: Record<number, string[]> = {
+  1: ['University'],                           // Degree — university is essential
+  2: ['Licensing Body'],                        // License — licensing body is essential
+  3: ['Employer'],                              // Employment — employer is essential
+  4: ['University', 'Licensing Body'],          // Certification — academic + body
+  5: ['University', 'Licensing Body'],          // Research — academic + body
+};
+
+/**
+ * Role weight bonuses per industry.
+ * Additive bonus (0–30) applied on top of reputation.
+ */
+const INDUSTRY_ROLE_BONUS: Record<string, Record<string, number>> = {
+  civil:       { 'Licensing Body': 25, University: 15, Employer: 10 },
+  mechanical:  { 'Licensing Body': 20, University: 15, Employer: 10 },
+  electrical:  { 'Licensing Body': 20, University: 15, Employer: 10 },
+  software:    { Employer: 25, University: 15, 'Licensing Body': 5 },
+  biomedical:  { University: 25, 'Licensing Body': 20, Employer: 10 },
+  chemical:    { 'Licensing Body': 25, University: 20, Employer: 10 },
+  aerospace:   { 'Licensing Body': 20, University: 20, Employer: 15 },
+};
+
+// ── Scoring ──────────────────────────────────────────────────────────────────
+
+function scoreCandidate(
+  candidate: AttestorCandidate,
+  ctx: RecommendationContext,
+): { score: number; reason: string } {
+  let score = candidate.reputationScore;
+  const reasons: string[] = [];
+
+  // Availability penalty — unavailable candidates get a hard penalty
+  if (!candidate.available) {
+    score -= 40;
+    reasons.push('unavailable');
+  }
+
+  // Credential-type rule bonus
+  const requiredRoles = ctx.credentialType ? CREDENTIAL_TYPE_REQUIRED_ROLES[ctx.credentialType] : undefined;
+  if (requiredRoles?.includes(candidate.role)) {
+    score += 30;
+    reasons.push(`required for ${credentialTypeLabel(ctx.credentialType!)}`);
+  }
+
+  // Industry bonus
+  const industryKey = ctx.industry?.toLowerCase();
+  if (industryKey && INDUSTRY_ROLE_BONUS[industryKey]) {
+    const bonus = INDUSTRY_ROLE_BONUS[industryKey][candidate.role] ?? 0;
+    if (bonus > 0) {
+      score += bonus;
+      reasons.push(`valued in ${ctx.industry} industry`);
+    }
+  }
+
+  // Historical pattern bonus — prior successful attestation signals trust
+  const historyCount = ctx.history?.[candidate.address] ?? 0;
+  if (historyCount > 0) {
+    const histBonus = Math.min(historyCount * 5, 20); // up to +20
+    score += histBonus;
+    reasons.push(`attested ${historyCount}× previously`);
+  }
+
+  const reason = reasons.length
+    ? reasons.join(', ')
+    : 'high reputation';
+
+  return { score, reason };
+}
+
+function credentialTypeLabel(typeId: number): string {
+  const labels: Record<number, string> = {
+    1: 'Degree', 2: 'License', 3: 'Employment', 4: 'Certification', 5: 'Research',
+  };
+  return labels[typeId] ?? `type ${typeId}`;
+}
+
+// ── Main export ───────────────────────────────────────────────────────────────
+
+/**
  * Recommends a quorum slice from a pool of candidates.
- * Ranks by: availability first, then reputation score.
- * Selects top N candidates and sets threshold to majority (ceil(N/2)).
+ *
+ * When a RecommendationContext is provided the scoring accounts for:
+ *  - credential type → required roles receive a +30 bonus
+ *  - industry        → industry-specific role bonuses (up to +25)
+ *  - history         → prior attestation counts add up to +20
+ *
+ * Falls back to availability + reputation ranking when no context is given.
  */
 export function recommendSlice(
   candidates: AttestorCandidate[],
   maxSize = 3,
+  ctx: RecommendationContext = {},
 ): SliceRecommendation | null {
   if (candidates.length === 0) return null;
 
-  const ranked = [...candidates]
-    .sort((a, b) => {
-      if (a.available !== b.available) return a.available ? -1 : 1;
-      return b.reputationScore - a.reputationScore;
-    })
+  const scored = candidates.map((c) => {
+    const { score, reason } = scoreCandidate(c, ctx);
+    return { candidate: c, score, reason };
+  });
+
+  const ranked = scored
+    .sort((a, b) => b.score - a.score)
     .slice(0, maxSize);
 
   const threshold = Math.ceil(ranked.length / 2);
-  const score = Math.round(
-    ranked.reduce((sum, c) => sum + c.reputationScore, 0) / ranked.length
+  const avgReputation = Math.round(
+    ranked.reduce((sum, { candidate }) => sum + candidate.reputationScore, 0) / ranked.length
   );
 
-  return { attestors: ranked, threshold, score };
+  const reasons: Record<string, string> = {};
+  for (const { candidate, reason } of ranked) {
+    reasons[candidate.address] = reason;
+  }
+
+  return {
+    attestors: ranked.map((r) => r.candidate),
+    threshold,
+    score: avgReputation,
+    reasons,
+  };
 }


### PR DESCRIPTION
## Summary

Closes #947 — adds a context-aware slice recommendation engine to the QuorumSlice Builder.

## Changes

**`frontend/src/lib/sliceRecommendation.ts`**
- Added `RecommendationContext` interface (`credentialType`, `industry`, `history`)
- Credential type rules: maps type IDs 1–5 to required roles (+30 score bonus)
- Industry role bonus table for 7 engineering domains (civil, mechanical, electrical, software, biomedical, chemical, aerospace)
- Historical attestation boost: prior usage count × 5, capped at +20
- `recommendSlice()` now accepts context and returns `reasons` map per attestor

**`frontend/src/components/SliceRecommendationPanel.tsx`**
- Accepts `context?: RecommendationContext` prop
- Shows credential type, industry, and history-aware context badges
- Per-attestor reason tags explaining each recommendation
- Adaptive description text based on whether context is active

**`frontend/src/components/QuorumSliceBuilder.tsx`**
- New "Smart Recommendations" section with credential type + industry selectors
- `handleAcceptRecommendation` populates the attestor list from the recommendation

## Testing

25/25 tests passing — covers algorithm scoring, all context signals, UI badges, reason tags, and accept flow.