### PR TITLE
Add parameterized complexity benchmarking for batch/attest scaling

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,87 @@
+# .github/workflows/benchmarks.yml — Parameterized benchmark scaling report.
+#
+# Runs benches/tests/benchmarks.rs's *_scaling tests across a range of n per
+# operation, fits an empirical complexity class via
+# benches/src/bin/scaling_report.rs (scripts/scaling_benchmark_report.sh
+# orchestrates both), and uploads the resulting Markdown report as a build
+# artifact on every run. On pushes to `main`, the updated
+# benches/history/*.jsonl files are committed back to the repo so gradual
+# regressions are visible across commits, not just within a single run.
+#
+# This is additive to the existing fixed-threshold gate — it does not
+# replace scripts/benchmark_compare.sh, scripts/profile_contracts.sh, or the
+# assert!s already in benches/tests/benchmarks.rs.
+
+name: Benchmark Scaling Report
+
+on:
+  pull_request:
+    paths:
+      - "contracts/**"
+      - "benches/**"
+  push:
+    branches:
+      - main
+    paths:
+      - "contracts/**"
+      - "benches/**"
+
+jobs:
+  scaling-report:
+    name: Scaling benchmarks & complexity report
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            benches/target
+          key: ${{ runner.os }}-cargo-benches-${{ hashFiles('benches/Cargo.lock', 'Cargo.lock') }}
+
+      - name: Run scaling benchmarks and generate report
+        id: report
+        run: |
+          set +e
+          ./scripts/scaling_benchmark_report.sh
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload scaling report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-scaling-report
+          path: |
+            benches/target/bench-scaling-report.md
+            benches/target/bench-scaling/raw.jsonl
+          retention-days: 90
+          if-no-files-found: warn
+
+      - name: Commit updated history (push to main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add benches/history/*.jsonl
+          if git diff --cached --quiet; then
+            echo "No history changes to commit."
+          else
+            git commit -m "chore(benches): update scaling history [skip ci]"
+            git push || echo "::warning::Failed to push history update (non-fatal)"
+          fi
+
+      - name: Fail if complexity gate failed
+        if: steps.report.outputs.exit_code != '0'
+        run: |
+          echo "Scaling report gate failed with exit code ${{ steps.report.outputs.exit_code }}."
+          echo "See the bench-scaling-report artifact for details."
+          exit 1

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -4,6 +4,18 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[lib]
+name = "quorum_proof_benches"
+path = "src/lib.rs"
+
+[[bin]]
+name = "scaling_report"
+path = "src/bin/scaling_report.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1.0"
+
 [dev-dependencies]
 soroban-sdk = { version = "21.7", features = ["testutils"] }
 quorum_proof = { path = "../contracts/quorum_proof", features = ["testutils"] }

--- a/benches/src/bin/scaling_report.rs
+++ b/benches/src/bin/scaling_report.rs
@@ -1,0 +1,113 @@
+// Reads the raw scaling data points written by the scaling benchmarks in
+// `tests/benchmarks.rs`, fits a complexity curve per operation, updates
+// cross-run history, renders a Markdown report, and exits non-zero if any
+// operation classifies as quadratic-or-worse. This is the additive gate on
+// top of (not a replacement for) the fixed-size threshold `assert!`s already
+// in `tests/benchmarks.rs`.
+//
+// Usage: cargo run --manifest-path benches/Cargo.toml --bin scaling_report
+// (run `cargo test --manifest-path benches/Cargo.toml --test benchmarks --
+// --nocapture` first to populate the raw data points.)
+
+use quorum_proof_benches::{complexity, history, report, scaling};
+use std::collections::BTreeMap;
+use std::process::Command;
+
+fn current_timestamp() -> String {
+    Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn current_commit() -> String {
+    if let Ok(sha) = std::env::var("GITHUB_SHA") {
+        if !sha.is_empty() {
+            return sha;
+        }
+    }
+    Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn main() {
+    let points = scaling::load_points();
+    if points.is_empty() {
+        eprintln!(
+            "No scaling data points found at {}. Run the scaling benchmarks first:\n  \
+             cargo test --manifest-path benches/Cargo.toml --test benchmarks -- --nocapture",
+            scaling::raw_points_path().display()
+        );
+        std::process::exit(2);
+    }
+
+    let mut by_op: BTreeMap<String, Vec<(u32, u64, u64)>> = BTreeMap::new();
+    for p in points {
+        by_op.entry(p.op.clone()).or_default().push((p.n, p.cpu, p.mem));
+    }
+
+    let commit = current_commit();
+    let generated_at = current_timestamp();
+
+    let mut reports = Vec::new();
+
+    for (op, mut pts) in by_op {
+        pts.sort_by_key(|(n, _, _)| *n);
+
+        let cpu_points: Vec<(u32, u64)> = pts.iter().map(|(n, cpu, _)| (*n, *cpu)).collect();
+        let mem_points: Vec<(u32, u64)> = pts.iter().map(|(n, _, mem)| (*n, *mem)).collect();
+
+        let cpu_fit = complexity::fit_power_law(&cpu_points);
+        let mem_fit = complexity::fit_power_law(&mem_points);
+
+        // Drift is computed against history *before* this run's entry is
+        // appended, so it never compares a run against itself.
+        let hist = history::load_history(&op);
+        let drift = cpu_fit.and_then(|f| history::detect_drift(&hist, f.exponent));
+
+        if let (Some((n_max, cpu_at_max, mem_at_max)), Some(cf)) =
+            (pts.last().map(|(n, c, m)| (*n, *c, *m)), cpu_fit)
+        {
+            let entry = history::HistoryEntry {
+                commit: commit.clone(),
+                timestamp: generated_at.clone(),
+                n_max,
+                exponent: cf.exponent,
+                r_squared: cf.r_squared,
+                cpu_at_n_max: cpu_at_max,
+                mem_at_n_max: mem_at_max,
+            };
+            if let Err(e) = history::append_entry(&op, &entry) {
+                eprintln!("warning: failed to append history for {op}: {e}");
+            }
+        }
+
+        reports.push(report::OpReport { op, points: pts, cpu_fit, mem_fit, drift });
+    }
+
+    let markdown = report::render_report(&generated_at, &commit, &reports);
+    let report_path = scaling::report_path();
+    if let Some(parent) = report_path.parent() {
+        std::fs::create_dir_all(parent).expect("failed to create report dir");
+    }
+    std::fs::write(&report_path, &markdown).expect("failed to write report");
+
+    println!("{markdown}");
+    println!("Report written to {}", report_path.display());
+
+    let any_failing = reports.iter().any(|r| r.is_failing());
+    if any_failing {
+        eprintln!("❌ One or more operations classified as quadratic-or-worse.");
+        std::process::exit(1);
+    }
+}

--- a/benches/src/complexity.rs
+++ b/benches/src/complexity.rs
@@ -1,0 +1,185 @@
+// Empirical complexity-class fitting for scaling benchmark data.
+//
+// Given (n, cost) points from running an operation at several input sizes,
+// fits `cost ≈ a·n^b` by ordinary least squares on (ln n, ln cost) — a
+// standard log-log linearization of a power law. `b` (the `exponent`) is the
+// thing we care about: b≈1 is linear, b≈2 is quadratic, etc.
+//
+// Bucket thresholds are heuristic, not exact Big-O classification: with only
+// a handful of (small, capped) n values, O(n) and O(n·log n) fits produce
+// very similar slopes and can't be reliably told apart. The buckets below
+// are deliberately coarse so the gate only fires on genuinely worse-than-
+// expected growth rather than false-positiving on log factors.
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FitResult {
+    pub exponent: f64,
+    pub r_squared: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ComplexityClass {
+    /// exponent < 1.2 — linear or better.
+    LinearOrBetter,
+    /// 1.2 <= exponent < 1.8 — superlinear; possibly n·log n, or a mild
+    /// polynomial. Worth a human look but not gate-failing on its own.
+    Superlinear,
+    /// exponent >= 1.8 — quadratic or worse. Fails the additive gate.
+    QuadraticOrWorse,
+}
+
+impl ComplexityClass {
+    pub fn is_failing(self) -> bool {
+        matches!(self, ComplexityClass::QuadraticOrWorse)
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            ComplexityClass::LinearOrBetter => "linear-or-better",
+            ComplexityClass::Superlinear => "superlinear (possible n log n)",
+            ComplexityClass::QuadraticOrWorse => "quadratic-or-worse",
+        }
+    }
+}
+
+pub fn classify(exponent: f64) -> ComplexityClass {
+    if exponent < 1.2 {
+        ComplexityClass::LinearOrBetter
+    } else if exponent < 1.8 {
+        ComplexityClass::Superlinear
+    } else {
+        ComplexityClass::QuadraticOrWorse
+    }
+}
+
+/// Fits `cost ≈ a·n^b` to the given (n, cost) points via least-squares
+/// regression on (ln n, ln cost). Returns `None` if fewer than two distinct,
+/// strictly-positive-n points are available (a power-law fit is meaningless
+/// otherwise).
+pub fn fit_power_law(points: &[(u32, u64)]) -> Option<FitResult> {
+    let xs_ys: Vec<(f64, f64)> = points
+        .iter()
+        .filter(|(n, cost)| *n > 0 && *cost > 0)
+        .map(|(n, cost)| ((*n as f64).ln(), (*cost as f64).ln()))
+        .collect();
+
+    if xs_ys.len() < 2 {
+        return None;
+    }
+
+    let count = xs_ys.len() as f64;
+    let sum_x: f64 = xs_ys.iter().map(|(x, _)| x).sum();
+    let sum_y: f64 = xs_ys.iter().map(|(_, y)| y).sum();
+    let mean_x = sum_x / count;
+    let mean_y = sum_y / count;
+
+    let mut ss_xx = 0.0;
+    let mut ss_xy = 0.0;
+    for (x, y) in &xs_ys {
+        ss_xx += (x - mean_x) * (x - mean_x);
+        ss_xy += (x - mean_x) * (y - mean_y);
+    }
+
+    if ss_xx == 0.0 {
+        // All points share the same n — no variation to fit a slope against.
+        return None;
+    }
+
+    let slope = ss_xy / ss_xx;
+    let intercept = mean_y - slope * mean_x;
+
+    let ss_tot: f64 = xs_ys.iter().map(|(_, y)| (y - mean_y).powi(2)).sum();
+    let ss_res: f64 = xs_ys
+        .iter()
+        .map(|(x, y)| {
+            let predicted = intercept + slope * x;
+            (y - predicted).powi(2)
+        })
+        .sum();
+    let r_squared = if ss_tot == 0.0 { 1.0 } else { 1.0 - (ss_res / ss_tot) };
+
+    Some(FitResult { exponent: slope, r_squared })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deterministic, seeded LCG — same construction as
+    /// `generate_batch_metadata` in `load_test_batch_operations.rs`. No
+    /// wall-clock or OS randomness, so this test is fully reproducible.
+    struct Lcg(u32);
+    impl Lcg {
+        fn next_unit(&mut self) -> f64 {
+            self.0 = self.0.wrapping_mul(1103515245).wrapping_add(12345);
+            // Top 24 bits, normalized to [0, 1) then shifted to [-0.5, 0.5).
+            ((self.0 >> 8) as f64 / 16_777_216.0) - 0.5
+        }
+    }
+
+    /// Seeded negative test: a synthetic operation with deliberately
+    /// quadratic cost (`cost = a·n² + noise`) must be classified as
+    /// quadratic-or-worse. This exercises the fitting/classification code
+    /// itself, independent of what any real contract currently does.
+    #[test]
+    fn detects_seeded_quadratic_growth() {
+        let mut rng = Lcg(0xC0FF_EE42); // fixed seed
+        let a = 1_000.0;
+        let points: Vec<(u32, u64)> = [1u32, 5, 10, 25, 50, 100]
+            .iter()
+            .map(|&n| {
+                let noise = rng.next_unit() * a; // small deterministic wobble
+                let cost = (a * (n as f64).powi(2) + noise).max(1.0);
+                (n, cost as u64)
+            })
+            .collect();
+
+        let fit = fit_power_law(&points).expect("expected a fit for 6 distinct n values");
+        assert!(
+            fit.exponent >= 1.8,
+            "seeded quadratic series should fit with exponent >= 1.8, got {}",
+            fit.exponent
+        );
+        assert_eq!(
+            classify(fit.exponent),
+            ComplexityClass::QuadraticOrWorse,
+            "seeded quadratic series must be classified as quadratic-or-worse (exponent={}, r2={})",
+            fit.exponent,
+            fit.r_squared
+        );
+        assert!(fit.r_squared > 0.9, "fit should be tight for a clean power-law series, r2={}", fit.r_squared);
+    }
+
+    /// Sanity check in the other direction: a linear series must NOT be
+    /// misclassified as failing, so the negative test above is meaningful
+    /// rather than the classifier always tripping.
+    #[test]
+    fn does_not_flag_linear_growth() {
+        let mut rng = Lcg(7);
+        let a = 500.0;
+        let points: Vec<(u32, u64)> = [1u32, 5, 10, 25, 50, 100]
+            .iter()
+            .map(|&n| {
+                let noise = rng.next_unit() * a;
+                let cost = (a * n as f64 + noise).max(1.0);
+                (n, cost as u64)
+            })
+            .collect();
+
+        let fit = fit_power_law(&points).expect("expected a fit for 6 distinct n values");
+        assert_eq!(
+            classify(fit.exponent),
+            ComplexityClass::LinearOrBetter,
+            "linear series must not be flagged (exponent={})",
+            fit.exponent
+        );
+    }
+
+    #[test]
+    fn returns_none_for_insufficient_points() {
+        assert!(fit_power_law(&[]).is_none());
+        assert!(fit_power_law(&[(5, 100)]).is_none());
+        assert!(fit_power_law(&[(0, 100), (0, 200)]).is_none()); // n must be > 0
+    }
+}

--- a/benches/src/history.rs
+++ b/benches/src/history.rs
@@ -1,0 +1,85 @@
+// Cross-run persistence for fitted complexity results, so a regression that
+// creeps in gradually across many small commits is visible even though no
+// single run trips the existing fixed 10%-over-baseline gate.
+//
+// One JSONL file per operation under `benches/history/`, committed to the
+// repo by CI on pushes to `main` (see `.github/workflows/benchmarks.yml`) —
+// append-only, one line per CI run, so history is diffable in normal `git
+// log` rather than living only in GitHub Actions artifact retention.
+
+use crate::scaling::history_dir;
+use serde::{Deserialize, Serialize};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistoryEntry {
+    pub commit: String,
+    pub timestamp: String,
+    pub n_max: u32,
+    pub exponent: f64,
+    pub r_squared: f64,
+    pub cpu_at_n_max: u64,
+    pub mem_at_n_max: u64,
+}
+
+pub fn history_path(op: &str) -> PathBuf {
+    history_dir().join(format!("{op}.jsonl"))
+}
+
+/// Loads all prior recorded entries for `op`, oldest first. Returns an empty
+/// vec if no history file exists yet (first run for this operation).
+pub fn load_history(op: &str) -> Vec<HistoryEntry> {
+    let path = history_path(op);
+    let Ok(contents) = fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    contents
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect()
+}
+
+pub fn append_entry(op: &str, entry: &HistoryEntry) -> std::io::Result<()> {
+    let path = history_path(op);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let line = serde_json::to_string(entry).expect("failed to serialize HistoryEntry");
+    let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+    writeln!(file, "{line}")
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DriftWarning {
+    pub baseline_exponent: f64,
+    pub current_exponent: f64,
+    pub delta: f64,
+}
+
+/// Flags drift beyond this many exponent-units above the trailing baseline.
+/// Deliberately looser than the per-run classification buckets in
+/// `complexity.rs`: this is meant to catch *creep* relative to this
+/// operation's own recent history, not to duplicate the absolute
+/// quadratic-or-worse gate.
+const DRIFT_THRESHOLD: f64 = 0.3;
+
+/// Compares the current run's fitted exponent against a smoothed baseline
+/// (mean of up to the last 5 history entries) so a single noisy prior run
+/// doesn't dominate the comparison. Returns `None` when there's no history
+/// yet or the exponent hasn't drifted meaningfully.
+pub fn detect_drift(history: &[HistoryEntry], current_exponent: f64) -> Option<DriftWarning> {
+    if history.is_empty() {
+        return None;
+    }
+    let window: Vec<f64> = history.iter().rev().take(5).map(|e| e.exponent).collect();
+    let baseline = window.iter().sum::<f64>() / window.len() as f64;
+    let delta = current_exponent - baseline;
+    if delta > DRIFT_THRESHOLD {
+        Some(DriftWarning { baseline_exponent: baseline, current_exponent, delta })
+    } else {
+        None
+    }
+}

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -1,1 +1,11 @@
 // Benchmark suite — see tests/ for the actual benchmark tests.
+//
+// This lib also hosts the scaling-benchmark analysis used by
+// `src/bin/scaling_report.rs`: raw data collection (`scaling`), power-law
+// curve fitting and complexity classification (`complexity`), cross-run
+// history persistence (`history`), and Markdown report rendering (`report`).
+
+pub mod complexity;
+pub mod history;
+pub mod report;
+pub mod scaling;

--- a/benches/src/report.rs
+++ b/benches/src/report.rs
@@ -1,0 +1,78 @@
+// Renders the human-readable Markdown report attached to CI runs, summarizing
+// the fitted complexity class per operation plus any drift versus history.
+
+use crate::complexity::FitResult;
+use crate::history::DriftWarning;
+
+pub struct OpReport {
+    pub op: String,
+    /// (n, cpu, mem) points, sorted ascending by n.
+    pub points: Vec<(u32, u64, u64)>,
+    pub cpu_fit: Option<FitResult>,
+    pub mem_fit: Option<FitResult>,
+    pub drift: Option<DriftWarning>,
+}
+
+impl OpReport {
+    pub fn is_failing(&self) -> bool {
+        self.cpu_fit.map(|f| classify_failing(f)).unwrap_or(false)
+            || self.mem_fit.map(|f| classify_failing(f)).unwrap_or(false)
+    }
+}
+
+fn classify_failing(fit: FitResult) -> bool {
+    crate::complexity::classify(fit.exponent).is_failing()
+}
+
+fn fmt_fit(fit: Option<FitResult>) -> String {
+    match fit {
+        Some(f) => {
+            let class = crate::complexity::classify(f.exponent);
+            format!("b={:.2}, R²={:.2} ({})", f.exponent, f.r_squared, class.label())
+        }
+        None => "n/a (not enough data points)".to_string(),
+    }
+}
+
+pub fn render_report(generated_at: &str, commit: &str, reports: &[OpReport]) -> String {
+    let mut out = String::new();
+    out.push_str("# Benchmark Scaling Report\n\n");
+    out.push_str(&format!("_Generated: {generated_at} · commit `{commit}`_\n\n"));
+
+    let any_failing = reports.iter().any(|r| r.is_failing());
+    let any_drift = reports.iter().any(|r| r.drift.is_some());
+    let overall = if any_failing {
+        "❌ FAIL — quadratic-or-worse growth detected"
+    } else if any_drift {
+        "⚠️ PASS with drift warnings — see below"
+    } else {
+        "✅ PASS"
+    };
+    out.push_str(&format!("**Overall: {overall}**\n\n"));
+
+    out.push_str("This report is additive to the existing fixed-size threshold gate in \
+        `benches/tests/benchmarks.rs` — it does not replace it.\n\n");
+
+    for r in reports {
+        out.push_str(&format!("## `{}`\n\n", r.op));
+        out.push_str("| n | CPU (instructions) | Memory (bytes) |\n|---|---|---|\n");
+        for (n, cpu, mem) in &r.points {
+            out.push_str(&format!("| {n} | {cpu} | {mem} |\n"));
+        }
+        out.push('\n');
+        out.push_str(&format!("- CPU fit: {}\n", fmt_fit(r.cpu_fit)));
+        out.push_str(&format!("- Memory fit: {}\n", fmt_fit(r.mem_fit)));
+        if let Some(DriftWarning { baseline_exponent, current_exponent, delta }) = r.drift {
+            out.push_str(&format!(
+                "- ⚠️ Drift vs. recent history: exponent {baseline_exponent:.2} → {current_exponent:.2} (+{delta:.2}). \
+                 No single run crossed the fixed threshold, but this operation's growth rate has been creeping up.\n"
+            ));
+        }
+        if r.is_failing() {
+            out.push_str("- ❌ **Classified quadratic-or-worse — additive gate failure.**\n");
+        }
+        out.push('\n');
+    }
+
+    out
+}

--- a/benches/src/scaling.rs
+++ b/benches/src/scaling.rs
@@ -1,0 +1,78 @@
+// Raw (n, cost) data points collected by the scaling benchmarks in
+// `tests/benchmarks.rs`, persisted to `target/bench-scaling/raw.jsonl` for
+// `bin/scaling_report.rs` to fit a complexity curve against.
+//
+// Paths are anchored on `CARGO_MANIFEST_DIR` (this crate's directory) rather
+// than the process CWD or the workspace target dir: `benches/` is not a
+// member of the root Cargo workspace, so its effective workspace root
+// (and therefore its `target/` location) depends on how it's invoked.
+// `CARGO_MANIFEST_DIR` is stable regardless of invocation style and is
+// shared at compile time by both the integration test binary and this lib.
+
+use serde::{Deserialize, Serialize};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScalingPoint {
+    pub op: String,
+    pub n: u32,
+    pub cpu: u64,
+    pub mem: u64,
+}
+
+fn manifest_dir() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+}
+
+pub fn raw_points_path() -> PathBuf {
+    manifest_dir().join("target/bench-scaling/raw.jsonl")
+}
+
+pub fn report_path() -> PathBuf {
+    manifest_dir().join("target/bench-scaling-report.md")
+}
+
+pub fn history_dir() -> PathBuf {
+    manifest_dir().join("history")
+}
+
+/// Appends one data point to `raw.jsonl`. Call `reset_raw_points` once at the
+/// start of a scaling run to avoid mixing points from a previous run.
+pub fn record_point(op: &str, n: u32, cpu: u64, mem: u64) {
+    let path = raw_points_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("failed to create bench-scaling dir");
+    }
+    let point = ScalingPoint { op: op.to_string(), n, cpu, mem };
+    let line = serde_json::to_string(&point).expect("failed to serialize ScalingPoint");
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .unwrap_or_else(|e| panic!("failed to open {}: {e}", path.display()));
+    writeln!(file, "{line}").expect("failed to write scaling point");
+}
+
+/// Truncates `raw.jsonl` so a fresh test run doesn't append to stale data.
+pub fn reset_raw_points() {
+    let path = raw_points_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("failed to create bench-scaling dir");
+    }
+    fs::write(&path, "").expect("failed to reset raw.jsonl");
+}
+
+/// Reads all recorded points, grouped by operation name.
+pub fn load_points() -> Vec<ScalingPoint> {
+    let path = raw_points_path();
+    let Ok(contents) = fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    contents
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap_or_else(|e| panic!("bad scaling point line: {e}")))
+        .collect()
+}

--- a/benches/tests/benchmarks.rs
+++ b/benches/tests/benchmarks.rs
@@ -18,10 +18,24 @@
 //   batch_verify (5) : ~3_000_000 CPU / ~3_000_000 MEM
 //
 // Run with: `cargo test -p quorum-proof-benches -- --nocapture`
+//
+// ── Scaling / complexity-class gate (additive, does not replace the above) ──
+// `bench_*_scaling` tests below run select operations across a range of `n`
+// (capped at the contract's own MAX_BATCH_SIZE/MAX_ATTESTORS_PER_SLICE — no
+// real call can exceed those) and record each (n, cpu, mem) point via
+// `quorum_proof_benches::scaling::record_point`. They assert nothing
+// themselves beyond what they already asserted (e.g. bench_attest_scaling's
+// existing flat-threshold check); the actual complexity-class fit, cross-run
+// history, and pass/fail gate live in `src/bin/scaling_report.rs` — run it
+// after this test binary to fit curves and get a report:
+//   cargo test --manifest-path benches/Cargo.toml --test benchmarks -- --nocapture
+//   cargo run  --manifest-path benches/Cargo.toml --bin scaling_report
+// or just `scripts/scaling_benchmark_report.sh` to do both.
 use soroban_sdk::{testutils::Address as _, Address, Bytes, BytesN, Env, Vec};
 use quorum_proof::{QuorumProofContract, QuorumProofContractClient};
 use sbt_registry::{SbtRegistryContract, SbtRegistryContractClient};
 use zk_verifier::{ClaimType, ZkVerifierContract, ZkVerifierContractClient};
+use quorum_proof_benches::scaling;
 
 // ── Regression thresholds (CPU instructions) ─────────────────────────────────
 // Each value = measured_baseline × 1.10 (10% regression gate).
@@ -263,9 +277,15 @@ fn bench_verify_claim() {
 
 /// Measures how attest cost scales with attestor count in a slice.
 /// Detects O(n²) regressions in attestation logic.
+///
+/// n is capped at `MAX_ATTESTORS_PER_SLICE` (20, contracts/quorum_proof/src/lib.rs:37) —
+/// no real slice can ever have more attestors than that, so this is the full
+/// range reachable through the public contract API. Points are recorded via
+/// `scaling::record_point` for `bin/scaling_report.rs` to fit a complexity
+/// curve against, on top of the fixed per-attest threshold assert below.
 #[test]
 fn bench_attest_scaling() {
-    for n in [1u32, 5, 10] {
+    for n in [1u32, 5, 10, 15, 20] {
         let env = Env::default();
         let (client, _) = setup_qp(&env);
         let issuer = Address::generate(&env);
@@ -287,6 +307,7 @@ fn bench_attest_scaling() {
         });
 
         println!("[bench_attest_scaling n={}] cpu={} mem={}", n, m.cpu, m.mem);
+        scaling::record_point("attest", n, m.cpu, m.mem);
         // Each attest must stay within the single-attest threshold regardless of slice size
         assert!(m.cpu <= THRESHOLD_ATTEST_CPU,
             "attest scaling CPU regression at n={}: {} > {}", n, m.cpu, THRESHOLD_ATTEST_CPU);
@@ -383,6 +404,40 @@ fn bench_batch_issue_credentials_5() {
         "batch_issue_credentials(5) MEM regression: {} > {}", m.mem, THRESHOLD_BATCH_ISSUE_5_MEM);
 }
 
+/// Measures how batch_issue_credentials cost scales with batch size.
+///
+/// n is capped at `MAX_BATCH_SIZE` (50, contracts/quorum_proof/src/lib.rs:38) —
+/// no real batch call can ever exceed that, so this is the full range
+/// reachable through the public contract API. Data-collection only: points
+/// are recorded via `scaling::record_point` for `bin/scaling_report.rs` to
+/// fit a complexity curve against; the fixed n=5 threshold gate above is
+/// unaffected.
+#[test]
+fn bench_batch_issue_credentials_scaling() {
+    for n in [1u32, 5, 10, 25, 50] {
+        let env = Env::default();
+        let (client, _) = setup_qp(&env);
+        let issuer = Address::generate(&env);
+        let meta = Bytes::from_slice(&env, b"QmBenchHash000000000000000000000000");
+
+        let mut subjects = Vec::new(&env);
+        let mut cred_types = Vec::new(&env);
+        let mut metas = Vec::new(&env);
+        for i in 1u32..=n {
+            subjects.push_back(Address::generate(&env));
+            cred_types.push_back(i);
+            metas.push_back(meta.clone());
+        }
+
+        let m = measure(&env, || {
+            client.batch_issue_credentials(&issuer, &subjects, &cred_types, &metas, &None);
+        });
+
+        println!("[bench_batch_issue_credentials_scaling n={}] cpu={} mem={}", n, m.cpu, m.mem);
+        scaling::record_point("batch_issue_credentials", n, m.cpu, m.mem);
+    }
+}
+
 /// Benchmarks verify_attestations_batch with 5 credential/slice pairs.
 /// Detects regressions in the batch verification loop.
 #[test]
@@ -418,4 +473,47 @@ fn bench_verify_attestations_batch_5() {
         "verify_attestations_batch(5) CPU regression: {} > {}", m.cpu, THRESHOLD_BATCH_VERIFY_5_CPU);
     assert!(m.mem <= THRESHOLD_BATCH_VERIFY_5_MEM,
         "verify_attestations_batch(5) MEM regression: {} > {}", m.mem, THRESHOLD_BATCH_VERIFY_5_MEM);
+}
+
+/// Measures how verify_attestations_batch cost scales with batch size.
+///
+/// n is capped at `MAX_BATCH_SIZE` (50, contracts/quorum_proof/src/lib.rs:38).
+/// This is the operation most likely to show superlinear growth: its
+/// implementation does a nested scan (per credential, per attestation
+/// record, linear scan over slice.attestors) rather than a map lookup —
+/// see contracts/quorum_proof/src/lib.rs:9894-9911. Data-collection only:
+/// points are recorded via `scaling::record_point`; the fixed n=5 threshold
+/// gate above is unaffected.
+#[test]
+fn bench_verify_attestations_batch_scaling() {
+    for n in [1u32, 5, 10, 25, 50] {
+        let env = Env::default();
+        let (client, _) = setup_qp(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let attestor = Address::generate(&env);
+        let meta = Bytes::from_slice(&env, b"QmBenchHash000000000000000000000000");
+
+        let mut att_list = Vec::new(&env);
+        att_list.push_back(attestor.clone());
+        let mut wts = Vec::new(&env);
+        wts.push_back(1u32);
+
+        let mut cred_ids = Vec::new(&env);
+        let mut slice_ids = Vec::new(&env);
+        for i in 1u32..=n {
+            let cid = client.issue_credential(&issuer, &subject, &i, &meta, &None, &0u64);
+            let sid = client.create_slice(&issuer, &att_list, &wts, &1u32);
+            client.attest(&attestor, &cid, &sid, &true, &None);
+            cred_ids.push_back(cid);
+            slice_ids.push_back(sid);
+        }
+
+        let m = measure(&env, || {
+            client.verify_attestations_batch(&cred_ids, &slice_ids);
+        });
+
+        println!("[bench_verify_attestations_batch_scaling n={}] cpu={} mem={}", n, m.cpu, m.mem);
+        scaling::record_point("verify_attestations_batch", n, m.cpu, m.mem);
+    }
 }

--- a/scripts/scaling_benchmark_report.sh
+++ b/scripts/scaling_benchmark_report.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Parameterized benchmark scaling report.
+#
+# Runs the *_scaling benchmarks (benches/tests/benchmarks.rs) across a range
+# of n per operation, fits an empirical complexity class (linear / superlinear
+# / quadratic-or-worse) per operation via benches/src/bin/scaling_report.rs,
+# updates benches/history/*.jsonl so drift is visible across commits (not
+# just single-run jumps), and writes benches/target/bench-scaling-report.md.
+#
+# This is additive to — not a replacement for — the existing fixed-threshold
+# gate (scripts/benchmark_compare.sh, scripts/profile_contracts.sh, and the
+# assert!s in benches/tests/benchmarks.rs itself).
+set -euo pipefail
+
+MANIFEST="benches/Cargo.toml"
+RAW_DIR="benches/target/bench-scaling"
+REPORT="benches/target/bench-scaling-report.md"
+
+echo "Clearing stale scaling data points..."
+rm -rf "$RAW_DIR"
+
+echo "Running scaling benchmarks..."
+cargo test --manifest-path "$MANIFEST" --test benchmarks -- --nocapture
+
+echo ""
+echo "Fitting complexity curves and updating history..."
+if cargo run --manifest-path "$MANIFEST" --bin scaling_report; then
+    STATUS=0
+else
+    STATUS=$?
+fi
+
+echo ""
+if [ "$STATUS" -eq 0 ]; then
+    echo "✅ Scaling report generated: $REPORT"
+else
+    echo "❌ Scaling report gate failed (exit $STATUS) — see $REPORT"
+fi
+
+exit "$STATUS"


### PR DESCRIPTION
## Summary
- Parameterizes the batch_issue_credentials, verify_attestations_batch, and attest benchmarks across a range of n (capped at the contract's own MAX_BATCH_SIZE=50 / MAX_ATTESTORS_PER_SLICE=20 — no real call can exceed those), instead of only ever measuring one fixed size.
- Adds a hand-rolled log-log least-squares fit + complexity classifier (`benches/src/complexity.rs`), with a seeded deterministic negative test proving a synthetic O(n²) series is correctly flagged.
- Persists fitted results per commit to `benches/history/*.jsonl` so gradual regressions are visible across many small commits, not just single-run jumps.
- Adds a new `scaling_report` binary and CI workflow (`.github/workflows/benchmarks.yml`) that renders a Markdown report, uploads it as a build artifact every run, and commits updated history on pushes to `main`.
- Existing fixed-size benchmark tests and their thresholds are unchanged — this is additive, not a replacement.

## Test plan
- [x] `cargo test --manifest-path benches/Cargo.toml --test benchmarks -- --nocapture` — confirm existing fixed-size benches still pass and new scaling tests run
- [x] `cargo test --manifest-path benches/Cargo.toml --lib` — confirm the seeded quadratic/linear classification tests pass
- [x] `scripts/scaling_benchmark_report.sh` — confirm it runs end-to-end and produces `benches/target/bench-scaling-report.md`
- [x] Inspect `benches/history/*.jsonl` after two runs to confirm entries append

Closes #1070