### PR TITLE
feat: crypto-shredding GDPR erasure with real attestor consent signatures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,10 @@ dist/
 dashboard/dist/
 frontend/dist/
 
+# Durable runtime state (GDPR request store, crypto-shredding vault)
+.data/
+api-server/.data/
+
 # Rust / Cargo
 Cargo.lock.bak
 **/*.rs.bak

--- a/api-server/src/index.ts
+++ b/api-server/src/index.ts
@@ -13,6 +13,7 @@ import recoveryRouter from './routes/recovery.js';
 import shareLinksRouter from './routes/shareLinks.js';
 import consentRouter from './routes/consent.js';
 import webhooksRouter from './routes/webhooks.js';
+import gdprRouter from './routes/gdpr.js';
 import { cacheControl } from './middleware/cacheControl.js';
 import { createRateLimiter } from './middleware/rateLimiter.js';
 import { createRequestDeduplication } from './middleware/requestDeduplication.js';
@@ -74,6 +75,7 @@ app.use('/api/attestor', attestorRouter);
 app.use('/api/issuer', issuerRouter);
 app.use('/api/recovery', recoveryRouter);
 app.use('/api/webhooks', webhooksRouter); // #926 event webhooks
+app.use('/api/gdpr', gdprRouter);
 
 app.get('/health', (_req, res) => {
   res.json({

--- a/api-server/src/routes/gdpr.ts
+++ b/api-server/src/routes/gdpr.ts
@@ -1,24 +1,18 @@
 import { Router, Request, Response } from 'express';
 import type { simulateCall as SimulateCallType } from '../soroban.js';
+import {
+  PersonalDataVault,
+  KeyDestroyedError,
+  PersonalDataNotFoundError,
+  getDefaultVault,
+} from '../services/cryptoShredding.js';
+import { GdprRequestStore, GdprRequest, getDefaultRequestStore } from '../services/gdprRequestStore.js';
+import { verifyAttestorConsentSignature } from '../services/attestorConsent.js';
 
 export type SorobanClient = {
   simulateCall: typeof SimulateCallType;
   u64Val: (n: number | bigint) => any;
 };
-
-type GdprRequestStatus = 'pending_consent' | 'anonymized' | 'rejected';
-
-type GdprRequest = {
-  requestId: string;
-  credentialId: number;
-  requestedAt: string;
-  status: GdprRequestStatus;
-  attestorConsents: string[];
-  requiredConsents: number;
-};
-
-const requests = new Map<string, GdprRequest>();
-let requestCounter = 0;
 
 function serializeBigInt(value: unknown): unknown {
   if (typeof value === 'bigint') return value.toString();
@@ -31,77 +25,257 @@ function serializeBigInt(value: unknown): unknown {
   return value;
 }
 
-export function createGdprRouter(soroban: SorobanClient) {
+function parseCredentialId(raw: unknown): number | null {
+  const id = typeof raw === 'number' ? raw : parseInt(String(raw), 10);
+  if (!Number.isInteger(id) || id <= 0) return null;
+  return id;
+}
+
+async function fetchCredentialSubject(
+  soroban: SorobanClient,
+  credentialId: number
+): Promise<{ subject: string } | null> {
+  try {
+    const credential = await soroban.simulateCall('get_credential', [soroban.u64Val(credentialId)]);
+    const subject =
+      credential && typeof credential === 'object' && 'subject' in (credential as Record<string, unknown>)
+        ? String((credential as Record<string, unknown>).subject)
+        : undefined;
+    if (!subject) return null;
+    return { subject };
+  } catch {
+    return null;
+  }
+}
+
+async function fetchAttestors(soroban: SorobanClient, credentialId: number): Promise<string[]> {
+  const raw = await soroban.simulateCall('get_attestors', [soroban.u64Val(credentialId)]);
+  return Array.isArray(raw) ? raw.map((a) => String(a)) : [];
+}
+
+export interface GdprRouterOptions {
+  vault?: PersonalDataVault;
+  requestStore?: GdprRequestStore;
+}
+
+export function createGdprRouter(soroban: SorobanClient, options: GdprRouterOptions = {}) {
   const router = Router();
+  // Resolved lazily inside each handler (not once at router-construction
+  // time) so that merely importing this module — or constructing a router
+  // with explicit test doubles via `options` — never has the side effect of
+  // creating the default on-disk data directories. They're only touched on
+  // the first request that actually needs them.
+  const getVault = () => options.vault ?? getDefaultVault();
+  const getRequestStore = () => options.requestStore ?? getDefaultRequestStore();
 
-  /**
-   * POST /api/gdpr/request
-   * Submit a GDPR right-to-be-forgotten request for a credential.
-   * The credential will be anonymized once all current attestors consent.
-   * Body: { credentialId: number }
-   */
-  router.post('/request', async (req: Request, res: Response) => {
-    const { credentialId } = req.body as { credentialId?: unknown };
+  function withVaultStatus(vault: PersonalDataVault, gdprRequest: GdprRequest) {
+    return { ...gdprRequest, vault: vault.status(gdprRequest.credentialId) };
+  }
 
-    if (typeof credentialId !== 'number' || !Number.isInteger(credentialId) || credentialId <= 0) {
+  // -------------------------------------------------------------------------
+  // POST /api/gdpr/personal-data
+  //
+  // Stores a credential's personal data off-chain, encrypted with a
+  // per-credential key. Returns a sha256 commitment of the plaintext —
+  // callers (typically the issuer, at credential issuance time) should
+  // anchor this commitment on-chain (e.g. as the credential's metadata_hash)
+  // so integrity remains verifiable without any personal data ever touching
+  // the ledger. See docs/crypto-shredding-architecture.md.
+  //
+  // Body: { credentialId: number, subject: string, personalData: unknown }
+  // -------------------------------------------------------------------------
+  router.post('/personal-data', async (req: Request, res: Response) => {
+    const { credentialId: rawCredentialId, subject, personalData } = req.body as {
+      credentialId?: unknown;
+      subject?: unknown;
+      personalData?: unknown;
+    };
+
+    const credentialId = parseCredentialId(rawCredentialId);
+    if (credentialId === null) {
+      res.status(400).json({ error: 'credentialId must be a positive integer' });
+      return;
+    }
+    if (typeof subject !== 'string' || subject.trim() === '') {
+      res.status(400).json({ error: 'subject (Stellar address) is required' });
+      return;
+    }
+    if (personalData === undefined) {
+      res.status(400).json({ error: 'personalData is required' });
+      return;
+    }
+
+    const onChain = await fetchCredentialSubject(soroban, credentialId);
+    if (!onChain) {
+      res.status(404).json({ error: 'Credential not found' });
+      return;
+    }
+    if (onChain.subject !== subject) {
+      res.status(400).json({ error: 'subject does not match the on-chain credential subject' });
+      return;
+    }
+
+    const vault = getVault();
+    try {
+      const { commitment } = vault.store(credentialId, subject, personalData);
+      res.status(201).json({ credentialId, subject, commitment, status: vault.status(credentialId) });
+    } catch (err: unknown) {
+      if (err instanceof KeyDestroyedError) {
+        res.status(410).json({ error: err.message });
+        return;
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: msg });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /api/gdpr/personal-data/:credentialId/status
+  //
+  // Metadata only — never decrypts. Safe to expose without authorization,
+  // since it reveals no personal data (only existence, timestamps, and the
+  // commitment hash, all of which remain meaningful post-erasure).
+  // -------------------------------------------------------------------------
+  router.get('/personal-data/:credentialId/status', (req: Request, res: Response) => {
+    const credentialId = parseCredentialId(req.params.credentialId);
+    if (credentialId === null) {
+      res.status(400).json({ error: 'credentialId must be a positive integer' });
+      return;
+    }
+    res.json(getVault().status(credentialId));
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /api/gdpr/personal-data/:credentialId
+  //
+  // Decrypts and returns the stored personal data. NOTE: production
+  // deployments must gate this behind the same holder/verifier authorization
+  // used elsewhere (see routes/consent.ts) before exposing plaintext — this
+  // route intentionally has no such check, matching the rest of this file's
+  // scope (correctness of the erasure mechanism, not endpoint authorization).
+  // -------------------------------------------------------------------------
+  router.get('/personal-data/:credentialId', (req: Request, res: Response) => {
+    const credentialId = parseCredentialId(req.params.credentialId);
+    if (credentialId === null) {
       res.status(400).json({ error: 'credentialId must be a positive integer' });
       return;
     }
 
-    let attestors: unknown[] = [];
+    const vault = getVault();
     try {
-      const raw = await soroban.simulateCall('get_attestors', [soroban.u64Val(credentialId)]);
-      attestors = Array.isArray(raw) ? raw : [];
-    } catch {
-      try {
-        await soroban.simulateCall('get_credential', [soroban.u64Val(credentialId)]);
-      } catch {
-        res.status(404).json({ error: 'Credential not found' });
+      const record = vault.retrieve(credentialId);
+      res.json(record);
+    } catch (err: unknown) {
+      if (err instanceof KeyDestroyedError) {
+        res.status(410).json({ error: err.message, erasedAt: vault.status(credentialId).erasedAt });
         return;
       }
+      if (err instanceof PersonalDataNotFoundError) {
+        res.status(404).json({ error: err.message });
+        return;
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: msg });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /api/gdpr/request
+  //
+  // Submit a GDPR right-to-erasure request for a credential. If the
+  // credential currently has no attestors, erasure completes immediately —
+  // by genuinely destroying the credential's decryption key, not by flipping
+  // a status flag. Otherwise the request waits for signed consent from every
+  // current attestor (see POST /consent).
+  //
+  // Body: { credentialId: number }
+  // -------------------------------------------------------------------------
+  router.post('/request', async (req: Request, res: Response) => {
+    const { credentialId: rawCredentialId } = req.body as { credentialId?: unknown };
+
+    const credentialId = parseCredentialId(rawCredentialId);
+    if (credentialId === null) {
+      res.status(400).json({ error: 'credentialId must be a positive integer' });
+      return;
     }
 
-    requestCounter += 1;
-    const requestId = `gdpr_${requestCounter}`;
+    const onChain = await fetchCredentialSubject(soroban, credentialId);
+    if (!onChain) {
+      res.status(404).json({ error: 'Credential not found' });
+      return;
+    }
+
+    let attestors: string[];
+    try {
+      attestors = await fetchAttestors(soroban, credentialId);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: `Could not determine attestor set: ${msg}` });
+      return;
+    }
+
+    const vault = getVault();
+    const requestStore = getRequestStore();
+
+    const requestId = requestStore.nextRequestId();
     const gdprRequest: GdprRequest = {
       requestId,
       credentialId,
+      subject: onChain.subject,
       requestedAt: new Date().toISOString(),
       status: attestors.length === 0 ? 'anonymized' : 'pending_consent',
       attestorConsents: [],
       requiredConsents: attestors.length,
+      eligibleAttestors: attestors,
     };
-    requests.set(requestId, gdprRequest);
 
-    res.status(201).json(serializeBigInt(gdprRequest));
+    if (gdprRequest.status === 'anonymized') {
+      const erasure = vault.eraseKey(credentialId);
+      gdprRequest.erasedAt = erasure.erasedAt;
+      gdprRequest.commitment = vault.status(credentialId).commitment;
+    }
+
+    requestStore.set(gdprRequest);
+
+    res.status(201).json(serializeBigInt(withVaultStatus(vault, gdprRequest)));
   });
 
-  /**
-   * GET /api/gdpr/request/:requestId
-   * Get the status of a GDPR request.
-   */
+  // -------------------------------------------------------------------------
+  // GET /api/gdpr/request/:requestId
+  // -------------------------------------------------------------------------
   router.get('/request/:requestId', (req: Request, res: Response) => {
-    const gdprRequest = requests.get(req.params.requestId);
+    const gdprRequest = getRequestStore().get(req.params.requestId);
     if (!gdprRequest) {
       res.status(404).json({ error: 'GDPR request not found' });
       return;
     }
-    res.json(gdprRequest);
+    res.json(serializeBigInt(withVaultStatus(getVault(), gdprRequest)));
   });
 
-  /**
-   * POST /api/gdpr/consent
-   * An attestor submits consent for a pending GDPR deletion/anonymization request.
-   * When all required attestors have consented, the credential is marked anonymized.
-   * Body: { requestId: string, attestorAddress: string }
-   */
-  router.post('/consent', (req: Request, res: Response) => {
-    const { requestId, attestorAddress } = req.body as {
+  // -------------------------------------------------------------------------
+  // POST /api/gdpr/consent
+  //
+  // An attestor consents to a pending GDPR erasure request by submitting an
+  // ed25519 signature (hex-encoded) over the canonical consent message for
+  // this request (see services/attestorConsent.ts). The signer must also be
+  // a member of the credential's *current* on-chain attestor set — a raw
+  // address string is never sufficient on its own.
+  //
+  // When the last required consent lands, the credential's decryption key is
+  // destroyed for real.
+  //
+  // Body: { requestId: string, attestorAddress: string, signature: string }
+  // -------------------------------------------------------------------------
+  router.post('/consent', async (req: Request, res: Response) => {
+    const { requestId, attestorAddress, signature } = req.body as {
       requestId?: string;
       attestorAddress?: string;
+      signature?: string;
     };
 
-    if (!requestId || !requests.has(requestId)) {
+    const requestStore = getRequestStore();
+
+    if (!requestId || !requestStore.has(requestId)) {
       res.status(400).json({ error: 'Invalid or unknown requestId' });
       return;
     }
@@ -109,27 +283,58 @@ export function createGdprRouter(soroban: SorobanClient) {
       res.status(400).json({ error: 'attestorAddress is required' });
       return;
     }
+    if (!signature || typeof signature !== 'string' || signature.trim() === '') {
+      res.status(400).json({ error: 'signature is required' });
+      return;
+    }
 
-    const gdprRequest = requests.get(requestId)!;
+    const gdprRequest = requestStore.get(requestId)!;
+    const addr = attestorAddress.trim();
 
     if (gdprRequest.status !== 'pending_consent') {
       res.status(400).json({ error: `Request is already ${gdprRequest.status}` });
       return;
     }
 
-    const addr = attestorAddress.trim();
-    if (!gdprRequest.attestorConsents.includes(addr)) {
-      gdprRequest.attestorConsents.push(addr);
+    let currentAttestors: string[];
+    try {
+      currentAttestors = await fetchAttestors(soroban, gdprRequest.credentialId);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: `Could not verify attestor set: ${msg}` });
+      return;
     }
 
+    if (!currentAttestors.includes(addr)) {
+      res.status(403).json({ error: 'attestorAddress is not a current attestor for this credential' });
+      return;
+    }
+
+    const verification = verifyAttestorConsentSignature(addr, requestId, gdprRequest.credentialId, signature.trim());
+    if (!verification.valid) {
+      res.status(401).json({ error: 'Invalid attestor signature', reason: verification.reason });
+      return;
+    }
+
+    const alreadyConsented = gdprRequest.attestorConsents.some((c) => c.attestor === addr);
+    if (!alreadyConsented) {
+      gdprRequest.attestorConsents.push({ attestor: addr, consentedAt: new Date().toISOString() });
+    }
+
+    const vault = getVault();
     if (
       gdprRequest.requiredConsents > 0 &&
       gdprRequest.attestorConsents.length >= gdprRequest.requiredConsents
     ) {
       gdprRequest.status = 'anonymized';
+      const erasure = vault.eraseKey(gdprRequest.credentialId);
+      gdprRequest.erasedAt = erasure.erasedAt;
+      gdprRequest.commitment = vault.status(gdprRequest.credentialId).commitment;
     }
 
-    res.json(gdprRequest);
+    requestStore.set(gdprRequest);
+
+    res.json(serializeBigInt(withVaultStatus(vault, gdprRequest)));
   });
 
   return router;

--- a/api-server/src/services/attestorConsent.ts
+++ b/api-server/src/services/attestorConsent.ts
@@ -1,0 +1,51 @@
+import { Keypair, StrKey } from '@stellar/stellar-sdk';
+
+const SIGNATURE_HEX_PATTERN = /^[0-9a-fA-F]{128}$/; // 64-byte ed25519 signature, hex-encoded
+
+/**
+ * Canonical message an attestor signs to consent to a GDPR erasure request.
+ * Binding requestId + credentialId + the attestor's own address prevents a
+ * signature collected for one request (or one attestor) from being replayed
+ * against another.
+ */
+export function buildConsentMessage(requestId: string, credentialId: number, attestorAddress: string): string {
+  return `QuorumProof GDPR Erasure Consent\nrequestId:${requestId}\ncredentialId:${credentialId}\nattestor:${attestorAddress}`;
+}
+
+export interface ConsentVerificationResult {
+  valid: boolean;
+  reason?: string;
+}
+
+/**
+ * Verifies that `signatureHex` is a genuine ed25519 signature, by the holder
+ * of `attestorAddress`'s private key, over the canonical consent message for
+ * this request. This is the cryptographic binding required for a "consent" —
+ * without it, any caller could POST an arbitrary address string and have it
+ * counted, regardless of whether that party ever agreed to anything.
+ */
+export function verifyAttestorConsentSignature(
+  attestorAddress: string,
+  requestId: string,
+  credentialId: number,
+  signatureHex: string,
+): ConsentVerificationResult {
+  if (!StrKey.isValidEd25519PublicKey(attestorAddress)) {
+    return { valid: false, reason: 'attestorAddress is not a valid Stellar ed25519 public key' };
+  }
+  if (typeof signatureHex !== 'string' || !SIGNATURE_HEX_PATTERN.test(signatureHex)) {
+    return { valid: false, reason: 'signature must be a 128-character hex-encoded 64-byte ed25519 signature' };
+  }
+
+  const message = Buffer.from(buildConsentMessage(requestId, credentialId, attestorAddress), 'utf8');
+  const signature = Buffer.from(signatureHex, 'hex');
+
+  try {
+    const keypair = Keypair.fromPublicKey(attestorAddress);
+    return keypair.verify(message, signature)
+      ? { valid: true }
+      : { valid: false, reason: 'signature verification failed' };
+  } catch {
+    return { valid: false, reason: 'signature verification failed' };
+  }
+}

--- a/api-server/src/services/cryptoShredding.ts
+++ b/api-server/src/services/cryptoShredding.ts
@@ -1,0 +1,233 @@
+import path from 'path';
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'crypto';
+import { DurableLog } from './durableLog.js';
+
+/**
+ * Crypto-shredding personal data store.
+ *
+ * Personal data is never held in plaintext at rest. Each credential's
+ * personal data is encrypted with its own randomly generated AES-256-GCM
+ * data encryption key (DEK) the first time it is stored. The ciphertext is
+ * durable and long-lived; the DEK lives in a separate durable log.
+ *
+ * "Erasure" (GDPR Art. 17) is implemented as destruction of the DEK via
+ * DurableLog#shred — an irreversible operation that zero-overwrites the
+ * on-disk key material before recompacting. Once a key is destroyed, the
+ * corresponding ciphertext is permanently unrecoverable by anyone, including
+ * the operator: there is no code path, backup key, or master secret that can
+ * reconstruct a destroyed DEK.
+ *
+ * See docs/crypto-shredding-architecture.md for the full spec, including a
+ * precise statement of what remains verifiable post-erasure (existence,
+ * timestamps, the sha256 commitment) versus what becomes permanently
+ * inaccessible (the plaintext personal data itself).
+ */
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;
+
+export class KeyDestroyedError extends Error {
+  constructor(credentialId: number) {
+    super(`Decryption key for credential ${credentialId} has been permanently destroyed and cannot be recovered`);
+    this.name = 'KeyDestroyedError';
+  }
+}
+
+export class PersonalDataNotFoundError extends Error {
+  constructor(credentialId: number) {
+    super(`No personal data record exists for credential ${credentialId}`);
+    this.name = 'PersonalDataNotFoundError';
+  }
+}
+
+interface KeyRecord {
+  /** hex-encoded 32-byte AES-256 key */
+  dek: string;
+  createdAt: string;
+}
+
+interface CiphertextRecord {
+  subject: string;
+  /** hex-encoded */
+  iv: string;
+  /** hex-encoded */
+  authTag: string;
+  /** hex-encoded */
+  ciphertext: string;
+  /** sha256 hex digest of the plaintext — the value anchored on-chain as metadata_hash */
+  commitment: string;
+  storedAt: string;
+  updatedAt: string;
+}
+
+interface ErasureRecord {
+  erasedAt: string;
+}
+
+export interface PersonalDataRecord {
+  credentialId: number;
+  subject: string;
+  personalData: unknown;
+  commitment: string;
+  storedAt: string;
+  updatedAt: string;
+}
+
+export interface PersonalDataStatus {
+  credentialId: number;
+  hasData: boolean;
+  subject?: string;
+  commitment?: string;
+  storedAt?: string;
+  updatedAt?: string;
+  erased: boolean;
+  erasedAt?: string;
+}
+
+export interface PersonalDataVaultOptions {
+  dataDir?: string;
+}
+
+function computeCommitment(plaintext: Buffer): string {
+  return createHash('sha256').update(plaintext).digest('hex');
+}
+
+export class PersonalDataVault {
+  private readonly keys: DurableLog<KeyRecord>;
+  private readonly ciphertexts: DurableLog<CiphertextRecord>;
+  private readonly erasures: DurableLog<ErasureRecord>;
+
+  constructor(options: PersonalDataVaultOptions = {}) {
+    const dataDir = options.dataDir ?? process.env.GDPR_VAULT_DATA_DIR ?? path.join(process.cwd(), '.data', 'gdpr-vault');
+    this.keys = new DurableLog<KeyRecord>(path.join(dataDir, 'keys.jsonl'));
+    this.ciphertexts = new DurableLog<CiphertextRecord>(path.join(dataDir, 'ciphertext.jsonl'));
+    this.erasures = new DurableLog<ErasureRecord>(path.join(dataDir, 'erasures.jsonl'));
+  }
+
+  private keyOf(credentialId: number): string {
+    return String(credentialId);
+  }
+
+  isErased(credentialId: number): boolean {
+    return this.erasures.has(this.keyOf(credentialId));
+  }
+
+  hasData(credentialId: number): boolean {
+    return this.ciphertexts.has(this.keyOf(credentialId));
+  }
+
+  /**
+   * Encrypts and durably stores `personalData` for a credential, generating
+   * a fresh DEK on first write and reusing it for subsequent updates to the
+   * same credential. Returns the sha256 commitment of the plaintext, which
+   * callers should anchor on-chain (e.g. as the credential's metadata_hash)
+   * so integrity remains verifiable without exposing content.
+   */
+  store(credentialId: number, subject: string, personalData: unknown): { commitment: string } {
+    if (this.isErased(credentialId)) {
+      throw new KeyDestroyedError(credentialId);
+    }
+
+    const key = this.keyOf(credentialId);
+    const plaintext = Buffer.from(JSON.stringify(personalData), 'utf8');
+    const commitment = computeCommitment(plaintext);
+
+    let keyRecord = this.keys.get(key);
+    if (!keyRecord) {
+      keyRecord = { dek: randomBytes(32).toString('hex'), createdAt: new Date().toISOString() };
+      this.keys.set(key, keyRecord);
+    }
+
+    const iv = randomBytes(IV_LENGTH);
+    const cipher = createCipheriv(ALGORITHM, Buffer.from(keyRecord.dek, 'hex'), iv);
+    const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+
+    const now = new Date().toISOString();
+    const existing = this.ciphertexts.get(key);
+    this.ciphertexts.set(key, {
+      subject,
+      iv: iv.toString('hex'),
+      authTag: authTag.toString('hex'),
+      ciphertext: ciphertext.toString('hex'),
+      commitment,
+      storedAt: existing?.storedAt ?? now,
+      updatedAt: now,
+    });
+
+    return { commitment };
+  }
+
+  /** Decrypts and returns the personal data. Throws KeyDestroyedError if the DEK has been erased. */
+  retrieve(credentialId: number): PersonalDataRecord {
+    const key = this.keyOf(credentialId);
+    const record = this.ciphertexts.get(key);
+    if (!record) throw new PersonalDataNotFoundError(credentialId);
+
+    const keyRecord = this.keys.get(key);
+    if (!keyRecord) throw new KeyDestroyedError(credentialId);
+
+    const decipher = createDecipheriv(ALGORITHM, Buffer.from(keyRecord.dek, 'hex'), Buffer.from(record.iv, 'hex'));
+    decipher.setAuthTag(Buffer.from(record.authTag, 'hex'));
+    const plaintext = Buffer.concat([decipher.update(Buffer.from(record.ciphertext, 'hex')), decipher.final()]);
+
+    return {
+      credentialId,
+      subject: record.subject,
+      personalData: JSON.parse(plaintext.toString('utf8')),
+      commitment: record.commitment,
+      storedAt: record.storedAt,
+      updatedAt: record.updatedAt,
+    };
+  }
+
+  /**
+   * Returns metadata about a credential's personal data without decrypting
+   * it — what stays verifiable regardless of erasure status: existence,
+   * subject, timestamps, and the commitment hash.
+   */
+  status(credentialId: number): PersonalDataStatus {
+    const key = this.keyOf(credentialId);
+    const record = this.ciphertexts.get(key);
+    const erasureRecord = this.erasures.get(key);
+    return {
+      credentialId,
+      hasData: !!record,
+      subject: record?.subject,
+      commitment: record?.commitment,
+      storedAt: record?.storedAt,
+      updatedAt: record?.updatedAt,
+      erased: !!erasureRecord,
+      erasedAt: erasureRecord?.erasedAt,
+    };
+  }
+
+  /**
+   * Irreversibly destroys the DEK for a credential. Idempotent: erasing an
+   * already-erased credential is a no-op that reports `alreadyErased: true`.
+   * After this call, `retrieve()` always throws KeyDestroyedError — for this
+   * process and for any future process that loads the same data directory,
+   * since the destruction is itself durably (and irreversibly) recorded.
+   */
+  eraseKey(credentialId: number): { erased: boolean; alreadyErased: boolean; erasedAt: string } {
+    const key = this.keyOf(credentialId);
+    const already = this.erasures.get(key);
+    if (already) {
+      return { erased: true, alreadyErased: true, erasedAt: already.erasedAt };
+    }
+
+    this.keys.shred(key);
+    const erasedAt = new Date().toISOString();
+    this.erasures.set(key, { erasedAt });
+
+    return { erased: true, alreadyErased: false, erasedAt };
+  }
+}
+
+let defaultVault: PersonalDataVault | undefined;
+
+/** Lazily-constructed process-wide vault, used by the default GDPR router export. */
+export function getDefaultVault(): PersonalDataVault {
+  if (!defaultVault) defaultVault = new PersonalDataVault();
+  return defaultVault;
+}

--- a/api-server/src/services/durableLog.ts
+++ b/api-server/src/services/durableLog.ts
@@ -1,0 +1,124 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface DurableLogOptions {
+  /** Number of appended lines after which the log auto-compacts. Defaults to max(200, 4x live keys). */
+  compactThreshold?: number;
+}
+
+/**
+ * Append-only JSONL log that replays the latest record per key on load.
+ *
+ * Every write is fsync'd to disk before being considered durable, so a fresh
+ * instance pointed at the same filePath recovers full state after a process
+ * restart (or crash — a torn last line from a mid-append crash is tolerated
+ * and skipped; every prior line is a complete record).
+ */
+export class DurableLog<T> {
+  private data = new Map<string, T>();
+  private lines = 0;
+
+  constructor(private readonly filePath: string, private readonly opts: DurableLogOptions = {}) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    this.load();
+  }
+
+  private load(): void {
+    if (!fs.existsSync(this.filePath)) return;
+    const raw = fs.readFileSync(this.filePath, 'utf8');
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const { key, value, deleted } = JSON.parse(line) as { key: string; value?: T; deleted?: boolean };
+        if (deleted) this.data.delete(key);
+        else this.data.set(key, value as T);
+        this.lines++;
+      } catch {
+        // Tolerate a torn last line from a crash mid-append.
+      }
+    }
+  }
+
+  private appendLine(obj: unknown): void {
+    const fd = fs.openSync(this.filePath, 'a');
+    try {
+      fs.writeSync(fd, JSON.stringify(obj) + '\n');
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    this.lines++;
+    const threshold = this.opts.compactThreshold ?? Math.max(200, this.data.size * 4);
+    if (this.lines > threshold) this.compact();
+  }
+
+  set(key: string, value: T): void {
+    this.data.set(key, value);
+    this.appendLine({ key, value });
+  }
+
+  get(key: string): T | undefined {
+    return this.data.get(key);
+  }
+
+  has(key: string): boolean {
+    return this.data.has(key);
+  }
+
+  delete(key: string): void {
+    this.data.delete(key);
+    this.appendLine({ key, deleted: true });
+  }
+
+  keys(): string[] {
+    return Array.from(this.data.keys());
+  }
+
+  values(): T[] {
+    return Array.from(this.data.values());
+  }
+
+  entries(): [string, T][] {
+    return Array.from(this.data.entries());
+  }
+
+  compact(): void {
+    const lines = Array.from(this.data.entries()).map(([key, value]) => JSON.stringify({ key, value }));
+    const fd = fs.openSync(this.filePath, 'w');
+    try {
+      if (lines.length) fs.writeSync(fd, lines.join('\n') + '\n');
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    this.lines = lines.length;
+  }
+
+  /**
+   * Irreversibly destroys `key`: the in-memory entry is dropped, the on-disk
+   * file is zero-overwritten in place (so no prior byte offset containing the
+   * key's serialized value survives, even before the rewrite lands), and the
+   * file is then recompacted to contain only the remaining live keys.
+   *
+   * Used for genuine key destruction (crypto-shredding), not ordinary delete:
+   * ordinary `delete()` leaves earlier log lines with the value physically
+   * present on disk until a future compaction; `shred()` guarantees the value
+   * is gone from this file immediately.
+   */
+  shred(key: string): void {
+    this.data.delete(key);
+    try {
+      const stat = fs.statSync(this.filePath);
+      const fd = fs.openSync(this.filePath, 'w');
+      try {
+        fs.writeSync(fd, Buffer.alloc(stat.size, 0));
+        fs.fsyncSync(fd);
+      } finally {
+        fs.closeSync(fd);
+      }
+    } catch {
+      // File may not exist yet — nothing on disk to shred.
+    }
+    this.compact();
+  }
+}

--- a/api-server/src/services/gdprRequestStore.ts
+++ b/api-server/src/services/gdprRequestStore.ts
@@ -1,0 +1,79 @@
+import path from 'path';
+import { DurableLog } from './durableLog.js';
+
+export type GdprRequestStatus = 'pending_consent' | 'anonymized' | 'rejected';
+
+export interface AttestorConsent {
+  attestor: string;
+  consentedAt: string;
+}
+
+export interface GdprRequest {
+  requestId: string;
+  credentialId: number;
+  subject: string;
+  requestedAt: string;
+  status: GdprRequestStatus;
+  attestorConsents: AttestorConsent[];
+  requiredConsents: number;
+  /** Attestor addresses recorded at request time, for audit — live membership is re-checked on each consent. */
+  eligibleAttestors: string[];
+  commitment?: string;
+  erasedAt?: string;
+}
+
+export interface GdprRequestStoreOptions {
+  dataDir?: string;
+}
+
+const REQUEST_ID_PATTERN = /^gdpr_(\d+)$/;
+
+/** Durable store for GDPR requests — state survives process restarts via an append-only WAL. */
+export class GdprRequestStore {
+  private readonly log: DurableLog<GdprRequest>;
+  private counter: number;
+
+  constructor(options: GdprRequestStoreOptions = {}) {
+    const dataDir = options.dataDir ?? process.env.GDPR_REQUEST_STORE_DATA_DIR ?? path.join(process.cwd(), '.data', 'gdpr-requests');
+    this.log = new DurableLog<GdprRequest>(path.join(dataDir, 'requests.jsonl'));
+    this.counter = this.recoverCounter();
+  }
+
+  private recoverCounter(): number {
+    let max = 0;
+    for (const key of this.log.keys()) {
+      const match = REQUEST_ID_PATTERN.exec(key);
+      if (match) max = Math.max(max, parseInt(match[1], 10));
+    }
+    return max;
+  }
+
+  nextRequestId(): string {
+    this.counter += 1;
+    return `gdpr_${this.counter}`;
+  }
+
+  set(request: GdprRequest): void {
+    this.log.set(request.requestId, request);
+  }
+
+  get(requestId: string): GdprRequest | undefined {
+    return this.log.get(requestId);
+  }
+
+  has(requestId: string): boolean {
+    return this.log.has(requestId);
+  }
+
+  all(): GdprRequest[] {
+    return this.log.values();
+  }
+}
+
+let defaultStore: GdprRequestStore | undefined;
+
+/** Lazily-constructed process-wide store, used by the default GDPR router export. */
+export function getDefaultRequestStore(): GdprRequestStore {
+  if (!defaultStore) defaultStore = new GdprRequestStore();
+  return defaultStore;
+}

--- a/api-server/tests/cryptoShredding.test.ts
+++ b/api-server/tests/cryptoShredding.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { PersonalDataVault, KeyDestroyedError, PersonalDataNotFoundError } from '../src/services/cryptoShredding.js';
+
+describe('PersonalDataVault', () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gdpr-vault-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('stores and retrieves encrypted personal data, returning a stable sha256 commitment', () => {
+    const vault = new PersonalDataVault({ dataDir });
+    const { commitment } = vault.store(1, 'GSUBJECT', { name: 'Ada Lovelace', email: 'ada@example.com' });
+    expect(commitment).toMatch(/^[0-9a-f]{64}$/);
+
+    const record = vault.retrieve(1);
+    expect(record.personalData).toEqual({ name: 'Ada Lovelace', email: 'ada@example.com' });
+    expect(record.commitment).toBe(commitment);
+  });
+
+  it('never writes plaintext to disk', () => {
+    const vault = new PersonalDataVault({ dataDir });
+    vault.store(2, 'GSUBJECT2', { ssn: '123-45-6789' });
+
+    const raw = fs.readFileSync(path.join(dataDir, 'ciphertext.jsonl'), 'utf8');
+    expect(raw).not.toContain('123-45-6789');
+  });
+
+  it('exposes status metadata (existence, commitment, timestamps) without decrypting', () => {
+    const vault = new PersonalDataVault({ dataDir });
+    vault.store(3, 'GSUBJECT3', { secret: 'classified' });
+    const status = vault.status(3);
+    expect(status.hasData).toBe(true);
+    expect(status.erased).toBe(false);
+    expect(status.commitment).toMatch(/^[0-9a-f]{64}$/);
+    expect(status.storedAt).toBeTruthy();
+  });
+
+  it('throws PersonalDataNotFoundError for a credential that was never stored', () => {
+    const vault = new PersonalDataVault({ dataDir });
+    expect(() => vault.retrieve(42)).toThrow(PersonalDataNotFoundError);
+  });
+
+  it('genuinely destroys the decryption key: retrieve throws afterward, not just a status flag flip', () => {
+    const vault = new PersonalDataVault({ dataDir });
+    vault.store(4, 'GSUBJECT4', { medicalHistory: 'penicillin allergy' });
+
+    expect(() => vault.retrieve(4)).not.toThrow();
+
+    const result = vault.eraseKey(4);
+    expect(result.erased).toBe(true);
+    expect(result.alreadyErased).toBe(false);
+    expect(vault.isErased(4)).toBe(true);
+
+    expect(() => vault.retrieve(4)).toThrow(KeyDestroyedError);
+  });
+
+  it('erasure is idempotent and returns the original erasure timestamp on repeat calls', () => {
+    const vault = new PersonalDataVault({ dataDir });
+    vault.store(5, 'GSUBJECT5', { data: 'x' });
+    const first = vault.eraseKey(5);
+    const second = vault.eraseKey(5);
+    expect(first.alreadyErased).toBe(false);
+    expect(second.alreadyErased).toBe(true);
+    expect(second.erasedAt).toBe(first.erasedAt);
+  });
+
+  it('erasing a credential with no stored data is a harmless no-op that still records a durable tombstone', () => {
+    const vault = new PersonalDataVault({ dataDir });
+    const result = vault.eraseKey(999);
+    expect(result.erased).toBe(true);
+    expect(vault.isErased(999)).toBe(true);
+  });
+
+  it('removes only the destroyed key from the on-disk key log, leaving other credentials untouched', () => {
+    const vault = new PersonalDataVault({ dataDir });
+    vault.store(6, 'GSIX', { data: 'six' });
+    vault.store(60, 'GSIXTY', { data: 'sixty' });
+
+    vault.eraseKey(6);
+
+    const keysAfter = fs.readFileSync(path.join(dataDir, 'keys.jsonl'), 'utf8');
+    expect(keysAfter).not.toContain('"key":"6"');
+    expect(keysAfter).toContain('"key":"60"');
+
+    expect(() => vault.retrieve(6)).toThrow(KeyDestroyedError);
+    expect(vault.retrieve(60).personalData).toEqual({ data: 'sixty' });
+  });
+
+  it('storing after erasure is rejected — erasure is one-way', () => {
+    const vault = new PersonalDataVault({ dataDir });
+    vault.store(8, 'GSUBJECT8', { data: 'first' });
+    vault.eraseKey(8);
+    expect(() => vault.store(8, 'GSUBJECT8', { data: 'second' })).toThrow(KeyDestroyedError);
+  });
+
+  it('data persists across a restart until explicitly erased', () => {
+    const vault = new PersonalDataVault({ dataDir });
+    vault.store(9, 'GSUBJECT9', { name: 'Restart Test' });
+
+    const restarted = new PersonalDataVault({ dataDir });
+    expect(restarted.retrieve(9).personalData).toEqual({ name: 'Restart Test' });
+  });
+
+  it('is unrecoverable across a process restart: a fresh instance from the same data directory still cannot decrypt, and no file on disk contains the plaintext', () => {
+    const vault = new PersonalDataVault({ dataDir });
+    vault.store(7, 'GSUBJECT7', { creditCard: '4111-1111-1111-1111' });
+    vault.eraseKey(7);
+
+    // Simulate a restart: brand-new instance, same on-disk state, no in-memory carryover.
+    const restarted = new PersonalDataVault({ dataDir });
+    expect(restarted.isErased(7)).toBe(true);
+    expect(() => restarted.retrieve(7)).toThrow(KeyDestroyedError);
+
+    // The ciphertext record may still exist as an audit artifact...
+    expect(restarted.status(7).hasData).toBe(true);
+
+    // ...but the plaintext itself is nowhere on disk, across every vault file —
+    // a real forensic check, not merely trusting the erased flag.
+    const allFiles = ['ciphertext.jsonl', 'keys.jsonl', 'erasures.jsonl']
+      .map((f) => path.join(dataDir, f))
+      .filter((f) => fs.existsSync(f))
+      .map((f) => fs.readFileSync(f, 'utf8'))
+      .join('\n');
+    expect(allFiles).not.toContain('4111-1111-1111-1111');
+  });
+
+  it('updates reuse the same DEK and commitment changes with content', () => {
+    const vault = new PersonalDataVault({ dataDir });
+    const first = vault.store(11, 'GSUBJECT11', { v: 1 });
+    const second = vault.store(11, 'GSUBJECT11', { v: 2 });
+    expect(second.commitment).not.toBe(first.commitment);
+    expect(vault.retrieve(11).personalData).toEqual({ v: 2 });
+  });
+});

--- a/api-server/tests/gdpr.test.ts
+++ b/api-server/tests/gdpr.test.ts
@@ -1,7 +1,33 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import express from 'express';
 import request from 'supertest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { Keypair } from '@stellar/stellar-sdk';
 import { createGdprRouter } from '../src/routes/gdpr.js';
+import { PersonalDataVault } from '../src/services/cryptoShredding.js';
+import { GdprRequestStore } from '../src/services/gdprRequestStore.js';
+import { buildConsentMessage } from '../src/services/attestorConsent.js';
+
+/**
+ * Intentional behavior changes vs. the pre-crypto-shredding version of this
+ * suite (see docs/crypto-shredding-architecture.md for the full rationale):
+ *
+ * 1. POST /consent now requires a `signature` field and rejects any
+ *    attestorAddress that isn't (a) a valid Stellar ed25519 public key,
+ *    (b) currently present in the credential's on-chain attestor set, and
+ *    (c) the genuine signer of the canonical consent message. The old
+ *    "raw address string count" tests (e.g. consenting as bare 'GATT1')
+ *    are replaced with real Keypair-signed consent.
+ * 2. POST /request and GET /request/:id now also call get_credential (to
+ *    resolve the on-chain subject and to serve as the single source of
+ *    truth for "does this credential exist"), not just get_attestors.
+ *    Mocks below stub both.
+ * 3. Reaching 'anonymized' now genuinely destroys the credential's
+ *    decryption key via PersonalDataVault#eraseKey, rather than only
+ *    flipping a status string.
+ */
 
 const mockSimulateCall = vi.fn();
 const mockSoroban = {
@@ -9,114 +35,353 @@ const mockSoroban = {
   u64Val: (n: number | bigint) => n as any,
 };
 
-const app = express();
-app.use(express.json());
-app.use('/api/gdpr', createGdprRouter(mockSoroban));
+interface ChainState {
+  credentials: Record<number, { subject: string }>;
+  attestors: Record<number, string[]>;
+}
 
-describe('POST /api/gdpr/request', () => {
-  beforeEach(() => mockSimulateCall.mockReset());
+function mockChain(state: ChainState) {
+  mockSimulateCall.mockImplementation(async (method: string, args: any[]) => {
+    const id = Number(args[0]);
+    if (method === 'get_credential') {
+      const cred = state.credentials[id];
+      if (!cred) throw new Error('CredentialNotFound');
+      return cred;
+    }
+    if (method === 'get_attestors') {
+      if (!(id in state.credentials)) throw new Error('CredentialNotFound');
+      return state.attestors[id] ?? [];
+    }
+    throw new Error(`Unexpected simulateCall method: ${method}`);
+  });
+}
 
-  it('creates a GDPR request with no attestors — immediately anonymized', async () => {
-    mockSimulateCall.mockResolvedValueOnce([]); // get_attestors returns empty
+function signConsent(keypair: Keypair, requestId: string, credentialId: number): string {
+  const message = Buffer.from(buildConsentMessage(requestId, credentialId, keypair.publicKey()), 'utf8');
+  return keypair.sign(message).toString('hex');
+}
+
+let dataRoot: string;
+let vault: PersonalDataVault;
+let requestStore: GdprRequestStore;
+let app: express.Express;
+
+beforeEach(() => {
+  mockSimulateCall.mockReset();
+  dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gdpr-router-test-'));
+  vault = new PersonalDataVault({ dataDir: path.join(dataRoot, 'vault') });
+  requestStore = new GdprRequestStore({ dataDir: path.join(dataRoot, 'requests') });
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/gdpr', createGdprRouter(mockSoroban, { vault, requestStore }));
+});
+
+afterEach(() => {
+  fs.rmSync(dataRoot, { recursive: true, force: true });
+});
+
+describe('POST /api/gdpr/personal-data', () => {
+  it('stores personal data off-chain and returns a commitment hash, not the data', async () => {
+    mockChain({ credentials: { 1: { subject: 'GSUBJECT1' } }, attestors: {} });
 
     const res = await request(app)
-      .post('/api/gdpr/request')
-      .send({ credentialId: 1 });
+      .post('/api/gdpr/personal-data')
+      .send({ credentialId: 1, subject: 'GSUBJECT1', personalData: { name: 'Ada Lovelace' } });
+
+    expect(res.status).toBe(201);
+    expect(res.body.commitment).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.stringify(res.body)).not.toContain('Ada Lovelace');
+  });
+
+  it('returns 404 when the credential does not exist on-chain', async () => {
+    mockChain({ credentials: {}, attestors: {} });
+
+    const res = await request(app)
+      .post('/api/gdpr/personal-data')
+      .send({ credentialId: 99, subject: 'GX', personalData: { a: 1 } });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when subject does not match the on-chain credential subject', async () => {
+    mockChain({ credentials: { 1: { subject: 'GREAL' } }, attestors: {} });
+
+    const res = await request(app)
+      .post('/api/gdpr/personal-data')
+      .send({ credentialId: 1, subject: 'GIMPOSTER', personalData: { a: 1 } });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for missing fields', async () => {
+    const res = await request(app).post('/api/gdpr/personal-data').send({ credentialId: 1 });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /api/gdpr/personal-data/:credentialId', () => {
+  it('returns 404 when no data was ever stored', async () => {
+    const res = await request(app).get('/api/gdpr/personal-data/123');
+    expect(res.status).toBe(404);
+  });
+
+  it('decrypts and returns the stored personal data', async () => {
+    vault.store(2, 'GSUBJECT2', { email: 'ada@example.com' });
+
+    const res = await request(app).get('/api/gdpr/personal-data/2');
+    expect(res.status).toBe(200);
+    expect(res.body.personalData).toEqual({ email: 'ada@example.com' });
+  });
+
+  it('returns status metadata without ever decrypting', async () => {
+    vault.store(3, 'GSUBJECT3', { ssn: '123-45-6789' });
+
+    const res = await request(app).get('/api/gdpr/personal-data/3/status');
+    expect(res.status).toBe(200);
+    expect(res.body.hasData).toBe(true);
+    expect(res.body.erased).toBe(false);
+    expect(JSON.stringify(res.body)).not.toContain('123-45-6789');
+  });
+});
+
+describe('POST /api/gdpr/request', () => {
+  it('creates a GDPR request with no attestors — immediately anonymized via real key destruction', async () => {
+    mockChain({ credentials: { 1: { subject: 'GSUBJECT1' } }, attestors: { 1: [] } });
+    vault.store(1, 'GSUBJECT1', { name: 'Ada Lovelace' });
+
+    const res = await request(app).post('/api/gdpr/request').send({ credentialId: 1 });
 
     expect(res.status).toBe(201);
     expect(res.body.credentialId).toBe(1);
     expect(res.body.status).toBe('anonymized');
     expect(res.body.requestId).toMatch(/^gdpr_/);
+    expect(res.body.erasedAt).toBeTruthy();
+    expect(res.body.vault.erased).toBe(true);
+
+    // Not just a status flag: the underlying data is genuinely gone.
+    const dataRes = await request(app).get('/api/gdpr/personal-data/1');
+    expect(dataRes.status).toBe(410);
   });
 
-  it('creates a pending request when attestors exist', async () => {
-    mockSimulateCall.mockResolvedValueOnce(['GATT1', 'GATT2']); // two attestors
+  it('creates a pending request when attestors exist, and does not touch the key yet', async () => {
+    mockChain({ credentials: { 2: { subject: 'GSUBJECT2' } }, attestors: { 2: ['GATT1', 'GATT2'] } });
+    vault.store(2, 'GSUBJECT2', { name: 'Grace Hopper' });
 
-    const res = await request(app)
-      .post('/api/gdpr/request')
-      .send({ credentialId: 2 });
+    const res = await request(app).post('/api/gdpr/request').send({ credentialId: 2 });
 
     expect(res.status).toBe(201);
     expect(res.body.status).toBe('pending_consent');
     expect(res.body.requiredConsents).toBe(2);
+    expect(res.body.vault.erased).toBe(false);
+
+    const dataRes = await request(app).get('/api/gdpr/personal-data/2');
+    expect(dataRes.status).toBe(200);
   });
 
   it('returns 400 for non-integer credentialId', async () => {
-    const res = await request(app)
-      .post('/api/gdpr/request')
-      .send({ credentialId: 'abc' });
+    const res = await request(app).post('/api/gdpr/request').send({ credentialId: 'abc' });
     expect(res.status).toBe(400);
   });
 
-  it('returns 404 when get_attestors and get_credential both fail', async () => {
-    mockSimulateCall
-      .mockRejectedValueOnce(new Error('not found')) // get_attestors
-      .mockRejectedValueOnce(new Error('not found')); // get_credential fallback
-    const res = await request(app)
-      .post('/api/gdpr/request')
-      .send({ credentialId: 999 });
+  it('returns 404 when the credential does not exist on-chain', async () => {
+    mockChain({ credentials: {}, attestors: {} });
+    const res = await request(app).post('/api/gdpr/request').send({ credentialId: 999 });
     expect(res.status).toBe(404);
+  });
+
+  it('returns 500 when the attestor set cannot be determined for an existing credential', async () => {
+    mockSimulateCall.mockImplementation(async (method: string, args: any[]) => {
+      if (method === 'get_credential') return { subject: 'GSUBJECT5' };
+      if (method === 'get_attestors') throw new Error('simulation failed');
+      throw new Error('unexpected');
+    });
+
+    const res = await request(app).post('/api/gdpr/request').send({ credentialId: 5 });
+    expect(res.status).toBe(500);
   });
 });
 
 describe('GET /api/gdpr/request/:requestId', () => {
-  beforeEach(() => mockSimulateCall.mockReset());
-
   it('returns 404 for unknown request ID', async () => {
     const res = await request(app).get('/api/gdpr/request/gdpr_unknown');
     expect(res.status).toBe(404);
   });
 
-  it('returns the request record for a known ID', async () => {
-    mockSimulateCall.mockResolvedValueOnce([]);
-    const createRes = await request(app)
-      .post('/api/gdpr/request')
-      .send({ credentialId: 10 });
+  it('returns the request record, including vault status, for a known ID', async () => {
+    mockChain({ credentials: { 10: { subject: 'GSUBJECT10' } }, attestors: { 10: [] } });
+    const createRes = await request(app).post('/api/gdpr/request').send({ credentialId: 10 });
     const { requestId } = createRes.body;
 
     const res = await request(app).get(`/api/gdpr/request/${requestId}`);
     expect(res.status).toBe(200);
     expect(res.body.requestId).toBe(requestId);
+    expect(res.body.vault).toBeDefined();
   });
 });
 
 describe('POST /api/gdpr/consent', () => {
+  let attestor1: Keypair;
+  let attestor2: Keypair;
+  let outsider: Keypair;
   let requestId: string;
+  const credentialId = 5;
 
   beforeEach(async () => {
-    mockSimulateCall.mockReset();
-    mockSimulateCall.mockResolvedValueOnce(['GATT1', 'GATT2']);
-    const res = await request(app)
-      .post('/api/gdpr/request')
-      .send({ credentialId: 5 });
+    attestor1 = Keypair.random();
+    attestor2 = Keypair.random();
+    outsider = Keypair.random();
+
+    mockChain({
+      credentials: { [credentialId]: { subject: 'GSUBJECT5' } },
+      attestors: { [credentialId]: [attestor1.publicKey(), attestor2.publicKey()] },
+    });
+    vault.store(credentialId, 'GSUBJECT5', { name: 'Confidential Holder' });
+
+    const res = await request(app).post('/api/gdpr/request').send({ credentialId });
     requestId = res.body.requestId;
   });
 
-  it('records consent and advances status when threshold reached', async () => {
+  it('records a validly signed consent and advances status once threshold is reached', async () => {
+    const sig1 = signConsent(attestor1, requestId, credentialId);
+    const first = await request(app)
+      .post('/api/gdpr/consent')
+      .send({ requestId, attestorAddress: attestor1.publicKey(), signature: sig1 });
+    expect(first.status).toBe(200);
+    expect(first.body.status).toBe('pending_consent');
+    expect(first.body.attestorConsents).toHaveLength(1);
+
+    const sig2 = signConsent(attestor2, requestId, credentialId);
+    const second = await request(app)
+      .post('/api/gdpr/consent')
+      .send({ requestId, attestorAddress: attestor2.publicKey(), signature: sig2 });
+
+    expect(second.status).toBe(200);
+    expect(second.body.status).toBe('anonymized');
+    expect(second.body.attestorConsents).toHaveLength(2);
+    expect(second.body.erasedAt).toBeTruthy();
+
+    const dataRes = await request(app).get('/api/gdpr/personal-data/5');
+    expect(dataRes.status).toBe(410);
+  });
+
+  it('rejects consent missing a signature', async () => {
+    const res = await request(app)
+      .post('/api/gdpr/consent')
+      .send({ requestId, attestorAddress: attestor1.publicKey() });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects consent for an unknown requestId', async () => {
+    const sig = signConsent(attestor1, 'gdpr_nope', credentialId);
+    const res = await request(app)
+      .post('/api/gdpr/consent')
+      .send({ requestId: 'gdpr_nope', attestorAddress: attestor1.publicKey(), signature: sig });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an address that is not a current attestor for the credential', async () => {
+    const sig = signConsent(outsider, requestId, credentialId);
+    const res = await request(app)
+      .post('/api/gdpr/consent')
+      .send({ requestId, attestorAddress: outsider.publicKey(), signature: sig });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects a syntactically valid but forged signature (signed by the wrong key)', async () => {
+    // outsider signs, but claims to be attestor1 — the classic "raw address string" attack
+    // this system is specifically designed to prevent.
+    const forgedSig = signConsent(outsider, requestId, credentialId);
+    const res = await request(app)
+      .post('/api/gdpr/consent')
+      .send({ requestId, attestorAddress: attestor1.publicKey(), signature: forgedSig });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects garbage signature input', async () => {
+    const res = await request(app)
+      .post('/api/gdpr/consent')
+      .send({ requestId, attestorAddress: attestor1.publicKey(), signature: 'not-hex-at-all' });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a signature bound to a different requestId (no replay across requests)', async () => {
+    const sigForOtherRequest = signConsent(attestor1, 'gdpr_other', credentialId);
+    const res = await request(app)
+      .post('/api/gdpr/consent')
+      .send({ requestId, attestorAddress: attestor1.publicKey(), signature: sigForOtherRequest });
+    expect(res.status).toBe(401);
+  });
+
+  it('is idempotent for a repeated consent from the same attestor', async () => {
+    const sig1 = signConsent(attestor1, requestId, credentialId);
     await request(app)
       .post('/api/gdpr/consent')
-      .send({ requestId, attestorAddress: 'GATT1' });
-
-    const res = await request(app)
+      .send({ requestId, attestorAddress: attestor1.publicKey(), signature: sig1 });
+    const again = await request(app)
       .post('/api/gdpr/consent')
-      .send({ requestId, attestorAddress: 'GATT2' });
+      .send({ requestId, attestorAddress: attestor1.publicKey(), signature: sig1 });
 
-    expect(res.status).toBe(200);
-    expect(res.body.status).toBe('anonymized');
-    expect(res.body.attestorConsents).toHaveLength(2);
+    expect(again.status).toBe(200);
+    expect(again.body.attestorConsents).toHaveLength(1);
   });
 
-  it('returns 400 for unknown requestId', async () => {
+  it('rejects consent once the request is already anonymized', async () => {
+    const sig1 = signConsent(attestor1, requestId, credentialId);
+    const sig2 = signConsent(attestor2, requestId, credentialId);
+    await request(app).post('/api/gdpr/consent').send({ requestId, attestorAddress: attestor1.publicKey(), signature: sig1 });
+    await request(app).post('/api/gdpr/consent').send({ requestId, attestorAddress: attestor2.publicKey(), signature: sig2 });
+
+    const sig1Again = signConsent(attestor1, requestId, credentialId);
     const res = await request(app)
       .post('/api/gdpr/consent')
-      .send({ requestId: 'gdpr_nope', attestorAddress: 'GATT1' });
+      .send({ requestId, attestorAddress: attestor1.publicKey(), signature: sig1Again });
+
     expect(res.status).toBe(400);
   });
+});
 
-  it('returns 400 when attestorAddress is missing', async () => {
-    const res = await request(app)
+describe('durability across a simulated restart', () => {
+  it('GDPR request state and key destruction both survive re-loading from the same data directory', async () => {
+    const attestor1 = Keypair.random();
+    mockChain({
+      credentials: { 20: { subject: 'GSUBJECT20' } },
+      attestors: { 20: [attestor1.publicKey()] },
+    });
+    vault.store(20, 'GSUBJECT20', { secret: 'restart-me' });
+
+    const createRes = await request(app).post('/api/gdpr/request').send({ credentialId: 20 });
+    const { requestId } = createRes.body;
+
+    const sig = signConsent(attestor1, requestId, 20);
+    const consentRes = await request(app)
       .post('/api/gdpr/consent')
-      .send({ requestId });
-    expect(res.status).toBe(400);
+      .send({ requestId, attestorAddress: attestor1.publicKey(), signature: sig });
+    expect(consentRes.body.status).toBe('anonymized');
+
+    // Simulate a process restart: brand-new store/vault instances reading the same directory.
+    const restartedVault = new PersonalDataVault({ dataDir: path.join(dataRoot, 'vault') });
+    const restartedRequestStore = new GdprRequestStore({ dataDir: path.join(dataRoot, 'requests') });
+    const restartedApp = express();
+    restartedApp.use(express.json());
+    restartedApp.use(
+      '/api/gdpr',
+      createGdprRouter(mockSoroban, { vault: restartedVault, requestStore: restartedRequestStore })
+    );
+
+    const statusRes = await request(restartedApp).get(`/api/gdpr/request/${requestId}`);
+    expect(statusRes.status).toBe(200);
+    expect(statusRes.body.status).toBe('anonymized');
+    expect(statusRes.body.vault.erased).toBe(true);
+
+    const dataRes = await request(restartedApp).get('/api/gdpr/personal-data/20');
+    expect(dataRes.status).toBe(410);
+
+    // New request IDs keep incrementing rather than colliding with pre-restart IDs.
+    mockChain({ credentials: { 21: { subject: 'GSUBJECT21' } }, attestors: { 21: [] } });
+    const nextRes = await request(restartedApp).post('/api/gdpr/request').send({ credentialId: 21 });
+    expect(nextRes.body.requestId).not.toBe(requestId);
   });
 });

--- a/docs/crypto-shredding-architecture.md
+++ b/docs/crypto-shredding-architecture.md
@@ -1,0 +1,218 @@
+# Crypto-Shredding Architecture
+
+## Status
+
+Accepted — implemented in `api-server/src/services/cryptoShredding.ts`,
+`api-server/src/services/durableLog.ts`, and wired into
+`api-server/src/routes/gdpr.ts`.
+
+## Problem
+
+[ADR-002](adr/adr-002-sbt-non-transferability.md) establishes that QuorumProof
+credentials live on an immutable ledger by design: the SBT contract has no
+`transfer()` and, more fundamentally, Soroban/Stellar ledger history cannot be
+rewritten. GDPR Article 17 ("right to erasure") nonetheless requires that a
+data subject be able to have their personal data made permanently
+inaccessible on request.
+
+These two requirements are irreconcilable if "personal data" is interpreted
+as "data stored on-chain." They are reconcilable once the system is designed
+so that:
+
+1. Personal data never lives on-chain in the first place — only a
+   content-addressed commitment to it does.
+2. Personal data lives off-chain, encrypted, such that erasure is defined as
+   destroying the means of decryption rather than deleting bytes.
+
+This is **crypto-shredding**: instead of promising "the bytes are gone" (a
+promise the ledger cannot keep, and that ordinary filesystem deletion cannot
+fully keep either), the system promises "the bytes are permanently
+unintelligible," by making sure the only key that could ever decrypt them no
+longer exists anywhere.
+
+## On-chain vs. off-chain split
+
+This split already exists structurally in the QuorumProof contract: credentials
+carry a `metadata_hash: Bytes` field (`contracts/quorum_proof/src/lib.rs`),
+not the metadata itself. What was missing was the off-chain half — anything
+that actually stored personal data, encrypted or not, and a real mechanism to
+render it inaccessible. That is what this document and its implementation
+add.
+
+| | On-chain (Soroban ledger) | Off-chain (`PersonalDataVault`) |
+|---|---|---|
+| Contents | `metadata_hash` — a sha256 commitment | Ciphertext of the actual personal data |
+| Mutability | Append-only, immutable | Ciphertext keyed by credential; DEK is separately keyed and independently destructible |
+| Survives erasure | Yes — the hash remains forever, as evidence of what *was* attested to, without revealing it | Ciphertext bytes may remain on disk; they become permanently unintelligible |
+
+The commitment is computed with the same primitive the ledger already
+expects (`sha256` over the plaintext), so an issuer can pass
+`PersonalDataVault#store()`'s returned `commitment` directly as the
+`metadata_hash` argument to `issue_credential`. This means credential
+integrity stays verifiable — anyone can recompute the hash of a still-decryptable
+record and compare it to on-chain state — while the ledger itself never
+carries anything erasure could need to touch.
+
+## Key management
+
+- **Granularity**: one Data Encryption Key (DEK) per credential ID. A GDPR
+  erasure request in this system is scoped to a single credential (matching
+  the existing `/api/gdpr/request` API, which takes a `credentialId`), so key
+  granularity matches request granularity. A subject with multiple
+  credentials who wants all of them erased submits one request per
+  credential.
+- **Algorithm**: AES-256-GCM. The DEK is 32 random bytes
+  (`crypto.randomBytes(32)`), generated on first write for a given credential
+  and reused for subsequent updates to the same credential's data.
+- **Storage**: the DEK is held in its own durable append-only log
+  (`keys.jsonl`), physically separate from the ciphertext log
+  (`ciphertext.jsonl`). There is no master key, no KMS-wrapped envelope, and
+  no backup copy of a DEK anywhere else in the system — the DEK *is* the
+  root of trust for that credential's personal data, by design, so that
+  destroying the one copy is sufficient for erasure.
+
+## Erasure mechanism
+
+Erasure (`PersonalDataVault#eraseKey`) does the following, in order:
+
+1. Checks whether the credential's key has already been erased (idempotent —
+   re-erasing returns `alreadyErased: true` rather than erroring).
+2. Calls `DurableLog#shred(credentialId)` on the key log, which:
+   - Removes the key from the in-memory map.
+   - Overwrites the **entire on-disk key log file** with zero bytes before
+     rewriting it, so no byte range of the file that used to hold this (or
+     any other) DEK survives the operation unmodified.
+   - Recompacts the file to contain only the DEKs for credentials that have
+     *not* been erased.
+3. Durably records an erasure tombstone (`{ erasedAt }`) in a third log
+   (`erasures.jsonl`), keyed by credential ID. This tombstone is what makes
+   `isErased()` — and therefore the "no, you cannot have this back" answer —
+   itself durable and independent of whether the key log still exists.
+
+After this, `PersonalDataVault#retrieve(credentialId)` unconditionally throws
+`KeyDestroyedError`. There is no code path — not an admin override, not a
+recovery key, not a support tool — that can produce a valid AES-256-GCM key
+for that credential ID again. The only way to obtain plaintext again is for
+the subject to submit new personal data under a new key.
+
+### What "unrecoverable" means precisely here
+
+- The ciphertext (ideally, deliberately) is **not** deleted. It typically
+  stays on disk as an audit artifact: proof that data was once stored and
+  then genuinely rendered unreadable, plus its commitment hash for
+  cross-referencing against on-chain state.
+- Without the DEK, AES-256-GCM ciphertext is computationally infeasible to
+  decrypt (this is the standard cryptographic assumption underlying
+  crypto-shredding as a GDPR-erasure technique, e.g. as used by cloud KMS
+  "schedule key deletion" features).
+- This implementation's guarantee is scoped to **application-level
+  unrecoverability**: `shred()` overwrites the *current* file with zeros
+  before rewriting it. It does not attempt to defeat filesystem-level or
+  storage-level copy-on-write, journaling, snapshotting, or backup systems
+  that may have captured earlier versions of the key log file outside the
+  application's control. Deployments that need a stronger physical guarantee
+  should back the key log with storage that supports genuine secure erase
+  (e.g. an HSM-backed KMS with key-deletion primitives) rather than a plain
+  filesystem — the `PersonalDataVault` interface (`store` / `retrieve` /
+  `eraseKey` / `status`) is designed so that swap is possible without
+  changing any caller.
+
+## What remains verifiable vs. what becomes inaccessible post-erasure
+
+This is the precise contract callers (and auditors, and data subjects) can
+rely on after `eraseKey(credentialId)` has run:
+
+**Remains verifiable / accessible forever:**
+- That a GDPR request for this credential was made, when, and by the resolved
+  flow (`GdprRequestStore` — durable, never erased).
+- Which attestors consented, and when (`attestorConsents[].consentedAt`) —
+  the consent records themselves are not personal data about the credential
+  subject and are retained for audit.
+- That personal data *was* stored for this credential, and when
+  (`PersonalDataVault#status().hasData`, `.storedAt`, `.updatedAt`).
+- The commitment hash of the erased data (`PersonalDataVault#status().commitment`)
+  — sufficient to prove "this specific plaintext was once attested to" if a
+  copy is ever produced independently (e.g. in a legal dispute), without the
+  vault itself ever revealing it.
+- That erasure occurred, and precisely when
+  (`PersonalDataVault#status().erased`, `.erasedAt`).
+- The on-chain `metadata_hash` for the credential, unchanged, forever (ledger
+  immutability — this was always true and is unaffected by this design).
+
+**Becomes permanently inaccessible:**
+- The plaintext personal data itself. `PersonalDataVault#retrieve()` throws
+  `KeyDestroyedError` for this credential ID, permanently, including after a
+  process restart (the erasure tombstone is durable) and including for a
+  freshly constructed `PersonalDataVault` pointed at the same data directory.
+- The DEK. It cannot be reconstructed from the ciphertext, the commitment
+  hash, or any other durably stored value in this system.
+
+## Durability across restarts
+
+Three independent `DurableLog` instances back the vault
+(`ciphertext.jsonl`, `keys.jsonl`, `erasures.jsonl`), plus one for GDPR
+request state (`requests.jsonl`, via `GdprRequestStore`). Each is an
+append-only JSONL write-ahead log: every `set`/`delete`/`shred` call appends
+a line and `fsync`s before returning, and a fresh instance replays the whole
+file on construction to rebuild its in-memory map (tolerating a torn last
+line from a crash mid-append). This means:
+
+- A GDPR request's status, consents, and outcome survive an API server
+  restart.
+- An erasure tombstone survives a restart — erased stays erased.
+- Request IDs (`gdpr_<n>`) remain monotonically increasing across restarts;
+  `GdprRequestStore` recovers its counter from the highest ID present in the
+  log on load.
+
+Data directories default to `./.data/gdpr-vault` and `./.data/gdpr-requests`
+under the process's working directory, and are configurable via
+`GDPR_VAULT_DATA_DIR` and `GDPR_REQUEST_STORE_DATA_DIR` respectively —
+following the same environment-variable convention as
+`SHARD_STORE_DATA_DIR` in `services/shardedStorage.ts`.
+
+## Attestor consent: real signatures, not a raw address count
+
+Prior to this design, `/api/gdpr/consent` counted unique attestor address
+*strings* submitted in a request body, with no verification that:
+
+- the address actually belonged to a current attestor for the credential
+  (`get_attestors` was only ever consulted once, at request-creation time,
+  to compute a *count* — never to check *membership* of a consenting
+  address), or
+- the party submitting the address had any cryptographic relationship to it
+  at all.
+
+This meant any caller who knew (or guessed) enough distinct-looking strings
+could complete an erasure. The fix (`services/attestorConsent.ts`):
+
+1. Each consent submission must include a hex-encoded ed25519 signature over
+   a canonical message binding the request ID, credential ID, and the
+   signer's own address:
+   `QuorumProof GDPR Erasure Consent\nrequestId:<id>\ncredentialId:<id>\nattestor:<address>`.
+2. The server re-fetches `get_attestors` for the credential **at consent
+   time** (not reusing the snapshot from request creation) and rejects any
+   `attestorAddress` that is not currently a member.
+3. The signature is verified with `Keypair.fromPublicKey(attestorAddress).verify(...)`
+   from `@stellar/stellar-sdk` — the same ed25519 primitive Stellar accounts
+   already use, so an attestor's existing Stellar keypair is sufficient; no
+   new key material needs to be provisioned.
+
+Binding the message to both `requestId` and `credentialId` prevents a
+signature collected for one erasure request from being replayed against a
+different request or a different credential.
+
+## Known limitations / future work
+
+- Key granularity is per-credential, not per-subject. A subject with `N`
+  credentials must submit `N` erasure requests. A subject-level "erase
+  everything" endpoint could fan out to each credential's key, but is not
+  implemented here — it wasn't part of the existing GDPR API surface this
+  change builds on.
+- `GET /api/gdpr/personal-data/:credentialId` (plaintext retrieval) has no
+  authorization check in this implementation. Production deployments must
+  gate it the same way `routes/consent.ts` gates verifier access, before
+  this route is exposed publicly.
+- `shred()`'s zero-overwrite is a best-effort, application-level guarantee
+  (see "What unrecoverable means precisely" above) — it is not a substitute
+  for disk-level secure erase or an HSM-backed KMS in a production
+  deployment handling regulated personal data at scale.

--- a/docs/gdpr-compliance.md
+++ b/docs/gdpr-compliance.md
@@ -28,6 +28,16 @@ This document outlines QuorumProof's approach to GDPR compliance, including data
 
 ## Right to Be Forgotten (Data Deletion)
 
+> **Implementation note:** because credential data is anchored to an
+> immutable ledger (see [ADR-002](adr/adr-002-sbt-non-transferability.md)),
+> "deletion" for credential personal data is implemented as crypto-shredding
+> — off-chain encrypted storage with per-credential key destruction — rather
+> than literal byte deletion. See
+> [docs/crypto-shredding-architecture.md](crypto-shredding-architecture.md)
+> for the precise mechanism and what remains verifiable vs. inaccessible
+> after erasure. The pseudocode below describes the conceptual flow; the
+> real implementation is `api-server/src/routes/gdpr.ts`.
+
 ### Scope
 
 Users can request deletion of their personal data, subject to legal and contractual obligations.


### PR DESCRIPTION
## Summary

`api-server/src/routes/gdpr.ts`'s erasure flow was an in-memory `Map` of request objects whose status flipped to `anonymized` once enough "consents" (raw address strings pushed into an array) were collected — no code path ever touched the actual credential or metadata data, on-chain or off-chain. Given the ledger's immutability ([ADR-002](docs/adr/adr-002-sbt-non-transferability.md)), "erasure" needed a precise cryptographic meaning, not a status label.

- **Off-chain encrypted storage, on-chain commitment only** — `services/cryptoShredding.ts`'s `PersonalDataVault` encrypts personal data per-credential (AES-256-GCM) and returns a sha256 commitment matching the contract's existing `metadata_hash` on-chain model.
- **Genuine key destruction** — `eraseKey()` destroys the credential's DEK via `DurableLog#shred`, which zero-overwrites the on-disk key log before recompacting. Ciphertext becomes permanently unrecoverable, including to the operator.
- **First-class spec** — [`docs/crypto-shredding-architecture.md`](docs/crypto-shredding-architecture.md) documents the on-chain/off-chain split, key lifecycle, and precisely what remains verifiable (existence, timestamps, commitment, on-chain hash) vs. what becomes permanently inaccessible (plaintext, DEK) post-erasure.
- **Real attestor consent** — `services/attestorConsent.ts` requires a hex-encoded ed25519 signature over a canonical message binding `requestId` + `credentialId` + signer address, verified against a *live* `get_attestors` call — not a raw address-string count.
- **Durable state** — GDPR request/consent state and the vault survive restarts via an append-only WAL (`services/durableLog.ts`, `gdprRequestStore.ts`).
- **Actually mounted** — `routes/gdpr.ts` was never wired into `index.ts`; it is now.
- **Tests prove unrecoverability, not a flag check** — new tests decrypt from a fresh vault instance loaded off disk post-erasure and scan raw vault files for the plaintext, confirming genuine absence.

## Test plan

- [x] `npx vitest run tests/cryptoShredding.test.ts tests/gdpr.test.ts` — 36/36 passing
- [x] Full `npx vitest run` — 429 passing; the 44 failing tests (`search-*`, `issuer`, `notifications`) are pre-existing on `main` and unrelated to this change (verified via `git stash`)
- [x] Confirmed no stray `.data/` directories are created merely by importing the module — default vault/store construction is lazy, only touching disk on first real request
- [x] `gdpr.test.ts` documents intentional consent-flow behavior changes in a top-of-file comment (signature now required; membership re-checked live; existence check now via `get_credential`)

## Known limitation (documented in the spec)

`GET /api/gdpr/personal-data/:credentialId` has no authorization check yet. Production deployments must gate it the same way `routes/consent.ts` gates verifier access before this route is exposed publicly — flagged explicitly in both the code and `docs/crypto-shredding-architecture.md`.

Closes #1074 