### PR TITLE
feat: add slice import/export in JSON format

### DIFF
--- a/frontend/src/components/QuorumSliceBuilder.tsx
+++ b/frontend/src/components/QuorumSliceBuilder.tsx
@@ -12,7 +12,8 @@ import {
   thresholdPercent,
   consensusSummary,
 } from '../lib/sliceBuilderUtils';
-import type { AttestorEntry } from '../lib/sliceBuilderUtils';
+import type { AttestorEntry, SliceDraft } from '../lib/sliceBuilderUtils';
+import { SliceImportExport } from './SliceImportExport';
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -307,6 +308,12 @@ export function QuorumSliceBuilder({ creatorAddress, initialAttestors, initialTh
     clearDraft();
   }
 
+  function handleImport(draft: SliceDraft) {
+    setAttestors(draft.attestors.map((a) => ({ ...a, id: a.id || crypto.randomUUID() })));
+    setThreshold(draft.threshold);
+    setAddrError(''); setThresholdError(''); setSubmitError(''); setSuccess(null);
+  }
+
   // ── Success screen ─────────────────────────────────────────────────────────
   if (success) {
     return (
@@ -537,6 +544,14 @@ export function QuorumSliceBuilder({ creatorAddress, initialAttestors, initialTh
       )}
 
       {attestors.length > 0 && <div className="divider" />}
+
+      {/* ── Import / Export ── */}
+      <SliceImportExport
+        slice={attestors.length > 0 ? { attestors, threshold } : null}
+        onImport={handleImport}
+      />
+
+      <div className="divider" />
 
       {/* ── Submit ── */}
       {submitError && (

--- a/frontend/src/components/SliceImportExport.tsx
+++ b/frontend/src/components/SliceImportExport.tsx
@@ -1,0 +1,92 @@
+/**
+ * SliceImportExport — issue #948
+ * Export/import quorum slice configurations in JSON format for backup and sharing.
+ */
+import { useRef, useState } from 'react';
+import type { ChangeEvent } from 'react';
+import { exportSliceAsJson, importSliceFromJson } from '../lib/sliceBuilderUtils';
+import type { SliceDraft } from '../lib/sliceBuilderUtils';
+
+interface SliceImportExportProps {
+  /** Current slice state to export (null when no attestors added yet). */
+  slice: SliceDraft | null;
+  /** Called with the parsed draft when a JSON file is successfully imported. */
+  onImport: (draft: SliceDraft) => void;
+}
+
+export function SliceImportExport({ slice, onImport }: SliceImportExportProps) {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [importError, setImportError] = useState('');
+  const [importSuccess, setImportSuccess] = useState(false);
+
+  function handleExport() {
+    if (!slice) return;
+    exportSliceAsJson(slice);
+  }
+
+  async function handleFileChange(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setImportError('');
+    setImportSuccess(false);
+    try {
+      const text = await file.text();
+      const draft = importSliceFromJson(text);
+      onImport(draft);
+      setImportSuccess(true);
+    } catch (err) {
+      setImportError(err instanceof Error ? err.message : 'Import failed.');
+    } finally {
+      if (fileRef.current) fileRef.current.value = '';
+    }
+  }
+
+  return (
+    <section className="qsb__section" aria-label="Import / Export slice configuration">
+      <div className="qsb__section-header">
+        <span className="detail-card__title">Import / Export JSON</span>
+      </div>
+
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+        <button
+          type="button"
+          className="btn btn--ghost btn--sm"
+          onClick={handleExport}
+          disabled={!slice}
+          data-testid="export-slice-btn"
+        >
+          ⬇ Export JSON
+        </button>
+
+        <label className="btn btn--ghost btn--sm" style={{ cursor: 'pointer' }}>
+          ⬆ Import JSON
+          <input
+            ref={fileRef}
+            type="file"
+            accept=".json,application/json"
+            style={{ display: 'none' }}
+            onChange={handleFileChange}
+            data-testid="import-slice-input"
+            aria-label="Import slice JSON file"
+          />
+        </label>
+      </div>
+
+      {importError && (
+        <p className="issue-form__field-error" role="alert" style={{ marginTop: 8 }} data-testid="import-error">
+          {importError}
+        </p>
+      )}
+      {importSuccess && (
+        <p style={{ fontSize: 13, color: 'var(--green)', marginTop: 8 }} role="status" data-testid="import-success">
+          ✅ Slice configuration imported.
+        </p>
+      )}
+      {!slice && (
+        <p style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 6 }}>
+          Add attestors to enable export.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -25,3 +25,4 @@ export { ClaimProofGenerator } from './ClaimProofGenerator';
 export { CLAIM_TYPE_OPTIONS, findClaimTypeOption, encodeProofRequest, buildProofShareUrl } from '../lib/claimDisclosure';
 export type { ClaimTypeOption } from '../lib/claimDisclosure';
 export { CredentialVerificationDashboard } from './CredentialVerificationDashboard';
+export { SliceImportExport } from './SliceImportExport';

--- a/frontend/src/lib/sliceBuilderUtils.ts
+++ b/frontend/src/lib/sliceBuilderUtils.ts
@@ -121,3 +121,41 @@ export function decodeSliceFromSearch(search: string): SliceDraft | null {
     return JSON.parse(atob(raw)) as SliceDraft;
   } catch { return null; }
 }
+
+// ── JSON Import / Export ──────────────────────────────────────────────────────
+
+export interface SliceExport {
+  version: 1;
+  exportedAt: string;
+  attestors: AttestorEntry[];
+  threshold: number;
+}
+
+/** Serialise the current draft to a JSON string and trigger a file download. */
+export function exportSliceAsJson(draft: SliceDraft, filename = 'quorum-slice.json'): void {
+  const payload: SliceExport = {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    ...draft,
+  };
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/** Parse a JSON string exported by `exportSliceAsJson`. Throws on invalid data. */
+export function importSliceFromJson(raw: string): SliceDraft {
+  let parsed: unknown;
+  try { parsed = JSON.parse(raw); } catch { throw new Error('Invalid JSON file.'); }
+  const data = parsed as SliceExport;
+  if (data.version !== 1 || !Array.isArray(data.attestors) || typeof data.threshold !== 'number') {
+    throw new Error('Unrecognised slice export format.');
+  }
+  return { attestors: data.attestors, threshold: data.threshold };
+}


### PR DESCRIPTION
## Summary

Adds JSON export and import for quorum slice configurations, enabling users to back up and share their slice setups.

## Changes

- **`sliceBuilderUtils.ts`**: Added `exportSliceAsJson` (serialises the slice to a versioned JSON file and triggers a browser download) and `importSliceFromJson` (parses and validates a previously exported file).
- **`SliceImportExport.tsx`** (new): Minimal UI component with an Export JSON button and an Import JSON file picker, with inline error/success feedback.
- **`QuorumSliceBuilder.tsx`**: Imports `SliceImportExport` and wires it in — exporting the live attestor list and handling imported drafts via a new `handleImport` callback.
- **`components/index.ts`**: Re-exports `SliceImportExport`.

## Exported JSON format

```json
{
  "version": 1,
  "exportedAt": "2026-06-29T18:31:25.411Z",
  "attestors": [...],
  "threshold": 4
}
```

Closes #948