### PR TITLE
feat: add issuer performance metrics endpoint

### DIFF
--- a/api-server/src/index.ts
+++ b/api-server/src/index.ts
@@ -7,6 +7,7 @@ import credentialsRouter from './routes/credentials.js';
 import notificationsRouter from './routes/notifications.js';
 import analyticsRouter from './routes/analytics.js';
 import attestorRouter from './routes/attestor.js';
+import issuerRouter from './routes/issuer.js';
 import recoveryRouter from './routes/recovery.js';
 import { createRateLimiter } from './middleware/rateLimiter.js';
 import { rbac } from './middleware/rbac.js';
@@ -60,6 +61,7 @@ app.use('/api/credentials', consentRouter); // #881 consent management
 app.use('/api/notifications', notificationsRouter);
 app.use('/api/analytics', analyticsRouter);
 app.use('/api/attestor', attestorRouter);
+app.use('/api/issuer', issuerRouter);
 app.use('/api/recovery', recoveryRouter);
 
 app.get('/health', (_req, res) => {

--- a/api-server/src/routes/issuer.ts
+++ b/api-server/src/routes/issuer.ts
@@ -1,0 +1,25 @@
+import { Router, Request, Response } from 'express';
+import { metricsStore } from '../services/metrics.js';
+
+const router = Router();
+
+// GET /api/issuer/:address/metrics?period_days=30
+router.get('/:address/metrics', (req: Request, res: Response) => {
+  const { address } = req.params;
+  const periodDays = req.query.period_days ? parseInt(req.query.period_days as string, 10) : 30;
+
+  if (!address) {
+    res.status(400).json({ error: 'address parameter required' });
+    return;
+  }
+
+  if (isNaN(periodDays) || periodDays < 1 || periodDays > 365) {
+    res.status(400).json({ error: 'period_days must be between 1 and 365' });
+    return;
+  }
+
+  const metrics = metricsStore.getIssuerMetrics(address, periodDays);
+  res.json(metrics);
+});
+
+export default router;

--- a/api-server/src/services/metrics.ts
+++ b/api-server/src/services/metrics.ts
@@ -5,7 +5,20 @@ export interface CredentialEvent {
   issuer?: string;
   subject?: string;
   attestor?: string;
+  /** Time in milliseconds from credential issuance to first attestation. */
+  attestation_time_ms?: number;
+  /** Whether this event is associated with a dispute. */
+  disputed?: boolean;
   metadata?: Record<string, unknown>;
+}
+
+export interface IssuerMetrics {
+  issuer: string;
+  credentials_issued: number;
+  avg_attestation_time_ms: number | null;
+  dispute_rate: number;
+  reputation_trend: { date: string; issued_count: number }[];
+  period_days: number;
 }
 
 export interface HourlyMetrics {
@@ -351,6 +364,49 @@ class MetricsStore {
       total_events: this.eventLog.length,
       total_days: this.dailyMetrics.size,
       retention_days: RETENTION_DAYS,
+    };
+  }
+
+  getIssuerMetrics(issuer: string, periodDays = 30): IssuerMetrics {
+    const endMs = Date.now();
+    const startMs = endMs - periodDays * 24 * 60 * 60 * 1000;
+
+    const issuerEvents = this.eventLog.filter(
+      (e) => e.issuer === issuer && new Date(e.timestamp).getTime() >= startMs
+    );
+
+    const issuedEvents = issuerEvents.filter((e) => e.type === 'issued');
+    const credentials_issued = issuedEvents.length;
+
+    const attestationTimes = issuerEvents
+      .filter((e) => e.type === 'attested' && e.attestation_time_ms != null)
+      .map((e) => e.attestation_time_ms as number);
+    const avg_attestation_time_ms =
+      attestationTimes.length > 0
+        ? attestationTimes.reduce((a, b) => a + b, 0) / attestationTimes.length
+        : null;
+
+    const disputedCount = issuerEvents.filter((e) => e.disputed).length;
+    const dispute_rate =
+      credentials_issued > 0 ? +(disputedCount / credentials_issued).toFixed(4) : 0;
+
+    // Build a daily issued count map for the reputation trend
+    const dailyMap: Map<string, number> = new Map();
+    for (const e of issuedEvents) {
+      const day = e.timestamp.split('T')[0];
+      dailyMap.set(day, (dailyMap.get(day) ?? 0) + 1);
+    }
+    const reputation_trend = Array.from(dailyMap.entries())
+      .sort(([a], [b]) => (a < b ? -1 : 1))
+      .map(([date, issued_count]) => ({ date, issued_count }));
+
+    return {
+      issuer,
+      credentials_issued,
+      avg_attestation_time_ms,
+      dispute_rate,
+      reputation_trend,
+      period_days: periodDays,
     };
   }
 

--- a/api-server/tests/issuer.test.ts
+++ b/api-server/tests/issuer.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import issuerRouter from '../src/routes/issuer.js';
+import { metricsStore } from '../src/services/metrics.js';
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/issuer', issuerRouter);
+  return app;
+}
+
+const app = createTestApp();
+const ISSUER = 'GISSUER1234';
+
+describe('GET /api/issuer/:address/metrics', () => {
+  beforeEach(() => {
+    metricsStore.reset();
+  });
+
+  it('returns zero-state metrics for unknown issuer', async () => {
+    const res = await request(app).get(`/api/issuer/${ISSUER}/metrics`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      issuer: ISSUER,
+      credentials_issued: 0,
+      avg_attestation_time_ms: null,
+      dispute_rate: 0,
+      reputation_trend: [],
+      period_days: 30,
+    });
+  });
+
+  it('counts credentials_issued correctly', async () => {
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c1', timestamp: new Date().toISOString(), issuer: ISSUER });
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c2', timestamp: new Date().toISOString(), issuer: ISSUER });
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c3', timestamp: new Date().toISOString(), issuer: 'OTHER' });
+
+    const res = await request(app).get(`/api/issuer/${ISSUER}/metrics`);
+    expect(res.status).toBe(200);
+    expect(res.body.credentials_issued).toBe(2);
+  });
+
+  it('computes avg_attestation_time_ms from attested events', async () => {
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c1', timestamp: new Date().toISOString(), issuer: ISSUER });
+    metricsStore.recordEvent({ type: 'attested', credential_id: 'c1', timestamp: new Date().toISOString(), issuer: ISSUER, attestation_time_ms: 1000 });
+    metricsStore.recordEvent({ type: 'attested', credential_id: 'c1', timestamp: new Date().toISOString(), issuer: ISSUER, attestation_time_ms: 3000 });
+
+    const res = await request(app).get(`/api/issuer/${ISSUER}/metrics`);
+    expect(res.status).toBe(200);
+    expect(res.body.avg_attestation_time_ms).toBe(2000);
+  });
+
+  it('returns null avg_attestation_time_ms when no attested events with timing', async () => {
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c1', timestamp: new Date().toISOString(), issuer: ISSUER });
+    metricsStore.recordEvent({ type: 'attested', credential_id: 'c1', timestamp: new Date().toISOString(), issuer: ISSUER });
+
+    const res = await request(app).get(`/api/issuer/${ISSUER}/metrics`);
+    expect(res.status).toBe(200);
+    expect(res.body.avg_attestation_time_ms).toBeNull();
+  });
+
+  it('computes dispute_rate correctly', async () => {
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c1', timestamp: new Date().toISOString(), issuer: ISSUER });
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c2', timestamp: new Date().toISOString(), issuer: ISSUER });
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c3', timestamp: new Date().toISOString(), issuer: ISSUER, disputed: true });
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c4', timestamp: new Date().toISOString(), issuer: ISSUER, disputed: true });
+
+    const res = await request(app).get(`/api/issuer/${ISSUER}/metrics`);
+    expect(res.status).toBe(200);
+    expect(res.body.dispute_rate).toBe(0.5);
+  });
+
+  it('builds reputation_trend sorted by date', async () => {
+    const day1 = '2026-06-27T10:00:00.000Z';
+    const day2 = '2026-06-28T10:00:00.000Z';
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c1', timestamp: day2, issuer: ISSUER });
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c2', timestamp: day1, issuer: ISSUER });
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c3', timestamp: day1, issuer: ISSUER });
+
+    const res = await request(app).get(`/api/issuer/${ISSUER}/metrics`);
+    expect(res.status).toBe(200);
+    const trend = res.body.reputation_trend;
+    expect(trend).toHaveLength(2);
+    expect(trend[0]).toEqual({ date: '2026-06-27', issued_count: 2 });
+    expect(trend[1]).toEqual({ date: '2026-06-28', issued_count: 1 });
+  });
+
+  it('respects period_days query parameter', async () => {
+    const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+    const recent = new Date().toISOString();
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c1', timestamp: old, issuer: ISSUER });
+    metricsStore.recordEvent({ type: 'issued', credential_id: 'c2', timestamp: recent, issuer: ISSUER });
+
+    const res = await request(app).get(`/api/issuer/${ISSUER}/metrics?period_days=7`);
+    expect(res.status).toBe(200);
+    expect(res.body.credentials_issued).toBe(1);
+    expect(res.body.period_days).toBe(7);
+  });
+
+  it('returns 400 for invalid period_days', async () => {
+    const res = await request(app).get(`/api/issuer/${ISSUER}/metrics?period_days=0`);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for period_days > 365', async () => {
+    const res = await request(app).get(`/api/issuer/${ISSUER}/metrics?period_days=366`);
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
- Add avg_attestation_time_ms, credentials_issued, dispute_rate, and reputation_trend to MetricsStore.getIssuerMetrics()
- Add attestation_time_ms and disputed fields to CredentialEvent
- New GET /api/issuer/:address/metrics route with period_days param
- 9 tests covering all metrics and input validation

closes #922