### PR TITLE
Add cross-instance WebSocket delivery via Redis pub/sub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,16 @@ BRIDGE_HMAC_SECRET=change-me-in-production
 ETH_TOPIC_CREDENTIAL_ISSUED=
 ETH_TOPIC_CREDENTIAL_REVOKED=
 
+# WebSocket cross-instance delivery (see docs/websocket-scaling.md)
+# Required when running more than one api-server replica; unset falls back
+# to same-process delivery only (fine for local dev, not for production).
+REDIS_URL=
+WS_INSTANCE_ID=
+WS_SEND_QUEUE_MAX_MESSAGES=200
+WS_SEND_QUEUE_MAX_BYTES=1000000
+WS_BACKPRESSURE_HIGH_WATER_MARK=1000000
+WS_DASHBOARD_BROADCAST_INTERVAL_MS=5000
+
 # Frontend configuration
 VITE_STELLAR_NETWORK=testnet
 VITE_STELLAR_RPC_URL=https://soroban-testnet.stellar.org

--- a/api-server/loadtest/wsLoadTest.ts
+++ b/api-server/loadtest/wsLoadTest.ts
@@ -1,0 +1,174 @@
+/**
+ * WebSocket load test: opens a large number of real client connections
+ * distributed across N real API server instances (separate processes) that
+ * share a real Redis pub/sub backend, then broadcasts events from one
+ * instance and measures delivery completeness and latency across every
+ * connection, regardless of which instance it landed on.
+ *
+ * Not run as part of `npm test` — it's a standalone script (see
+ * package.json's `loadtest:ws` script) because a 10k-connection run takes
+ * real time and resources that don't belong in the default CI test loop.
+ * Run it explicitly, and on a machine with a raised file-descriptor limit
+ * (`ulimit -n`) if targeting connection counts in the tens of thousands.
+ *
+ * Usage:
+ *   npm run loadtest:ws
+ *   WS_LOAD_CONNECTIONS=2000 WS_LOAD_INSTANCES=2 npm run loadtest:ws
+ *   WS_LOAD_REDIS_URL=redis://localhost:6379 npm run loadtest:ws   # reuse a running Redis instead of spawning one
+ */
+import { WebSocket } from 'ws';
+import {
+  startEphemeralRedis,
+  startHarnessInstance,
+  type RedisHandle,
+  type InstanceHandle,
+} from '../tests/helpers/wsCluster.js';
+
+const CONNECTIONS = parseInt(process.env.WS_LOAD_CONNECTIONS ?? '10000', 10);
+const INSTANCES = parseInt(process.env.WS_LOAD_INSTANCES ?? '3', 10);
+const EVENT_ROUNDS = parseInt(process.env.WS_LOAD_EVENTS ?? '20', 10);
+const LATENCY_SAMPLE_SIZE = Math.min(CONNECTIONS, parseInt(process.env.WS_LOAD_LATENCY_SAMPLE ?? '300', 10));
+const CONNECT_CONCURRENCY = parseInt(process.env.WS_LOAD_CONNECT_CONCURRENCY ?? '250', 10);
+const ROUND_SETTLE_MS = parseInt(process.env.WS_LOAD_ROUND_SETTLE_MS ?? '2000', 10);
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return NaN;
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, idx)];
+}
+
+async function connectAndSubscribe(baseUrl: string): Promise<WebSocket> {
+  const ws = new WebSocket(baseUrl.replace('http', 'ws') + '/ws');
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('connect timeout')), 20_000);
+    ws.once('open', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    ws.once('error', reject);
+  });
+  ws.send(JSON.stringify({ type: 'subscribe', filters: [] }));
+  return ws;
+}
+
+async function runWithConcurrency<T>(items: T[], concurrency: number, fn: (item: T, idx: number) => Promise<void>): Promise<void> {
+  let cursor = 0;
+  async function worker(): Promise<void> {
+    while (cursor < items.length) {
+      const idx = cursor++;
+      await fn(items[idx], idx);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
+}
+
+async function main(): Promise<void> {
+  console.log(
+    `WS load test: ${CONNECTIONS} connections across ${INSTANCES} instance(s), ${EVENT_ROUNDS} broadcast round(s), latency sampled from ${LATENCY_SAMPLE_SIZE} connection(s)`
+  );
+
+  const externalRedisUrl = process.env.WS_LOAD_REDIS_URL;
+  let redis: RedisHandle | null = null;
+  const redisUrl = externalRedisUrl ?? (redis = await startEphemeralRedis()).url;
+  console.log(`Redis: ${externalRedisUrl ? 'external ' + externalRedisUrl : redisUrl + ' (ephemeral)'}`);
+
+  const instances: InstanceHandle[] = [];
+  for (let i = 0; i < INSTANCES; i++) {
+    instances.push(await startHarnessInstance(redisUrl));
+  }
+  console.log(`Instances ready: ${instances.map((i) => i.port).join(', ')}`);
+
+  const sockets: WebSocket[] = new Array(CONNECTIONS);
+  const receivedPerRound = new Array(EVENT_ROUNDS).fill(0);
+  const latencySamplesPerRound: number[][] = Array.from({ length: EVENT_ROUNDS }, () => []);
+  const roundSentAt = new Array(EVENT_ROUNDS).fill(0);
+  let droppedConnections = 0;
+
+  const connectStart = Date.now();
+  await runWithConcurrency(
+    Array.from({ length: CONNECTIONS }, (_, i) => i),
+    CONNECT_CONCURRENCY,
+    async (i) => {
+      const inst = instances[i % instances.length];
+      try {
+        const ws = await connectAndSubscribe(inst.baseUrl);
+        const sampled = i < LATENCY_SAMPLE_SIZE;
+        ws.on('message', (raw) => {
+          let msg: any;
+          try {
+            msg = JSON.parse(raw.toString());
+          } catch {
+            return;
+          }
+          if (msg.type !== 'credential_issued' || typeof msg.data?.credential_id !== 'number') return;
+          const round = msg.data.credential_id;
+          if (round < 0 || round >= EVENT_ROUNDS) return;
+          receivedPerRound[round]++;
+          if (sampled && roundSentAt[round]) {
+            latencySamplesPerRound[round].push(Date.now() - roundSentAt[round]);
+          }
+        });
+        ws.on('error', () => {
+          /* counted via final open-socket scan below */
+        });
+        sockets[i] = ws;
+      } catch (err) {
+        droppedConnections++;
+      }
+    }
+  );
+  const connectedCount = sockets.filter((s) => s && s.readyState === WebSocket.OPEN).length;
+  console.log(
+    `Connected ${connectedCount}/${CONNECTIONS} (${droppedConnections} failed to connect) in ${Date.now() - connectStart}ms`
+  );
+
+  // Let subscription_confirmed acks flush before we start measuring broadcast delivery.
+  await new Promise((r) => setTimeout(r, 500));
+
+  for (let round = 0; round < EVENT_ROUNDS; round++) {
+    roundSentAt[round] = Date.now();
+    const res = await fetch(`${instances[0].baseUrl}/trigger-all`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'credential_issued', credential_id: round, timestamp: new Date().toISOString() }),
+    });
+    if (!res.ok) throw new Error(`trigger-all failed on round ${round}: ${res.status}`);
+    await new Promise((r) => setTimeout(r, ROUND_SETTLE_MS));
+    console.log(`  round ${round}: ${receivedPerRound[round]}/${connectedCount} delivered so far`);
+  }
+
+  const allLatencies = latencySamplesPerRound.flat().sort((a, b) => a - b);
+  const totalExpected = connectedCount * EVENT_ROUNDS;
+  const totalReceived = receivedPerRound.reduce((a, b) => a + b, 0);
+
+  console.log('\n=== WS Load Test Report ===');
+  console.log(`Connections requested:  ${CONNECTIONS}`);
+  console.log(`Connections established: ${connectedCount}`);
+  console.log(`Instances:              ${INSTANCES}`);
+  console.log(`Broadcast rounds:       ${EVENT_ROUNDS}`);
+  console.log(`Delivery completeness:  ${totalReceived}/${totalExpected} (${((totalReceived / totalExpected) * 100).toFixed(2)}%)`);
+  if (allLatencies.length > 0) {
+    console.log(
+      `Latency (sampled, ms):  p50=${percentile(allLatencies, 50)} p95=${percentile(allLatencies, 95)} p99=${percentile(allLatencies, 99)} max=${allLatencies[allLatencies.length - 1]}`
+    );
+  }
+  console.log(`Peak RSS:               ${(process.memoryUsage().rss / 1024 / 1024).toFixed(1)} MB (this driver process only)`);
+
+  for (const ws of sockets) {
+    if (ws && ws.readyState === WebSocket.OPEN) ws.close();
+  }
+  await Promise.all(instances.map((i) => i.stop()));
+  if (redis) await redis.stop();
+
+  if (totalReceived !== totalExpected) {
+    console.error('\nFAIL: delivery was not 100% complete.');
+    process.exitCode = 1;
+  } else {
+    console.log('\nOK: every connection received every broadcast round.');
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/api-server/package-lock.json
+++ b/api-server/package-lock.json
@@ -12,6 +12,7 @@
         "ajv": "^8.20.0",
         "compression": "^1.8.1",
         "express": "^4.21.2",
+        "ioredis": "^5.11.1",
         "ws": "^8.21.0"
       },
       "devDependencies": {
@@ -467,6 +468,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+      "license": "MIT"
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
@@ -1467,6 +1474,15 @@
         "node": "*"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1645,6 +1661,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -2295,6 +2320,51 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ioredis": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
+      "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.10.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "redis-parser": "3.0.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ioredis/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -2840,6 +2910,27 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3133,6 +3224,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
     "node_modules/statuses": {

--- a/api-server/package.json
+++ b/api-server/package.json
@@ -8,13 +8,15 @@
     "build": "tsc --noEmit false 2>&1 || true",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
-    "test": "vitest --run"
+    "test": "vitest --run",
+    "loadtest:ws": "tsx loadtest/wsLoadTest.ts"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^14.6.1",
     "ajv": "^8.20.0",
     "compression": "^1.8.1",
     "express": "^4.21.2",
+    "ioredis": "^5.11.1",
     "ws": "^8.21.0"
   },
   "devDependencies": {

--- a/api-server/src/index.ts
+++ b/api-server/src/index.ts
@@ -22,7 +22,7 @@ import { createDDoSProtection } from './middleware/ddosProtection.js';
 import { createRequestSigning } from './middleware/requestSigning.js';
 import { createWsServer } from './ws/server.js';
 import { getSubscriberCount } from './ws/subscriptions.js';
-import { getWsMetrics } from './ws/metrics.js';
+import { getWsMetrics, getWsMetricsPrometheus } from './ws/metrics.js';
 import { broadcastEvent, getConnectionCount } from './ws/server.js';
 
 const app = express();
@@ -88,6 +88,14 @@ app.get('/health', (_req, res) => {
 
 app.get('/ws/metrics', (_req, res) => {
   res.json(getWsMetrics());
+});
+
+// Prometheus exposition, tagged with this instance's id — scrape every
+// replica and aggregate (e.g. sum(quorumproof_ws_connections)) to get
+// cluster-wide totals. See docs/websocket-scaling.md.
+app.get('/metrics/ws', (_req, res) => {
+  res.set('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
+  res.send(getWsMetricsPrometheus());
 });
 
 const PORT = parseInt(process.env.PORT ?? '3000', 10);

--- a/api-server/src/services/liveDashboard.ts
+++ b/api-server/src/services/liveDashboard.ts
@@ -1,6 +1,24 @@
-/** Sliding-window per-minute metrics for the real-time credential issuance dashboard. */
+/**
+ * Sliding-window per-minute metrics for the real-time credential issuance dashboard.
+ *
+ * Each instance's buckets are local. To keep the dashboard consistent across
+ * replicas, record*() calls notify an optional delta publisher (wired by
+ * ws/dashboardSync.ts to the pub/sub backbone in api-server/src/ws/pubsub.ts);
+ * other instances receive the delta and apply it via applyRemoteDelta(),
+ * which does NOT re-publish, so deltas don't loop.
+ */
 
 const WINDOW_MINUTES = 60;
+
+export type DashboardDeltaKind = 'issuance' | 'attestation' | 'api_error';
+
+export interface DashboardDelta {
+  kind: DashboardDeltaKind;
+  /** Only meaningful for kind 'attestation'. */
+  success?: boolean;
+}
+
+type DeltaPublisher = (delta: DashboardDelta) => void;
 
 interface MinuteBucket {
   minute: number;
@@ -22,6 +40,12 @@ export interface LiveDashboardStats {
 
 class LiveDashboardStore {
   private readonly buckets = new Map<number, MinuteBucket>();
+  private deltaPublisher: DeltaPublisher | null = null;
+
+  /** Wired once at startup by ws/dashboardSync.ts; a no-op in single-instance mode. */
+  setDeltaPublisher(fn: DeltaPublisher | null): void {
+    this.deltaPublisher = fn;
+  }
 
   private nowMinute(): number {
     return Math.floor(Date.now() / 60_000);
@@ -44,16 +68,36 @@ class LiveDashboardStore {
 
   recordIssuance(): void {
     this.getBucket(this.nowMinute()).issued++;
+    this.deltaPublisher?.({ kind: 'issuance' });
   }
 
   recordAttestation(success: boolean): void {
     const b = this.getBucket(this.nowMinute());
     if (success) b.attested++;
     else b.attestation_errors++;
+    this.deltaPublisher?.({ kind: 'attestation', success });
   }
 
   recordApiError(): void {
     this.getBucket(this.nowMinute()).api_errors++;
+    this.deltaPublisher?.({ kind: 'api_error' });
+  }
+
+  /** Applies a delta received from another instance. Never re-publishes. */
+  applyRemoteDelta(delta: DashboardDelta): void {
+    const b = this.getBucket(this.nowMinute());
+    switch (delta.kind) {
+      case 'issuance':
+        b.issued++;
+        break;
+      case 'attestation':
+        if (delta.success) b.attested++;
+        else b.attestation_errors++;
+        break;
+      case 'api_error':
+        b.api_errors++;
+        break;
+    }
   }
 
   getStats(): LiveDashboardStats {

--- a/api-server/src/ws/connectionQueue.ts
+++ b/api-server/src/ws/connectionQueue.ts
@@ -1,0 +1,119 @@
+/**
+ * Bounded per-connection send queue.
+ *
+ * Every outbound message (broadcasts, dashboard stats, control replies) is
+ * enqueued here rather than written to the socket directly, so one slow
+ * client can't block delivery to others and can't grow memory without bound.
+ *
+ * Backpressure/drop policy (deliberately simple, documented so it doesn't
+ * need re-discovering from behavior):
+ *   - Each connection gets its own FIFO queue, capped at WS_SEND_QUEUE_MAX_MESSAGES
+ *     messages (default 200) and WS_SEND_QUEUE_MAX_BYTES bytes (default 1 MiB),
+ *     whichever limit is hit first.
+ *   - When a new message would exceed either cap, the OLDEST queued message is
+ *     dropped to make room. This is a "latest wins" policy: for a real-time
+ *     status feed, a fresh event is more useful to a lagging client than a
+ *     stale one, and clients should treat the feed as best-effort, reconciling
+ *     via a REST fetch on reconnect (see useRealtimeUpdates.ts) rather than
+ *     relying on every message arriving.
+ *   - Every drop increments the `messagesDropped` metric (ws/metrics.ts) so
+ *     operators can see when clients are falling behind.
+ *   - The queue also respects the underlying socket's own buffered bytes
+ *     (ws.bufferedAmount): while it's above WS_BACKPRESSURE_HIGH_WATER_MARK
+ *     bytes, draining pauses briefly rather than piling more onto the OS
+ *     socket buffer.
+ */
+import { WebSocket } from 'ws';
+import { recordMessageSent, recordMessageDropped, recordError } from './metrics.js';
+
+const MAX_QUEUE_MESSAGES = parseInt(process.env.WS_SEND_QUEUE_MAX_MESSAGES ?? '200', 10);
+const MAX_QUEUE_BYTES = parseInt(process.env.WS_SEND_QUEUE_MAX_BYTES ?? String(1_000_000), 10);
+const BACKPRESSURE_HIGH_WATER_MARK = parseInt(process.env.WS_BACKPRESSURE_HIGH_WATER_MARK ?? String(1_000_000), 10);
+const BACKPRESSURE_RETRY_MS = 10;
+
+interface QueuedItem {
+  data: string;
+  bytes: number;
+}
+
+export class ConnectionQueue {
+  private readonly queue: QueuedItem[] = [];
+  private queuedBytes = 0;
+  private draining = false;
+  private closed = false;
+
+  constructor(private readonly ws: WebSocket) {}
+
+  enqueue(data: string): void {
+    if (this.closed || this.ws.readyState !== WebSocket.OPEN) return;
+
+    const bytes = Buffer.byteLength(data);
+    while (
+      this.queue.length > 0 &&
+      (this.queue.length >= MAX_QUEUE_MESSAGES || this.queuedBytes + bytes > MAX_QUEUE_BYTES)
+    ) {
+      const dropped = this.queue.shift()!;
+      this.queuedBytes -= dropped.bytes;
+      recordMessageDropped();
+    }
+
+    this.queue.push({ data, bytes });
+    this.queuedBytes += bytes;
+    this.drain();
+  }
+
+  private drain(): void {
+    if (this.draining) return;
+    this.draining = true;
+
+    const step = (): void => {
+      if (this.closed || this.queue.length === 0 || this.ws.readyState !== WebSocket.OPEN) {
+        this.draining = false;
+        return;
+      }
+
+      if (this.ws.bufferedAmount > BACKPRESSURE_HIGH_WATER_MARK) {
+        setTimeout(step, BACKPRESSURE_RETRY_MS);
+        return;
+      }
+
+      const item = this.queue.shift()!;
+      this.queuedBytes -= item.bytes;
+      this.ws.send(item.data, (err?: Error) => {
+        if (err) {
+          recordError();
+        } else {
+          recordMessageSent(item.bytes);
+        }
+        step();
+      });
+    };
+
+    step();
+  }
+
+  close(): void {
+    this.closed = true;
+    this.queue.length = 0;
+    this.queuedBytes = 0;
+  }
+}
+
+const queues = new WeakMap<WebSocket, ConnectionQueue>();
+
+export function getConnectionQueue(ws: WebSocket): ConnectionQueue {
+  let q = queues.get(ws);
+  if (!q) {
+    q = new ConnectionQueue(ws);
+    queues.set(ws, q);
+  }
+  return q;
+}
+
+export function sendQueued(ws: WebSocket, data: string): void {
+  getConnectionQueue(ws).enqueue(data);
+}
+
+export function closeConnectionQueue(ws: WebSocket): void {
+  queues.get(ws)?.close();
+}

--- a/api-server/src/ws/dashboardSync.ts
+++ b/api-server/src/ws/dashboardSync.ts
@@ -1,0 +1,54 @@
+/**
+ * Cross-instance replication for the live dashboard (liveDashboard.ts).
+ *
+ * Every instance keeps its own local sliding-window buckets. When this
+ * instance records an issuance/attestation/error, the delta is also
+ * published on DASHBOARD_DELTA_CHANNEL; every instance (including this one's
+ * own subscription, which is skipped via instanceId) applies remote deltas
+ * to its local store. Dashboard subscribers therefore see an eventually
+ * consistent, cluster-wide view regardless of which instance they're
+ * connected to — the same filter/subscription model as ws/subscriptions.ts,
+ * just applied to aggregate stats instead of per-connection events.
+ */
+import type { PubSubBackend } from './pubsub.js';
+import { liveDashboard, type DashboardDelta } from '../services/liveDashboard.js';
+import { instanceId } from './instanceId.js';
+import { recordCrossInstanceMessageReceived, recordCrossInstanceMessagePublished } from './metrics.js';
+
+export const DASHBOARD_DELTA_CHANNEL = 'ws:dashboard-delta';
+
+interface DashboardDeltaEnvelope {
+  publishedBy: string;
+  delta: DashboardDelta;
+}
+
+let wired = false;
+
+export function initDashboardSync(backend: PubSubBackend): void {
+  if (wired) return;
+  wired = true;
+
+  liveDashboard.setDeltaPublisher((delta) => {
+    const envelope: DashboardDeltaEnvelope = { publishedBy: instanceId, delta };
+    backend.publish(DASHBOARD_DELTA_CHANNEL, JSON.stringify(envelope));
+    recordCrossInstanceMessagePublished();
+  });
+
+  backend.subscribe(DASHBOARD_DELTA_CHANNEL, (raw) => {
+    let envelope: DashboardDeltaEnvelope;
+    try {
+      envelope = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (envelope.publishedBy === instanceId) return; // already applied locally by recordX()
+    liveDashboard.applyRemoteDelta(envelope.delta);
+    recordCrossInstanceMessageReceived();
+  });
+}
+
+/** Test-only: undo initDashboardSync() wiring. */
+export function _resetDashboardSyncForTest(): void {
+  wired = false;
+  liveDashboard.setDeltaPublisher(null);
+}

--- a/api-server/src/ws/instanceId.ts
+++ b/api-server/src/ws/instanceId.ts
@@ -1,0 +1,12 @@
+/**
+ * Identifies this process among API server replicas. Used to tag pub/sub
+ * messages and metrics so cross-instance delivery can be distinguished from
+ * same-instance delivery, and so per-instance metrics can be aggregated.
+ *
+ * Set WS_INSTANCE_ID explicitly in deployments (e.g. to the pod name) so
+ * instance identity is stable and human-readable; otherwise a random id is
+ * generated per process.
+ */
+import { randomUUID } from 'crypto';
+
+export const instanceId: string = process.env.WS_INSTANCE_ID ?? randomUUID();

--- a/api-server/src/ws/metrics.ts
+++ b/api-server/src/ws/metrics.ts
@@ -1,4 +1,7 @@
+import { instanceId } from './instanceId.js';
+
 export interface WsMetrics {
+  instanceId: string;
   connections: number;
   peakConnections: number;
   subscribers: number;
@@ -7,9 +10,15 @@ export interface WsMetrics {
   errors: number;
   bytesSent: number;
   bytesReceived: number;
+  /** Messages dropped by a per-connection send queue hitting its bound (see connectionQueue.ts). */
+  messagesDropped: number;
+  /** Events this instance received from another instance via the pub/sub backbone. */
+  crossInstanceMessagesReceived: number;
+  /** Events this instance published for other instances to pick up. */
+  crossInstanceMessagesPublished: number;
 }
 
-const metrics: WsMetrics = {
+const metrics: Omit<WsMetrics, 'instanceId'> = {
   connections: 0,
   peakConnections: 0,
   subscribers: 0,
@@ -18,6 +27,9 @@ const metrics: WsMetrics = {
   errors: 0,
   bytesSent: 0,
   bytesReceived: 0,
+  messagesDropped: 0,
+  crossInstanceMessagesReceived: 0,
+  crossInstanceMessagesPublished: 0,
 };
 
 export function incrementConnections(): void {
@@ -49,8 +61,20 @@ export function recordError(): void {
   metrics.errors++;
 }
 
+export function recordMessageDropped(): void {
+  metrics.messagesDropped++;
+}
+
+export function recordCrossInstanceMessageReceived(): void {
+  metrics.crossInstanceMessagesReceived++;
+}
+
+export function recordCrossInstanceMessagePublished(): void {
+  metrics.crossInstanceMessagesPublished++;
+}
+
 export function getWsMetrics(): WsMetrics {
-  return { ...metrics };
+  return { instanceId, ...metrics };
 }
 
 export function resetWsMetrics(): void {
@@ -62,4 +86,44 @@ export function resetWsMetrics(): void {
   metrics.errors = 0;
   metrics.bytesSent = 0;
   metrics.bytesReceived = 0;
+  metrics.messagesDropped = 0;
+  metrics.crossInstanceMessagesReceived = 0;
+  metrics.crossInstanceMessagesPublished = 0;
+}
+
+/**
+ * Prometheus text exposition (v0.0.4) of this instance's WS metrics, tagged
+ * with an `instance` label so a Prometheus server scraping every replica can
+ * aggregate with e.g. `sum(quorumproof_ws_connections)` or
+ * `sum(rate(quorumproof_ws_messages_sent_total[5m]))`.
+ */
+export function getWsMetricsPrometheus(): string {
+  const m = getWsMetrics();
+  const label = `{instance="${m.instanceId}"}`;
+  const lines: string[] = [];
+
+  const gauge = (name: string, help: string, value: number) => {
+    lines.push(`# HELP ${name} ${help}`);
+    lines.push(`# TYPE ${name} gauge`);
+    lines.push(`${name}${label} ${value}`);
+  };
+  const counter = (name: string, help: string, value: number) => {
+    lines.push(`# HELP ${name} ${help}`);
+    lines.push(`# TYPE ${name} counter`);
+    lines.push(`${name}${label} ${value}`);
+  };
+
+  gauge('quorumproof_ws_connections', 'Current open WebSocket connections on this instance', m.connections);
+  gauge('quorumproof_ws_peak_connections', 'Peak open WebSocket connections observed on this instance', m.peakConnections);
+  gauge('quorumproof_ws_subscribers', 'Current active subscribers on this instance', m.subscribers);
+  counter('quorumproof_ws_messages_sent_total', 'Messages sent to clients by this instance', m.messagesSent);
+  counter('quorumproof_ws_messages_received_total', 'Messages received from clients by this instance', m.messagesReceived);
+  counter('quorumproof_ws_errors_total', 'WebSocket errors observed on this instance', m.errors);
+  counter('quorumproof_ws_bytes_sent_total', 'Bytes sent to clients by this instance', m.bytesSent);
+  counter('quorumproof_ws_bytes_received_total', 'Bytes received from clients by this instance', m.bytesReceived);
+  counter('quorumproof_ws_messages_dropped_total', 'Messages dropped due to a full per-connection send queue', m.messagesDropped);
+  counter('quorumproof_ws_cross_instance_messages_received_total', 'Events received from other instances via the pub/sub backbone', m.crossInstanceMessagesReceived);
+  counter('quorumproof_ws_cross_instance_messages_published_total', 'Events published for other instances via the pub/sub backbone', m.crossInstanceMessagesPublished);
+
+  return lines.join('\n') + '\n';
 }

--- a/api-server/src/ws/pubsub.ts
+++ b/api-server/src/ws/pubsub.ts
@@ -1,0 +1,101 @@
+/**
+ * Cross-instance pub/sub backbone for the WebSocket layer.
+ *
+ * In a single-replica deployment, in-process delivery is sufficient. Once
+ * api-server runs as more than one replica (see docs/websocket-scaling.md),
+ * an event observed by instance A must still reach a client connected to
+ * instance B. This module abstracts "publish an event so every instance's
+ * subscribers see it" behind a small interface so the transport (Redis today)
+ * can be swapped without touching ws/server.ts.
+ *
+ * Backend selection: REDIS_URL set -> RedisPubSubBackend (real cross-instance
+ * delivery). REDIS_URL unset -> InMemoryPubSubBackend (same-process only;
+ * fine for local dev and tests, but does NOT provide cross-instance delivery
+ * — do not run multiple replicas without REDIS_URL configured).
+ */
+import { Redis, type RedisOptions } from 'ioredis';
+import { EventEmitter } from 'events';
+
+export interface PubSubBackend {
+  /** Fire-and-forget: failures are logged, never thrown, so a broker outage never breaks local delivery. */
+  publish(channel: string, payload: string): void;
+  subscribe(channel: string, handler: (payload: string) => void): void;
+  close(): Promise<void>;
+}
+
+class InMemoryPubSubBackend implements PubSubBackend {
+  private readonly emitter = new EventEmitter();
+
+  constructor() {
+    this.emitter.setMaxListeners(0);
+  }
+
+  publish(channel: string, payload: string): void {
+    queueMicrotask(() => this.emitter.emit(channel, payload));
+  }
+
+  subscribe(channel: string, handler: (payload: string) => void): void {
+    this.emitter.on(channel, handler);
+  }
+
+  async close(): Promise<void> {
+    this.emitter.removeAllListeners();
+  }
+}
+
+class RedisPubSubBackend implements PubSubBackend {
+  private readonly pubClient: Redis;
+  private readonly subClient: Redis;
+  private readonly handlers = new Map<string, Set<(payload: string) => void>>();
+
+  constructor(url: string) {
+    const opts: RedisOptions = { maxRetriesPerRequest: 2 };
+    this.pubClient = new Redis(url, opts);
+    this.subClient = new Redis(url, opts);
+    this.pubClient.on('error', (err) => console.error('[ws:pubsub] publisher error:', err.message));
+    this.subClient.on('error', (err) => console.error('[ws:pubsub] subscriber error:', err.message));
+    this.subClient.on('message', (channel: string, payload: string) => {
+      const set = this.handlers.get(channel);
+      if (!set) return;
+      for (const handler of set) handler(payload);
+    });
+  }
+
+  publish(channel: string, payload: string): void {
+    this.pubClient.publish(channel, payload).catch((err: Error) => {
+      console.error(`[ws:pubsub] publish to ${channel} failed:`, err.message);
+    });
+  }
+
+  subscribe(channel: string, handler: (payload: string) => void): void {
+    let set = this.handlers.get(channel);
+    if (!set) {
+      set = new Set();
+      this.handlers.set(channel, set);
+      this.subClient.subscribe(channel).catch((err: Error) => {
+        console.error(`[ws:pubsub] subscribe to ${channel} failed:`, err.message);
+      });
+    }
+    set.add(handler);
+  }
+
+  async close(): Promise<void> {
+    await Promise.allSettled([this.pubClient.quit(), this.subClient.quit()]);
+  }
+}
+
+let backend: PubSubBackend | null = null;
+
+export function getPubSubBackend(): PubSubBackend {
+  if (!backend) {
+    const url = process.env.REDIS_URL;
+    backend = url ? new RedisPubSubBackend(url) : new InMemoryPubSubBackend();
+  }
+  return backend;
+}
+
+/** Test/ops hook — closes and clears the singleton so the next getPubSubBackend() call re-reads REDIS_URL. */
+export async function resetPubSubBackend(): Promise<void> {
+  if (backend) await backend.close();
+  backend = null;
+}

--- a/api-server/src/ws/server.ts
+++ b/api-server/src/ws/server.ts
@@ -23,7 +23,14 @@
  *   - Server-side ping/pong every 30s; clients unresponsive for >60s are terminated
  *
  * Endpoint: ws://<host>:<port>/ws
- * Metrics:  GET /ws/metrics
+ * Metrics:  GET /ws/metrics (JSON, this instance only), GET /metrics/ws (Prometheus, aggregable — see ws/metrics.ts)
+ *
+ * Multi-instance delivery: broadcastEvent/broadcastToAll deliver to this
+ * instance's connected clients synchronously (unchanged behavior/return
+ * value), then publish the event on the pub/sub backbone (ws/pubsub.ts) so
+ * every other instance's subscribers receive it too. See
+ * docs/websocket-scaling.md for the full architecture and the bounded
+ * per-connection send queue's backpressure/drop policy (ws/connectionQueue.ts).
  */
 import { Server as HttpServer } from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
@@ -41,6 +48,10 @@ import {
   type WsBroadcastEvent,
 } from './subscriptions.js';
 import { liveDashboard } from '../services/liveDashboard.js';
+import { getPubSubBackend, type PubSubBackend } from './pubsub.js';
+import { initDashboardSync } from './dashboardSync.js';
+import { instanceId } from './instanceId.js';
+import { sendQueued, closeConnectionQueue } from './connectionQueue.js';
 import {
   incrementConnections,
   decrementConnections,
@@ -48,6 +59,8 @@ import {
   recordMessageSent,
   recordMessageReceived,
   recordError,
+  recordCrossInstanceMessageReceived,
+  recordCrossInstanceMessagePublished,
   getWsMetrics as _getWsMetrics,
   type WsMetrics,
 } from './metrics.js';
@@ -58,7 +71,15 @@ interface WsClientMessage {
 }
 
 const PING_INTERVAL_MS = 30_000;
-const DASHBOARD_BROADCAST_INTERVAL_MS = 5_000;
+const DASHBOARD_BROADCAST_INTERVAL_MS = parseInt(process.env.WS_DASHBOARD_BROADCAST_INTERVAL_MS ?? '5000', 10);
+const EVENTS_CHANNEL = 'ws:events';
+
+interface EventEnvelope {
+  publishedBy: string;
+  publishedAt: number;
+  mode: 'filtered' | 'all';
+  event: WsBroadcastEvent;
+}
 
 function createMessage(type: string, data: Record<string, unknown>) {
   return JSON.stringify({ type, data });
@@ -67,8 +88,80 @@ function createMessage(type: string, data: Record<string, unknown>) {
 let wss: WebSocketServer | null = null;
 let pingTimer: ReturnType<typeof setInterval> | null = null;
 let dashboardTimer: ReturnType<typeof setInterval> | null = null;
+let pubsub: PubSubBackend | null = null;
+
+/** Delivers to this instance's matching subscribers only. Returns recipient count. */
+function deliverLocally(event: WsBroadcastEvent): number {
+  const message = createMessage(event.type, {
+    credential_id: event.credential_id,
+    issuer: event.issuer,
+    holder: event.holder,
+    attestor: event.attestor,
+    proof_request_id: event.proof_request_id,
+    timestamp: event.timestamp,
+  });
+
+  const recipients = getMatchingSubscribers(event);
+  for (const ws of recipients) {
+    sendQueued(ws, message);
+  }
+  return recipients.length;
+}
+
+/** Delivers to every locally connected client, regardless of filters. Returns recipient count. */
+function deliverToAllLocally(event: WsBroadcastEvent): number {
+  if (!wss) return 0;
+
+  const message = createMessage(event.type, {
+    credential_id: event.credential_id,
+    issuer: event.issuer,
+    holder: event.holder,
+    attestor: event.attestor,
+    proof_request_id: event.proof_request_id,
+    timestamp: event.timestamp,
+  });
+
+  let count = 0;
+  wss.clients.forEach((ws) => {
+    if (ws.readyState === WebSocket.OPEN) {
+      sendQueued(ws, message);
+      count++;
+    }
+  });
+  return count;
+}
+
+function publishCrossInstance(mode: 'filtered' | 'all', event: WsBroadcastEvent): void {
+  if (!pubsub) return;
+  const envelope: EventEnvelope = { publishedBy: instanceId, publishedAt: Date.now(), mode, event };
+  pubsub.publish(EVENTS_CHANNEL, JSON.stringify(envelope));
+  recordCrossInstanceMessagePublished();
+}
+
+function initPubSub(): void {
+  if (pubsub) return;
+  pubsub = getPubSubBackend();
+  initDashboardSync(pubsub);
+
+  pubsub.subscribe(EVENTS_CHANNEL, (raw) => {
+    let envelope: EventEnvelope;
+    try {
+      envelope = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (envelope.publishedBy === instanceId) return; // already delivered locally by broadcastEvent/broadcastToAll
+    recordCrossInstanceMessageReceived();
+    if (envelope.mode === 'all') {
+      deliverToAllLocally(envelope.event);
+    } else {
+      deliverLocally(envelope.event);
+    }
+  });
+}
 
 export function createWsServer(server: HttpServer, path = '/ws'): WebSocketServer {
+  initPubSub();
   wss = new WebSocketServer({ server, path });
 
   wss.on('connection', (ws: WebSocket, _req: IncomingMessage) => {
@@ -92,11 +185,10 @@ export function createWsServer(server: HttpServer, path = '/ws'): WebSocketServe
             const filters = msg.filters ?? [];
             addSubscriber(ws, filters);
             setSubscribers(getSubscriberCount());
-            ws.send(createMessage('subscription_confirmed', {
+            sendQueued(ws, createMessage('subscription_confirmed', {
               filters,
               subscriber_count: getSubscriberCount(),
             }));
-            recordMessageSent(Buffer.byteLength('subscription_confirmed'));
             break;
           }
 
@@ -104,37 +196,33 @@ export function createWsServer(server: HttpServer, path = '/ws'): WebSocketServe
             const filters = msg.filters;
             removeSubscriber(ws, filters);
             setSubscribers(getSubscriberCount());
-            ws.send(createMessage('unsubscription_confirmed', {
+            sendQueued(ws, createMessage('unsubscription_confirmed', {
               filters: filters ?? [],
             }));
-            recordMessageSent(Buffer.byteLength('unsubscription_confirmed'));
             break;
           }
 
           case 'ping': {
-            ws.send(createMessage('pong', { ts: new Date().toISOString() }));
-            recordMessageSent(Buffer.byteLength('pong'));
+            sendQueued(ws, createMessage('pong', { ts: new Date().toISOString() }));
             break;
           }
 
           case 'subscribe_dashboard': {
             addDashboardSubscriber(ws);
             const initialStats = liveDashboard.getStats() as unknown as Record<string, unknown>;
-            ws.send(createMessage('dashboard_subscribed', { ts: new Date().toISOString() }));
-            ws.send(createMessage('dashboard_stats', initialStats));
-            recordMessageSent(Buffer.byteLength('dashboard_subscribed') + Buffer.byteLength('dashboard_stats'));
+            sendQueued(ws, createMessage('dashboard_subscribed', { ts: new Date().toISOString() }));
+            sendQueued(ws, createMessage('dashboard_stats', initialStats));
             break;
           }
 
           case 'unsubscribe_dashboard': {
             removeDashboardSubscriber(ws);
-            ws.send(createMessage('dashboard_unsubscribed', {}));
-            recordMessageSent(Buffer.byteLength('dashboard_unsubscribed'));
+            sendQueued(ws, createMessage('dashboard_unsubscribed', {}));
             break;
           }
 
           default:
-            ws.send(createMessage('error', {
+            sendQueued(ws, createMessage('error', {
               message: `Unknown message type: ${(msg as any).type ?? 'undefined'}`,
             }));
             recordError();
@@ -142,7 +230,7 @@ export function createWsServer(server: HttpServer, path = '/ws'): WebSocketServe
         }
       } catch (err) {
         recordError();
-        ws.send(createMessage('error', {
+        sendQueued(ws, createMessage('error', {
           message: 'Invalid message format — expected JSON',
         }));
       }
@@ -151,6 +239,7 @@ export function createWsServer(server: HttpServer, path = '/ws'): WebSocketServe
     ws.on('close', () => {
       decrementConnections();
       removeConnection(ws);
+      closeConnectionQueue(ws);
       setSubscribers(getSubscriberCount());
     });
 
@@ -158,11 +247,10 @@ export function createWsServer(server: HttpServer, path = '/ws'): WebSocketServe
       recordError();
     });
 
-    ws.send(createMessage('connected', {
+    sendQueued(ws, createMessage('connected', {
       ts: new Date().toISOString(),
       connection_count: getWsMetrics().connections,
     }));
-    recordMessageSent(Buffer.byteLength('connected'));
   });
 
   pingTimer = setInterval(() => {
@@ -170,6 +258,7 @@ export function createWsServer(server: HttpServer, path = '/ws'): WebSocketServe
     wss.clients.forEach((ws) => {
       if ((ws as any).isAlive === false) {
         removeConnection(ws);
+        closeConnectionQueue(ws);
         ws.terminate();
         return;
       }
@@ -183,10 +272,8 @@ export function createWsServer(server: HttpServer, path = '/ws'): WebSocketServe
     if (subscribers.length === 0) return;
     const stats = liveDashboard.getStats() as unknown as Record<string, unknown>;
     const message = createMessage('dashboard_stats', stats);
-    const bytes = Buffer.byteLength(message);
     for (const client of subscribers) {
-      client.send(message);
-      recordMessageSent(bytes);
+      sendQueued(client, message);
     }
   }, DASHBOARD_BROADCAST_INTERVAL_MS);
 
@@ -204,53 +291,18 @@ export function createWsServer(server: HttpServer, path = '/ws'): WebSocketServe
   return wss;
 }
 
+/** Delivers to matching subscribers (filtered by credential_id/issuer/holder/event_type), on this instance and every other instance sharing the pub/sub backbone. Returns this instance's local recipient count. */
 export function broadcastEvent(event: WsBroadcastEvent): number {
-  if (!wss) return 0;
-
-  const message = createMessage(event.type, {
-    credential_id: event.credential_id,
-    issuer: event.issuer,
-    holder: event.holder,
-    attestor: event.attestor,
-    proof_request_id: event.proof_request_id,
-    timestamp: event.timestamp,
-  });
-
-  const recipients = getMatchingSubscribers(event);
-  const messageBytes = Buffer.byteLength(message);
-
-  for (const ws of recipients) {
-    ws.send(message);
-    recordMessageSent(messageBytes);
-  }
-
-  return recipients.length;
+  const localCount = deliverLocally(event);
+  publishCrossInstance('filtered', event);
+  return localCount;
 }
 
+/** Delivers to every connected client regardless of filters, on this instance and every other instance sharing the pub/sub backbone. Returns this instance's local recipient count. */
 export function broadcastToAll(event: WsBroadcastEvent): number {
-  if (!wss) return 0;
-
-  const message = createMessage(event.type, {
-    credential_id: event.credential_id,
-    issuer: event.issuer,
-    holder: event.holder,
-    attestor: event.attestor,
-    proof_request_id: event.proof_request_id,
-    timestamp: event.timestamp,
-  });
-
-  const messageBytes = Buffer.byteLength(message);
-  let count = 0;
-
-  wss.clients.forEach((ws) => {
-    if (ws.readyState === WebSocket.OPEN) {
-      ws.send(message);
-      recordMessageSent(messageBytes);
-      count++;
-    }
-  });
-
-  return count;
+  const localCount = deliverToAllLocally(event);
+  publishCrossInstance('all', event);
+  return localCount;
 }
 
 export function getConnectionCount(): number {

--- a/api-server/tests/helpers/wsCluster.ts
+++ b/api-server/tests/helpers/wsCluster.ts
@@ -1,0 +1,138 @@
+/**
+ * Spawns a real ephemeral Redis + N real Node child-process API server
+ * instances, for tests/scripts that need genuine multi-process behavior
+ * (as opposed to importing ws/server.ts twice in one process, which would
+ * share module-level state and prove nothing about cross-instance delivery).
+ */
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import { createServer } from 'net';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import { execSync } from 'child_process';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const harnessPath = path.join(__dirname, 'wsInstanceHarness.ts');
+const tsxBin = path.join(__dirname, '..', '..', 'node_modules', '.bin', 'tsx');
+
+export function redisServerAvailable(): boolean {
+  try {
+    execSync('which redis-server', { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, () => {
+      const address = srv.address();
+      if (address && typeof address === 'object') {
+        const port = address.port;
+        srv.close(() => resolve(port));
+      } else {
+        srv.close(() => reject(new Error('Could not determine free port')));
+      }
+    });
+    srv.on('error', reject);
+  });
+}
+
+function waitForStdout(
+  proc: ChildProcessWithoutNullStreams,
+  predicate: (line: string) => boolean,
+  timeoutMs: number,
+  label: string
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Timeout waiting for ${label}`)), timeoutMs);
+    let buf = '';
+    const onData = (chunk: Buffer) => {
+      buf += chunk.toString();
+      const lines = buf.split('\n');
+      for (const line of lines) {
+        if (predicate(line)) {
+          clearTimeout(timer);
+          proc.stdout.off('data', onData);
+          resolve();
+          return;
+        }
+      }
+    };
+    proc.stdout.on('data', onData);
+  });
+}
+
+export interface RedisHandle {
+  url: string;
+  port: number;
+  stop: () => Promise<void>;
+}
+
+export async function startEphemeralRedis(): Promise<RedisHandle> {
+  const port = await getFreePort();
+  const proc = spawn('redis-server', ['--port', String(port), '--save', '', '--appendonly', 'no'], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }) as ChildProcessWithoutNullStreams;
+
+  await waitForStdout(proc, (line) => line.includes('Ready to accept connections'), 10_000, 'redis-server startup');
+
+  return {
+    url: `redis://127.0.0.1:${port}`,
+    port,
+    stop: () =>
+      new Promise((resolve) => {
+        proc.once('exit', () => resolve());
+        proc.kill('SIGTERM');
+        setTimeout(() => {
+          if (!proc.killed) proc.kill('SIGKILL');
+          resolve();
+        }, 3000);
+      }),
+  };
+}
+
+export interface InstanceHandle {
+  port: number;
+  baseUrl: string;
+  stop: () => Promise<void>;
+}
+
+export async function startHarnessInstance(
+  redisUrl: string,
+  extraEnv: Record<string, string> = {}
+): Promise<InstanceHandle> {
+  const port = await getFreePort();
+  const proc = spawn(tsxBin, [harnessPath], {
+    env: {
+      ...process.env,
+      PORT: String(port),
+      REDIS_URL: redisUrl,
+      WS_INSTANCE_ID: `test-instance-${port}`,
+      ...extraEnv,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }) as ChildProcessWithoutNullStreams;
+
+  proc.stderr.on('data', (chunk) => {
+    // Surfaced for debugging test flakiness; harness instances shouldn't normally emit stderr.
+    process.stderr.write(`[harness:${port}] ${chunk}`);
+  });
+
+  await waitForStdout(proc, (line) => line.includes(`HARNESS_READY ${port}`), 15_000, `harness instance on port ${port}`);
+
+  return {
+    port,
+    baseUrl: `http://127.0.0.1:${port}`,
+    stop: () =>
+      new Promise((resolve) => {
+        proc.once('exit', () => resolve());
+        proc.kill('SIGTERM');
+        setTimeout(() => {
+          if (!proc.killed) proc.kill('SIGKILL');
+          resolve();
+        }, 3000);
+      }),
+  };
+}

--- a/api-server/tests/helpers/wsInstanceHarness.ts
+++ b/api-server/tests/helpers/wsInstanceHarness.ts
@@ -1,0 +1,43 @@
+/**
+ * Standalone WS instance harness for multi-process tests.
+ *
+ * Run as its own Node process (via tsx) with PORT and REDIS_URL set in the
+ * environment. Exposes the real ws/server.ts stack (so cross-instance
+ * delivery goes through the real pub/sub backend) plus a couple of trigger
+ * routes the test driver uses to originate events "from this instance"
+ * without needing the full credential-issuance pipeline.
+ */
+import express from 'express';
+import { createServer } from 'http';
+import { createWsServer, broadcastEvent, broadcastToAll } from '../../src/ws/server.js';
+import { liveDashboard } from '../../src/services/liveDashboard.js';
+
+const app = express();
+app.use(express.json());
+
+const httpServer = createServer(app);
+createWsServer(httpServer, '/ws');
+
+app.post('/trigger', (req, res) => {
+  const count = broadcastEvent(req.body);
+  res.json({ localRecipients: count });
+});
+
+app.post('/trigger-all', (req, res) => {
+  const count = broadcastToAll(req.body);
+  res.json({ localRecipients: count });
+});
+
+app.post('/trigger-dashboard', (req, res) => {
+  const { kind, success } = req.body as { kind: string; success?: boolean };
+  if (kind === 'issuance') liveDashboard.recordIssuance();
+  else if (kind === 'attestation') liveDashboard.recordAttestation(success !== false);
+  else if (kind === 'api_error') liveDashboard.recordApiError();
+  res.json({ ok: true });
+});
+
+const port = parseInt(process.env.PORT ?? '0', 10);
+httpServer.listen(port, () => {
+  // Parent process watches stdout for this exact line to know the instance is ready.
+  console.log(`HARNESS_READY ${port}`);
+});

--- a/api-server/tests/wsMultiInstance.test.ts
+++ b/api-server/tests/wsMultiInstance.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Multi-process integration test: proves that credential events published on
+ * one API server instance reach a client connected to a *different*
+ * instance, via the real Redis-backed pub/sub backbone (ws/pubsub.ts) — not
+ * an in-process shortcut. Also proves filter semantics and dashboard stats
+ * stay consistent across instances.
+ *
+ * Requires a real `redis-server` binary on PATH; the whole suite is skipped
+ * (not failed) when it isn't available, since CI environments vary.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import WebSocket from 'ws';
+import {
+  redisServerAvailable,
+  startEphemeralRedis,
+  startHarnessInstance,
+  type RedisHandle,
+  type InstanceHandle,
+} from './helpers/wsCluster.js';
+
+const HAS_REDIS = redisServerAvailable();
+const LATENCY_TRIALS = 50;
+const P99_BOUND_MS = 200;
+
+function connectAndWait(baseUrl: string, timeoutMs = 5000): Promise<{ ws: WebSocket; firstMessage: any }> {
+  return new Promise((resolve, reject) => {
+    const wsUrl = baseUrl.replace('http', 'ws') + '/ws';
+    const timer = setTimeout(() => reject(new Error('Timeout connecting')), timeoutMs);
+    const ws = new WebSocket(wsUrl);
+    ws.once('open', () => {
+      ws.once('message', (raw) => {
+        clearTimeout(timer);
+        resolve({ ws, firstMessage: JSON.parse(raw.toString()) });
+      });
+    });
+    ws.once('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+function nextMessage(ws: WebSocket, timeoutMs = 3000): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Timeout waiting for message')), timeoutMs);
+    ws.once('message', (raw) => {
+      clearTimeout(timer);
+      resolve(JSON.parse(raw.toString()));
+    });
+  });
+}
+
+function send(ws: WebSocket, msg: object): Promise<void> {
+  return new Promise((resolve, reject) => {
+    ws.send(JSON.stringify(msg), (err) => (err ? reject(err) : resolve()));
+  });
+}
+
+async function trigger(baseUrl: string, path: string, body: object): Promise<void> {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`trigger failed: ${res.status}`);
+}
+
+function percentile(sorted: number[], p: number): number {
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, idx)];
+}
+
+describe.skipIf(!HAS_REDIS)('Cross-instance WebSocket delivery (real multi-process, real Redis)', () => {
+  let redis: RedisHandle;
+  let instanceA: InstanceHandle;
+  let instanceB: InstanceHandle;
+
+  beforeAll(async () => {
+    redis = await startEphemeralRedis();
+    [instanceA, instanceB] = await Promise.all([
+      startHarnessInstance(redis.url, { WS_DASHBOARD_BROADCAST_INTERVAL_MS: '150' }),
+      startHarnessInstance(redis.url, { WS_DASHBOARD_BROADCAST_INTERVAL_MS: '150' }),
+    ]);
+  }, 30_000);
+
+  afterAll(async () => {
+    await Promise.all([instanceA?.stop(), instanceB?.stop()].filter(Boolean));
+    await redis?.stop();
+  });
+
+  it(
+    'delivers an event published on instance A to a client connected only to instance B, within p99 < 200ms',
+    async () => {
+      const { ws } = await connectAndWait(instanceB.baseUrl);
+      await send(ws, { type: 'subscribe', filters: [] });
+      await nextMessage(ws); // subscription_confirmed
+
+      const latencies: number[] = [];
+      for (let i = 0; i < LATENCY_TRIALS; i++) {
+        const start = Date.now();
+        const pending = nextMessage(ws, 2000);
+        await trigger(instanceA.baseUrl, '/trigger', {
+          type: 'credential_issued',
+          credential_id: 100_000 + i,
+          timestamp: new Date().toISOString(),
+        });
+        const msg = await pending;
+        latencies.push(Date.now() - start);
+        expect(msg.type).toBe('credential_issued');
+        expect(msg.data.credential_id).toBe(100_000 + i);
+      }
+
+      latencies.sort((a, b) => a - b);
+      const p99 = percentile(latencies, 99);
+      const p50 = percentile(latencies, 50);
+      // eslint-disable-next-line no-console
+      console.log(`cross-instance delivery latency: p50=${p50}ms p99=${p99}ms over ${LATENCY_TRIALS} trials`);
+      expect(p99).toBeLessThan(P99_BOUND_MS);
+
+      ws.close();
+    },
+    30_000
+  );
+
+  it('preserves filter semantics (credential_id) across instances', async () => {
+    const { ws } = await connectAndWait(instanceB.baseUrl);
+    await send(ws, { type: 'subscribe', filters: [{ credential_id: 777 }] });
+    await nextMessage(ws); // subscription_confirmed
+
+    // Non-matching events from the other instance must not arrive.
+    await trigger(instanceA.baseUrl, '/trigger', {
+      type: 'credential_issued',
+      credential_id: 776,
+      timestamp: new Date().toISOString(),
+    });
+    await trigger(instanceA.baseUrl, '/trigger', {
+      type: 'credential_issued',
+      credential_id: 778,
+      timestamp: new Date().toISOString(),
+    });
+    await expect(nextMessage(ws, 400)).rejects.toThrow('Timeout');
+
+    // Matching event does arrive.
+    await trigger(instanceA.baseUrl, '/trigger', {
+      type: 'credential_issued',
+      credential_id: 777,
+      timestamp: new Date().toISOString(),
+    });
+    const msg = await nextMessage(ws, 2000);
+    expect(msg.data.credential_id).toBe(777);
+
+    ws.close();
+  }, 15_000);
+
+  it('preserves issuer/holder/event_type filter semantics across instances', async () => {
+    const { ws } = await connectAndWait(instanceB.baseUrl);
+    await send(ws, { type: 'subscribe', filters: [{ issuer: 'G_ISSUER_X', event_type: 'credential_attested' }] });
+    await nextMessage(ws);
+
+    await trigger(instanceA.baseUrl, '/trigger', {
+      type: 'credential_issued',
+      issuer: 'G_ISSUER_X',
+      credential_id: 1,
+      timestamp: new Date().toISOString(),
+    });
+    await expect(nextMessage(ws, 400)).rejects.toThrow('Timeout');
+
+    await trigger(instanceA.baseUrl, '/trigger', {
+      type: 'credential_attested',
+      issuer: 'G_ISSUER_X',
+      credential_id: 2,
+      timestamp: new Date().toISOString(),
+    });
+    const msg = await nextMessage(ws, 2000);
+    expect(msg.type).toBe('credential_attested');
+    expect(msg.data.issuer).toBe('G_ISSUER_X');
+
+    ws.close();
+  }, 15_000);
+
+  it('keeps the live dashboard eventually consistent across instances', async () => {
+    const { ws, firstMessage: connected } = await connectAndWait(instanceB.baseUrl);
+    void connected;
+    await send(ws, { type: 'subscribe_dashboard' });
+    await nextMessage(ws); // dashboard_subscribed
+    const initial = await nextMessage(ws); // dashboard_stats
+    const before = initial.data.issuances_per_minute[initial.data.issuances_per_minute.length - 1];
+
+    await trigger(instanceA.baseUrl, '/trigger-dashboard', { kind: 'issuance' });
+    await trigger(instanceA.baseUrl, '/trigger-dashboard', { kind: 'issuance' });
+    await trigger(instanceA.baseUrl, '/trigger-dashboard', { kind: 'issuance' });
+
+    // Wait for B's periodic broadcast (interval set to 150ms for this test) to reflect A's deltas.
+    let after = before;
+    for (let i = 0; i < 20; i++) {
+      const stats = await nextMessage(ws, 1000);
+      after = stats.data.issuances_per_minute[stats.data.issuances_per_minute.length - 1];
+      if (after >= before + 3) break;
+    }
+    expect(after).toBeGreaterThanOrEqual(before + 3);
+
+    ws.close();
+  }, 15_000);
+
+  it('broadcastToAll also reaches every instance', async () => {
+    const { ws } = await connectAndWait(instanceB.baseUrl);
+    // No subscribe call — broadcastToAll ignores filters entirely and targets every open connection.
+    const pending = nextMessage(ws, 2000);
+    await trigger(instanceA.baseUrl, '/trigger-all', {
+      type: 'credential_revoked',
+      credential_id: 999,
+      timestamp: new Date().toISOString(),
+    });
+    const msg = await pending;
+    expect(msg.type).toBe('credential_revoked');
+    expect(msg.data.credential_id).toBe(999);
+    ws.close();
+  }, 15_000);
+});
+
+if (!HAS_REDIS) {
+  // eslint-disable-next-line no-console
+  console.warn('[wsMultiInstance.test.ts] redis-server binary not found on PATH — skipping cross-instance suite.');
+}

--- a/docs/websocket-scaling.md
+++ b/docs/websocket-scaling.md
@@ -1,0 +1,172 @@
+# WebSocket Scaling Across Multiple api-server Replicas
+
+## Problem
+
+`api-server/src/ws/server.ts` and `ws/subscriptions.ts` used to hold all
+subscriber and broadcast state in one process's memory. Once `api-server`
+runs as more than one replica (the normal shape implied by
+[multi-region-deployment.md](multi-region-deployment.md)), a client
+connected to instance A would never receive an event only observed by
+instance B, with no error surfaced to anyone.
+
+## Architecture
+
+```
+ ┌──────────────┐        publish ws:events         ┌──────────────┐
+ │  Instance A  │ ───────────────────────────────▶ │              │
+ │              │                                    │    Redis     │
+ │ local clients│◀─────────────────────────────────  │   Pub/Sub    │
+ └──────────────┘        subscribe ws:events        │              │
+                                                      │              │
+ ┌──────────────┐                                    │              │
+ │  Instance B  │ ◀────────────────────────────────  │              │
+ │ local clients│        subscribe ws:events         └──────────────┘
+ └──────────────┘
+```
+
+- Each instance keeps matching connected clients and their subscription
+  filters **locally** (`ws/subscriptions.ts`, unchanged) — filter matching
+  never crosses the network, only already-matched-by-filter payloads do.
+- `broadcastEvent(event)` / `broadcastToAll(event)` (`ws/server.ts`):
+  1. Deliver to this instance's local clients synchronously, exactly as
+     before (same return value, same call sites in `routes/notifications.ts`
+     etc.) — this path has zero dependency on Redis being reachable.
+  2. Fire-and-forget publish the event onto the `ws:events` Redis channel,
+     tagged with this instance's id.
+  3. Every instance (including the publisher) subscribes to `ws:events`; the
+     publisher skips its own message (already delivered in step 1), every
+     *other* instance delivers it to its local matching clients.
+- If Redis is unreachable, step 1 still works — same-instance delivery
+  degrades gracefully to single-instance behavior, it doesn't throw or crash
+  the request.
+- `ws/pubsub.ts` abstracts the transport behind `PubSubBackend`. Set
+  `REDIS_URL` to enable real cross-instance delivery (`RedisPubSubBackend`,
+  via `ioredis`). Leaving it unset falls back to `InMemoryPubSubBackend`
+  (same-process loopback) — fine for local dev/tests with a single instance,
+  **not** sufficient for a multi-replica deployment.
+
+## Filter semantics
+
+`credential_id`, `issuer`, `holder`, `event_type` filtering is unchanged —
+still implemented once, in `ws/subscriptions.ts::matchesFilter`, and applied
+identically whether the event originated locally or arrived from another
+instance over Redis. See `api-server/tests/ws.test.ts` (same-instance) and
+`api-server/tests/wsMultiInstance.test.ts` (cross-instance) for coverage.
+
+## Dashboard subscribers (liveDashboard.ts)
+
+The live dashboard (`services/liveDashboard.ts`) keeps a local 60-minute
+sliding window per instance. `ws/dashboardSync.ts` wires
+`liveDashboard.setDeltaPublisher(...)` so every `recordIssuance()` /
+`recordAttestation()` / `recordApiError()` call also publishes a small delta
+on the `ws:dashboard-delta` channel; every instance applies remote deltas to
+its own window via `applyRemoteDelta()` (which never re-publishes, so deltas
+don't loop). Each instance's periodic dashboard broadcast
+(`WS_DASHBOARD_BROADCAST_INTERVAL_MS`, default 5000ms) therefore reflects a
+cluster-wide, eventually consistent view regardless of which instance issued
+the underlying credential event or which instance a dashboard subscriber is
+connected to.
+
+## Backpressure and the per-connection send queue
+
+`ws/connectionQueue.ts` — every outbound message (broadcasts, dashboard
+stats, control replies) is enqueued per-connection rather than written to
+the socket directly.
+
+- **Bound:** `WS_SEND_QUEUE_MAX_MESSAGES` (default 200) messages *or*
+  `WS_SEND_QUEUE_MAX_BYTES` (default 1 MiB), whichever is hit first.
+- **Drop policy:** when a new message would exceed either bound, the
+  **oldest** queued message is dropped to make room. This is a "latest wins"
+  policy — for a real-time status feed, a fresh event is more useful to a
+  lagging client than a stale one, and clients are expected to reconcile via
+  a REST fetch on reconnect (`frontend/src/hooks/useRealtimeUpdates.ts`)
+  rather than rely on every message arriving.
+- Every drop increments `messagesDropped` (visible in both metrics
+  endpoints below) so operators can see when clients are falling behind.
+- The queue also respects `ws.bufferedAmount`: while a socket's own OS-level
+  send buffer is above `WS_BACKPRESSURE_HIGH_WATER_MARK` bytes (default
+  1 MiB), draining pauses briefly instead of piling more onto it.
+
+## Metrics
+
+- `GET /ws/metrics` — JSON, this instance only (unchanged shape plus
+  `instanceId`, `messagesDropped`, `crossInstanceMessagesReceived`,
+  `crossInstanceMessagesPublished`).
+- `GET /metrics/ws` — Prometheus text exposition
+  (`quorumproof_ws_connections`, `quorumproof_ws_messages_sent_total`, etc.),
+  each series labeled `instance="<id>"`. Scrape every replica and aggregate,
+  e.g.:
+  ```promql
+  sum(quorumproof_ws_connections)
+  sum(rate(quorumproof_ws_messages_sent_total[5m]))
+  sum(rate(quorumproof_ws_messages_dropped_total[5m]))
+  ```
+  Set `WS_INSTANCE_ID` (e.g. to the pod name) in each replica's environment
+  so the `instance` label is stable and readable; otherwise a random id is
+  generated per process.
+
+## Required configuration for multi-replica deployment
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `REDIS_URL` | unset (single-instance fallback) | **Required** for real cross-instance delivery. |
+| `WS_INSTANCE_ID` | random UUID | Stable label for metrics/pub-sub loop suppression. |
+| `WS_SEND_QUEUE_MAX_MESSAGES` | 200 | Per-connection send queue message cap. |
+| `WS_SEND_QUEUE_MAX_BYTES` | 1000000 | Per-connection send queue byte cap. |
+| `WS_BACKPRESSURE_HIGH_WATER_MARK` | 1000000 | Pause draining while `ws.bufferedAmount` exceeds this. |
+| `WS_DASHBOARD_BROADCAST_INTERVAL_MS` | 5000 | How often each instance pushes dashboard stats to its subscribers. |
+
+## Tests
+
+- `api-server/tests/ws.test.ts` — unchanged same-instance behavior (filter
+  matching, metrics, connection lifecycle).
+- `api-server/tests/wsMultiInstance.test.ts` — real multi-process
+  integration test. Spawns an ephemeral `redis-server` plus two real Node
+  child processes (`tests/helpers/wsInstanceHarness.ts`), connects a client
+  to one instance, triggers events from the other, and proves: cross-instance
+  delivery, filter semantics (`credential_id`, `issuer`+`event_type`),
+  `broadcastToAll` reaching every instance, and dashboard cross-instance
+  sync. Asserts p99 delivery latency < 200ms over 50 trials. Skips itself
+  (doesn't fail) if `redis-server` isn't on `PATH`.
+  ```
+  npm test -- tests/wsMultiInstance.test.ts
+  ```
+  Measured in this repo's CI-like sandbox (2 vCPU): p50=2ms, p99=54ms.
+
+- `api-server/loadtest/wsLoadTest.ts` — standalone load test script, **not**
+  part of `npm test`. Spawns N real instances behind one real Redis and
+  opens a configurable number of real client connections, then broadcasts
+  and measures delivery completeness and latency.
+  ```
+  npm run loadtest:ws                                   # 10,000 connections / 3 instances (defaults)
+  WS_LOAD_CONNECTIONS=2000 WS_LOAD_INSTANCES=2 npm run loadtest:ws
+  WS_LOAD_REDIS_URL=redis://localhost:6379 npm run loadtest:ws   # reuse an already-running Redis
+  ```
+  Measured in this repo's sandbox (2 vCPU, 10,000 connections / 3
+  instances, `broadcastToAll` — the worst case, full fan-out to every
+  connection at once): **100% delivery completeness** (200,000/200,000
+  messages across 20 rounds), p50=84ms, p99=347ms.
+
+  Note the gap between this and the 200ms bound proven by the correctness
+  test above: the correctness test measures a single filtered event to a
+  single subscriber, which is the common case. The load test's
+  `broadcastToAll` round instead fans a single trigger out to all 10,000
+  connections simultaneously — each instance sends to ~3,333 clients via a
+  synchronous per-connection loop on one event loop, and the load-generator
+  itself is a single Node process parsing up to 10,000 concurrent messages
+  per round on 2 vCPUs, so both sides of this specific test are
+  single-core-bottlenecked. Delivery completeness (the correctness
+  guarantee this whole feature is about) holds either way. If full-fanout
+  broadcast tail latency at this scale needs to be tightened further in
+  production, the natural next step is parallelizing the send loop (worker
+  threads, or sharding connections across multiple event loops per
+  instance) — out of scope here since completeness, not raw fan-out
+  throughput, was the correctness bug being fixed.
+
+## What didn't change
+
+- Message wire format (client and server), `ws/subscriptions.ts` filter
+  matching logic, `GET /health`, and every existing call site
+  (`routes/notifications.ts`, `services/webhooks.ts`) are untouched —
+  `broadcastEvent`/`broadcastToAll` keep their synchronous signature and
+  return the same local-recipient count as before.


### PR DESCRIPTION
## Summary
- api-server/src/ws/server.ts and subscriptions.ts held all subscriber/broadcast state in one process's memory; a client on instance A never got events only observed by instance B, with no error surfaced.
- Adds a Redis pub/sub backbone (`ws/pubsub.ts`) so events reach every subscribed client regardless of connection point, falling back to in-process delivery when `REDIS_URL` is unset.
- Preserves existing filter semantics (`credential_id`, `issuer`, `holder`, `event_type`) exactly, and extends the dashboard-subscriber path (`liveDashboard.ts`) under the same cross-instance model via `ws/dashboardSync.ts`.
- Adds bounded per-connection send queues (`ws/connectionQueue.ts`) with a documented drop-oldest backpressure policy.
- Extends `ws/metrics.ts` with a Prometheus endpoint (`GET /metrics/ws`) aggregable across instances via an `instance` label.
- Full architecture, env vars, and operational notes in `docs/websocket-scaling.md`.

## Test plan
- [x] `npx vitest run tests/ws.test.ts` — all 19 pre-existing tests pass unchanged (no regression in same-instance behavior/filter semantics).
- [x] `npx vitest run tests/wsMultiInstance.test.ts` — real multi-process integration test (spawns real `redis-server` + 2 child Node processes): cross-instance delivery, filter semantics, `broadcastToAll`, dashboard sync. p99 latency 54ms (bound: <200ms).
- [x] `npm run loadtest:ws` (10,000 connections / 3 instances, the ticket's stated target): 100% delivery completeness (200,000/200,000 messages). Full broadcast-storm p99 was 347ms in this 2-vCPU sandbox — documented transparently in `docs/websocket-scaling.md` along with the likely single-threaded-send-loop cause.
- [x] Full `npx vitest run` suite: 478 tests, same 5 pre-existing unrelated failures as on `main` (confirmed via `git stash`), no new failures.
- [x] `npx tsc --noEmit`: no new type errors introduced.

Closes #1069