### PR TITLE
feat(frontend): Implement form autosave (#950)

### DIFF
--- a/frontend/src/hooks/__tests__/useFormAutosave.test.ts
+++ b/frontend/src/hooks/__tests__/useFormAutosave.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useFormAutosave } from '../useFormAutosave';
+
+const KEY = 'test-form';
+const STORAGE_KEY = `qp_autosave_${KEY}`;
+
+describe('useFormAutosave', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('does not report a draft when storage is empty', () => {
+    const { result } = renderHook(() => useFormAutosave(KEY, { name: '' }));
+    expect(result.current.draft).toBeNull();
+    expect(result.current.hasDraft).toBe(false);
+  });
+
+  it('debounce-saves changed values to localStorage', () => {
+    const { rerender } = renderHook(({ value }) => useFormAutosave(KEY, value, { debounceMs: 1000 }), {
+      initialProps: { value: { name: '' } },
+    });
+
+    rerender({ value: { name: 'Acme University' } });
+    act(() => vi.advanceTimersByTime(1000));
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored.data).toEqual({ name: 'Acme University' });
+    expect(typeof stored.savedAt).toBe('number');
+  });
+
+  it('does not overwrite an existing draft while the form is pristine', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ data: { name: 'Saved Draft' }, savedAt: 123 }),
+    );
+
+    renderHook(() => useFormAutosave(KEY, { name: '' }, { debounceMs: 1000 }));
+    act(() => vi.advanceTimersByTime(5000));
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored.data).toEqual({ name: 'Saved Draft' });
+  });
+
+  it('recovers a saved draft that differs from the pristine value', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ data: { name: 'Recovered' }, savedAt: 456 }),
+    );
+
+    const { result } = renderHook(() => useFormAutosave(KEY, { name: '' }));
+    expect(result.current.hasDraft).toBe(true);
+    expect(result.current.draft).toEqual({ name: 'Recovered' });
+    expect(result.current.savedAt).toBe(456);
+  });
+
+  it('clear() removes the draft from storage and dismisses recovery', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ data: { name: 'Recovered' }, savedAt: 456 }),
+    );
+
+    const { result } = renderHook(() => useFormAutosave(KEY, { name: '' }));
+    act(() => result.current.clear());
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(result.current.draft).toBeNull();
+    expect(result.current.hasDraft).toBe(false);
+  });
+
+  it('periodically saves on the interval as a safety net', () => {
+    const { rerender } = renderHook(({ value }) => useFormAutosave(KEY, value, { debounceMs: 999999, intervalMs: 5000 }), {
+      initialProps: { value: { name: '' } },
+    });
+
+    rerender({ value: { name: 'Interval Save' } });
+    act(() => vi.advanceTimersByTime(5000));
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored.data).toEqual({ name: 'Interval Save' });
+  });
+
+  it('does nothing when disabled', () => {
+    const { rerender } = renderHook(({ value }) => useFormAutosave(KEY, value, { enabled: false, debounceMs: 1000 }), {
+      initialProps: { value: { name: '' } },
+    });
+
+    rerender({ value: { name: 'Should Not Save' } });
+    act(() => vi.advanceTimersByTime(10000));
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('treats corrupt stored data as no draft', () => {
+    localStorage.setItem(STORAGE_KEY, '{not valid json');
+    const { result } = renderHook(() => useFormAutosave(KEY, { name: '' }));
+    expect(result.current.draft).toBeNull();
+  });
+});

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,3 +1,8 @@
 export { useWallet } from '../context/WalletContext';
 export { useRealtimeUpdates } from './useRealtimeUpdates';
 export { useServiceWorker } from './useServiceWorker';
+export { useFormAutosave } from './useFormAutosave';
+export type {
+  UseFormAutosaveOptions,
+  UseFormAutosaveResult,
+} from './useFormAutosave';

--- a/frontend/src/hooks/useFormAutosave.ts
+++ b/frontend/src/hooks/useFormAutosave.ts
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Periodically persists form state to localStorage so long forms survive a
+ * crash, accidental navigation, or reload. On mount the hook surfaces any
+ * previously saved draft (`draft`) so the component can offer recovery, without
+ * clobbering the live form. Call `clear()` once the form is successfully
+ * submitted (or the user discards the draft).
+ */
+
+const AUTOSAVE_PREFIX = 'qp_autosave_';
+
+interface AutosaveEnvelope<T> {
+  data: T;
+  savedAt: number;
+}
+
+export interface UseFormAutosaveOptions {
+  /** Debounce delay before saving after a change, in ms. Default 1000. */
+  debounceMs?: number;
+  /** Periodic save interval as a safety net, in ms. Default 30000. */
+  intervalMs?: number;
+  /** When false, autosave is paused (no reads or writes). Default true. */
+  enabled?: boolean;
+}
+
+export interface UseFormAutosaveResult<T> {
+  /** A recoverable draft found in storage on mount, or null if none. */
+  draft: T | null;
+  /** Timestamp (ms since epoch) of the recovered draft, or null. */
+  savedAt: number | null;
+  /** Convenience flag: true when a recoverable draft exists. */
+  hasDraft: boolean;
+  /** Force an immediate save of the current value. */
+  save: () => void;
+  /** Remove the saved draft and dismiss the recovery prompt. */
+  clear: () => void;
+}
+
+function storageKeyFor(key: string): string {
+  return AUTOSAVE_PREFIX + key;
+}
+
+function readDraft<T>(key: string): AutosaveEnvelope<T> | null {
+  try {
+    const raw = localStorage.getItem(storageKeyFor(key));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as AutosaveEnvelope<T>;
+    if (parsed && typeof parsed.savedAt === 'number' && 'data' in parsed) {
+      return parsed;
+    }
+  } catch {
+    // Corrupt or unavailable storage — treat as no draft.
+  }
+  return null;
+}
+
+export function useFormAutosave<T>(
+  key: string,
+  value: T,
+  options: UseFormAutosaveOptions = {},
+): UseFormAutosaveResult<T> {
+  const { debounceMs = 1000, intervalMs = 30000, enabled = true } = options;
+
+  // Snapshot the pristine value once so an untouched form never overwrites a
+  // recovered draft. Lazy init keeps the serialization off every render.
+  const [pristine] = useState(() => JSON.stringify(value));
+
+  // Keep the latest value in a ref so interval/unmount saves stay current
+  // without re-subscribing the timers on every keystroke.
+  const valueRef = useRef(value);
+  useEffect(() => {
+    valueRef.current = value;
+  });
+
+  const [restored] = useState(() => (enabled ? readDraft<T>(key) : null));
+  const [draft, setDraft] = useState<T | null>(() => {
+    if (!restored) return null;
+    // Ignore a stored draft that matches the pristine form — nothing to recover.
+    return JSON.stringify(restored.data) === pristine ? null : restored.data;
+  });
+  const [savedAt, setSavedAt] = useState<number | null>(() =>
+    draft !== null && restored ? restored.savedAt : null,
+  );
+
+  const save = useCallback(() => {
+    if (!enabled) return;
+    // Skip writing while the form is still pristine to preserve any draft.
+    if (JSON.stringify(valueRef.current) === pristine) return;
+    try {
+      const envelope: AutosaveEnvelope<T> = { data: valueRef.current, savedAt: Date.now() };
+      localStorage.setItem(storageKeyFor(key), JSON.stringify(envelope));
+    } catch {
+      // Quota exceeded or storage unavailable — drop silently.
+    }
+  }, [enabled, key, pristine]);
+
+  const clear = useCallback(() => {
+    try {
+      localStorage.removeItem(storageKeyFor(key));
+    } catch {
+      // Ignore — best effort.
+    }
+    setDraft(null);
+    setSavedAt(null);
+  }, [key]);
+
+  // Debounced save whenever the value changes.
+  useEffect(() => {
+    if (!enabled) return;
+    const timer = setTimeout(save, debounceMs);
+    return () => clearTimeout(timer);
+  }, [value, enabled, debounceMs, save]);
+
+  // Periodic save as a safety net against crashes between keystrokes.
+  useEffect(() => {
+    if (!enabled) return;
+    const id = setInterval(save, intervalMs);
+    return () => clearInterval(id);
+  }, [enabled, intervalMs, save]);
+
+  // Final flush on unmount so in-flight edits aren't lost.
+  useEffect(() => {
+    return () => save();
+  }, [save]);
+
+  return { draft, savedAt, hasDraft: draft !== null, save, clear };
+}

--- a/frontend/src/pages/UniversityRegistration.tsx
+++ b/frontend/src/pages/UniversityRegistration.tsx
@@ -1,6 +1,6 @@
-import { useState, useRef } from 'react';
+import { useMemo, useState, useRef } from 'react';
 import { Navbar } from '../components/Navbar';
-import { useWallet } from '../hooks';
+import { useWallet, useFormAutosave } from '../hooks';
 import { formatAddress } from '../lib/credentialUtils';
 
 interface StudentRow {
@@ -56,6 +56,29 @@ export default function UniversityRegistration() {
 
   const [activeTab, setActiveTab] = useState<'register' | 'import'>('register');
 
+  // Periodically persist the registration form so a crash/reload doesn't lose
+  // typed details. Pauses once the registration is submitted.
+  const registrationDraft = useMemo(
+    () => ({ universityName, country, accreditationBody, contactEmail }),
+    [universityName, country, accreditationBody, contactEmail],
+  );
+  const {
+    draft: savedDraft,
+    savedAt,
+    clear: clearDraft,
+  } = useFormAutosave('university-registration', registrationDraft, {
+    enabled: !registrationSubmitted,
+  });
+
+  const restoreDraft = () => {
+    if (!savedDraft) return;
+    setUniversityName(savedDraft.universityName ?? '');
+    setCountry(savedDraft.country ?? '');
+    setAccreditationBody(savedDraft.accreditationBody ?? '');
+    setContactEmail(savedDraft.contactEmail ?? '');
+    clearDraft();
+  };
+
   const handleRegister = () => {
     if (!universityName.trim()) {
       setRegistrationMsg('University name is required.');
@@ -75,6 +98,7 @@ export default function UniversityRegistration() {
     }
     setRegistrationSubmitted(true);
     setRegistrationMsg(null);
+    clearDraft();
   };
 
   const handleCSVUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -230,6 +254,36 @@ export default function UniversityRegistration() {
                 </div>
               ) : (
                 <div style={{ display: 'grid', gap: 16 }}>
+                  {savedDraft && (
+                    <div
+                      role="alert"
+                      style={{
+                        display: 'flex',
+                        flexWrap: 'wrap',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        gap: 12,
+                        padding: '12px 16px',
+                        borderRadius: 6,
+                        border: '1px solid var(--color-warning, #f59e0b)',
+                        background: 'rgba(245, 158, 11, 0.08)',
+                        fontSize: 13,
+                      }}
+                    >
+                      <span>
+                        📝 We recovered unsaved registration details
+                        {savedAt ? ` from ${new Date(savedAt).toLocaleString()}` : ''}.
+                      </span>
+                      <div style={{ display: 'flex', gap: 8 }}>
+                        <button className="btn btn--primary btn--sm" onClick={restoreDraft}>
+                          Restore
+                        </button>
+                        <button className="btn btn--ghost btn--sm" onClick={clearDraft}>
+                          Discard
+                        </button>
+                      </div>
+                    </div>
+                  )}
                   <label style={{ display: 'flex', flexDirection: 'column', gap: 6, fontSize: 13 }}>
                     University / Institution Name *
                     <input


### PR DESCRIPTION
## Summary

Implements **Form Autosave** (#950). Long forms previously lost all data on a crash or accidental reload. This adds periodic autosave to `localStorage` with recovery on reload.

## Changes

- **`useFormAutosave` hook** (`frontend/src/hooks/useFormAutosave.ts`) — a reusable, generic, value-driven hook:
  - Debounced save on change (1s) + periodic interval save (30s) + flush on unmount.
  - On mount, exposes any saved `draft` / `savedAt` / `hasDraft` for recovery — never silently overwrites the live form.
  - Won't wipe an existing draft with a pristine/empty form.
  - Crash-safe: all storage access wrapped in try/catch (quota / corrupt-JSON tolerant).
  - Uses the existing `qp_autosave_<key>` localStorage convention; exported from `hooks/index.ts`.
- **Wired into the heaviest form** (`frontend/src/pages/UniversityRegistration.tsx`) — autosaves the institution registration fields, shows a recovery banner (**Restore** / **Discard**), and clears the draft on successful submit.
- **Tests** (`frontend/src/hooks/__tests__/useFormAutosave.test.ts`) — 8 tests covering debounce/interval save, pristine protection, recovery, clear, disabled mode, and corrupt-data handling.

## Verification

- `vitest` — 8/8 pass
- `eslint` — clean on all changed files
- `tsc -b` — no new type errors in changed files

The hook is generic and can be dropped into the other long forms (IssueCredentialForm, GdprRequest, etc.) the same way.

Closes #950