### PR TITLE
Add security response guidelines, claim type registry, DR runbook gaps, and perf-regression docs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,118 @@
+# Security Policy
+
+QuorumProof handles professional credential attestation on Stellar Soroban.
+Security issues in the contracts, API server, or ZK verification pipeline can
+directly affect the integrity of issued credentials — please report them
+responsibly rather than disclosing them publicly.
+
+## Supported Versions
+
+Only the code on the `main` branch and the most recently deployed mainnet
+contract versions receive security fixes. There are no separate LTS branches
+at this time.
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report suspected vulnerabilities privately to:
+
+**security@quorumproof.io**
+
+If the report concerns a deployed smart contract with an active exploit path
+(e.g. a bug that lets funds or credentials be stolen or forged right now),
+say so explicitly in the subject line so it can be triaged immediately.
+
+### What to Include
+
+- A clear description of the vulnerability and its impact.
+- Affected component(s): `contracts/quorum_proof`, `contracts/sbt_registry`,
+  `contracts/zk_verifier`, `contracts/bbs_plus_v1`, `api-server`, `frontend`,
+  `dashboard`, or infrastructure/CI.
+- Steps to reproduce, or a proof-of-concept (a failing test against the
+  contract test harness is ideal for on-chain issues).
+- The commit hash or deployed contract address you tested against.
+- Your assessment of severity and any suggested mitigation, if you have one.
+
+Encrypt your report if it contains exploit details you consider sensitive;
+otherwise plain email is fine.
+
+### Response Process
+
+1. **Acknowledgment** — within 3 business days of your report.
+2. **Triage** — we confirm the issue, assess severity and affected scope,
+   and reply with our initial assessment within 7 business days.
+3. **Fix development** — a patch is developed and tested privately. For
+   contract bugs this includes a testnet redeployment dry run before any
+   mainnet action; see [Disaster Recovery](docs/disaster-recovery.md) for
+   the emergency pause/redeploy procedure used if the bug is actively
+   exploitable.
+4. **Disclosure coordination** — we agree on a disclosure date with you
+   (see Embargo Periods below).
+5. **Release & credit** — the fix ships, an advisory is published, and you
+   are credited (see Credit below) unless you ask to remain anonymous.
+
+### Embargo Periods
+
+We ask for a coordinated disclosure embargo so affected users have time to
+act, particularly for anything touching deployed contracts (on-chain fixes
+cannot be silently "patched" the way a server can):
+
+| Severity | Target embargo |
+|---|---|
+| Critical (active fund/credential exploit) | Up to 90 days, or until a fix is deployed and confirmed, whichever is sooner |
+| High (exploitable but not actively abused) | Up to 60 days |
+| Medium/Low | Up to 30 days, or by mutual agreement |
+
+If a vulnerability is already being actively exploited in the wild, we will
+move to emergency disclosure and mitigation (contract pause, key rotation,
+etc.) ahead of any embargo — see the emergency procedures in
+[docs/disaster-recovery.md](docs/disaster-recovery.md).
+
+We will extend or shorten these windows in discussion with the reporter
+based on real-world risk, complexity of the fix, and whether third parties
+(exchanges, integrators, custodians) need advance notice.
+
+### Credit
+
+Reporters who follow this policy and give us reasonable time to fix the
+issue before public disclosure will be credited by name (or handle) in the
+security advisory and release notes, unless they request anonymity. We do
+not currently run a paid bug bounty program.
+
+## Scope
+
+**In scope:**
+- `contracts/quorum_proof`, `contracts/sbt_registry`, `contracts/zk_verifier`,
+  `contracts/bbs_plus_v1` — logic errors, authorization bypass, storage
+  corruption, integer overflow, denial-of-service via gas exhaustion,
+  cryptographic weaknesses in the ZK verification or BBS+ signing paths.
+- `api-server` — authentication/authorization bypass, injection, request
+  signing/HMAC weaknesses, rate-limiting/DDoS-protection bypass.
+- `frontend`, `dashboard` — XSS, CSRF, key-handling bugs (e.g. exposing a
+  wallet secret), dependency vulnerabilities with a real exploit path.
+- CI/CD and deployment scripts — anything that could lead to a supply-chain
+  compromise of a release artifact or deployed contract.
+
+**Out of scope:**
+- Issues requiring physical access to a user's device.
+- Social engineering against QuorumProof maintainers or third-party
+  institutions issuing credentials.
+- Vulnerabilities in third-party dependencies with no demonstrated impact on
+  QuorumProof specifically (report those upstream instead).
+- Best-practice suggestions with no concrete exploit — open those as a
+  normal GitHub issue or discussion instead.
+
+## Background Reading
+
+- [Threat Model & Security Analysis](docs/threat-model.md) — asset
+  identification, threat actors, attack vectors and mitigations already
+  considered. Please check here first; a report that matches an already
+  -documented and accepted risk will be triaged accordingly.
+- [Security Best Practices Guide](docs/security-best-practices.md)
+- [Security Audit Checklist](docs/security-audit-checklist.md) — internal
+  review checklist, useful context for what we already check for.
+- [Known Limitations (ZK proof scheme)](docs/zk-proof-scheme-specification.md#13-known-limitations)
+- [Disaster Recovery Procedures](docs/disaster-recovery.md) — what happens
+  operationally once a critical issue is confirmed (emergency pause,
+  redeployment, credential restoration).

--- a/docs/claim-types.md
+++ b/docs/claim-types.md
@@ -1,0 +1,181 @@
+# Claim Type Registry
+
+## Overview
+
+A **claim type** is the specific assertion a zero-knowledge proof makes about
+a credential — e.g. "this credential holder has a degree" — without revealing
+the credential's underlying metadata. This is distinct from the
+[credential type registry](credential-types.md), which classifies what a
+*credential itself* is (a degree, a license, an employment record). A single
+credential type is typically proved against one or more claim types.
+
+Claim types are consumed by `generate_proof_request` /
+`generate_anonymous_proof_request` and `verify_claim` in
+`contracts/zk_verifier`, and mirrored in `contracts/quorum_proof` so the two
+contracts can pass the same value across the contract boundary (see the
+`#[repr(u32)]` note in `contracts/zk_verifier/src/lib.rs` — the two enums
+must stay byte-identical or cross-contract calls fail with a
+`ConversionError`).
+
+This document defines the canonical, standardized set of claim types, the
+proof circuit design behind each, the registry's versioning strategy, and
+the process for proposing a new one.
+
+## Canonical Claim Types
+
+`ClaimType` is a fixed, `#[repr(u32)]` enum — **not** an arbitrary string —
+defined identically in `contracts/quorum_proof/src/lib.rs` and
+`contracts/zk_verifier/src/lib.rs`:
+
+| Variant | Discriminant | Domain-separation index | Status |
+|---|---|---|---|
+| `HasDegree` | 1 | 0 | Standard |
+| `HasLicense` | 2 | 1 | Standard |
+| `HasEmploymentHistory` | 3 | 2 | Standard |
+| `HasCertification` | 4 | 3 | Standard |
+| `HasResearchPublication` | 5 | 4 | Standard |
+
+The "domain-separation index" is the value each claim type maps to
+internally (`ClaimType::HasDegree => 0u8`, etc. in `zk_verifier::lib.rs`) and
+is mixed into the Fiat-Shamir transcript / public-input encoding so a proof
+generated for one claim type cannot be replayed as valid for another. See
+[ZK Proof Scheme Specification](zk-proof-scheme-specification.md) and
+[PLONK Verification](plonk-verification.md) for the full transcript
+construction.
+
+> **Note on scope vs. the original proposal**: this issue's brief called for
+> `has_degree`, `has_license`, `experience_years`, and
+> `employer_verification`. Two of those (`HasDegree`, `HasLicense`) already
+> exist as-is. `experience_years` and `employer_verification` do not exist
+> as separate variants today — the closest existing type is
+> `HasEmploymentHistory`, which proves *that* an employment credential
+> exists and is valid, not a minimum-years threshold or a specific-employer
+> match. Adding either as a true standard type requires a new circuit (see
+> [Custom / Proposed Claim Types](#custom--proposed-claim-types) below) and
+> is not implemented in this change — this document defines the process so
+> that work can proceed as its own scoped task.
+
+## Proof Circuit Design Per Claim Type
+
+All standard claim types share one circuit *shape* — a membership /
+validity proof over a committed credential — differing only in which fields
+of the credential's metadata commitment are constrained. `verify_claim`
+takes `(admin, quorum_proof_contract, credential_id, claim_type, proof)`;
+`claim_type` selects the constraint set applied to `proof` against the
+on-chain credential commitment. See
+[ZK API Reference](zk-api-reference.md) for the full parameter reference and
+[Groth16 → PLONK Migration](groth16-migration.md) for the current backend.
+
+### `HasDegree` (1)
+
+- **Statement**: the subject holds a valid, non-revoked credential of type
+  `Degree` (or a descendant in the
+  [credential type hierarchy](credential-types.md#credential-type-hierarchy))
+  issued by an authorized issuer.
+- **Public inputs**: credential type root ID, issuer commitment, revocation
+  root, nonce.
+- **Private witness**: full credential metadata (institution, field of
+  study, graduation date), Merkle path to the credential commitment.
+- **What is *not* revealed**: institution name, GPA, exact graduation date.
+
+### `HasLicense` (2)
+
+- **Statement**: the subject holds a valid, non-expired professional license
+  credential, optionally scoped to a specific `license_type`
+  (see [credential-types.md](credential-types.md), Professional License
+  hierarchy) passed as an additional circuit parameter.
+- **Public inputs**: as above, plus `current_ledger_timestamp` so expiry can
+  be checked without revealing the exact `expiry_date`.
+- **Private witness**: license number, jurisdiction, discipline, issuing
+  authority, expiry date.
+- **What is *not* revealed**: license number, exact jurisdiction/discipline
+  unless the verifier explicitly requested a scoped proof.
+
+### `HasEmploymentHistory` (3)
+
+- **Statement**: the subject holds at least one valid Employment History
+  credential from an attested employer.
+- **Public inputs**: credential type root ID, issuer (employer) commitment.
+- **Private witness**: employer identity, role, dates of employment.
+- **What is *not* revealed**: employer identity, role, or duration — this is
+  existence-only. It does **not** prove a minimum tenure or a specific
+  employer; see `experience_years` / `employer_verification` below for how
+  those stronger statements would extend this circuit.
+
+### `HasCertification` (4)
+
+- **Statement**: the subject holds a valid, non-revoked Certificate-type
+  credential.
+- **Public inputs / witness**: same shape as `HasDegree`, scoped to the
+  Certificate branch of the credential type hierarchy.
+
+### `HasResearchPublication` (5)
+
+- **Statement**: the subject holds a valid credential attesting authorship
+  or co-authorship of a research publication.
+- **Public inputs / witness**: same shape as `HasDegree`, scoped to a
+  research-publication credential type.
+
+## Registry Versioning Strategy
+
+`ClaimType` is a compiled `#[repr(u32)]` Rust enum shared by two contracts,
+**not** a runtime-registrable value like the credential type registry — so
+its versioning rules are stricter:
+
+1. **Additive only, in-place.** New claim types are added as new enum
+   variants with the next unused discriminant (currently `6` is next).
+   Existing discriminants are never reused or renumbered — a `verify_claim`
+   call with a stale discriminant must always resolve to the same claim
+   type it did when issued, indefinitely.
+2. **No removals.** A claim type is never deleted, only marked `Deprecated`
+   in this document, to preserve verifiability of proofs generated against
+   it in the past.
+3. **Both contracts move together.** Because `quorum_proof` and
+   `zk_verifier` mirror this enum for cross-contract ABI compatibility
+   (see the safety comment at the top of the enum in
+   `contracts/zk_verifier/src/lib.rs`), a new variant must be added to
+   *both* files in the same change and deployed together. A mismatch
+   between the two is a deploy-time correctness bug, not just a docs gap.
+4. **Circuit changes require a new type, not a mutation.** If a claim's
+   constraint set changes in a way that alters what a proof attests to,
+   ship it as a new variant rather than changing what an existing
+   discriminant means — old proofs must keep verifying against the
+   semantics they were generated under.
+5. **This document is the source of truth for semantics.** The enum defines
+   the wire values; this file defines what each one *means*. Update this
+   table in the same PR that adds a variant.
+
+| Registry version | Change |
+|---|---|
+| 1.0 (current) | `HasDegree`, `HasLicense`, `HasEmploymentHistory`, `HasCertification`, `HasResearchPublication` |
+
+## Custom / Proposed Claim Type Process
+
+To propose a new standard claim type (e.g. `experience_years`,
+`employer_verification`):
+
+1. **Open an issue** describing the statement the claim should prove, and
+   explicitly what it must *not* reveal.
+2. **Design the circuit**: define public inputs, private witness, and how
+   the statement is constrained (e.g. `experience_years` needs a range
+   proof over a computed `end_date - start_date`, which is a materially
+   different circuit from the existence-only proofs above; a threshold
+   parameter such as "at least 5 years" becomes an additional public
+   input). Cross-reference against
+   [ZK Proof Scheme Specification](zk-proof-scheme-specification.md) for
+   the constraint primitives already available in the circuit.
+3. **Security review**: run the new circuit design past
+   [Threat Model & Security Analysis](threat-model.md) and
+   [Security Audit Checklist](security-audit-checklist.md) — a new proof
+   circuit is new attack surface (soundness/completeness of the
+   constraints, information leakage through public inputs).
+4. **Implement as a new discriminant** in both `quorum_proof::ClaimType`
+   and `zk_verifier::ClaimType` per the versioning rules above, with tests
+   in both contracts and in `contracts/integration_tests`.
+5. **Update this document** with the new type's row in the canonical table
+   and a full "Proof Circuit Design" subsection, and bump the registry
+   version above.
+
+Until a proposed type completes this process and lands as a real enum
+variant, it is **not** a valid `claim_type` value — `generate_proof_request`
+only accepts the five standard types listed above.

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -61,6 +61,53 @@ cursor, not in the orchestrator process.
 1. Redeploy from the latest tagged release on the `main` branch via the CI/CD pipeline (`workflow_dispatch` on `deploy.yml`).
 2. If the hosting provider is unavailable, deploy to an alternate static host using `npm run build` output from `frontend/` or `dashboard/`.
 
+### 1.6 API Server Compromise
+
+Use this procedure if there is evidence the `api-server` process, its host, or one of its secrets (`HMAC_SIGNING_SECRET`, `SHARE_LINK_HMAC_SECRET`, `BRIDGE_HMAC_SECRET`) has been compromised. The API server never holds credential-issuing authority itself — it only relays requests to the contracts and serves the search index — so compromise here is a confidentiality/availability incident, not a direct threat to on-chain state, but a compromised signing secret can be used to forge request signatures against downstream consumers.
+
+1. **Contain**: take the affected `api-server` instance(s) out of rotation at the load balancer / DNS level immediately. Do not wait for root-cause analysis to pull it offline.
+2. **Rotate every secret** the compromised instance had access to, even if you are not sure which one was used:
+   - `HMAC_SIGNING_SECRET`, `SHARE_LINK_HMAC_SECRET`, `BRIDGE_HMAC_SECRET` — generate new values, update the secret store / GitHub Actions secrets, redeploy.
+   - Any RPC credentials or `TRUSTED_IPS`/`TRUSTED_HEADER_VALUE` bypass values.
+   - Note: contract-level secrets (`STELLAR_SECRET_KEY`) are **not** stored on the API server; only rotate those too if the same host or operator also held them (see §1.1).
+3. **Invalidate sessions/tokens**: any share links or signed requests issued under the old `HMAC_SIGNING_SECRET`/`SHARE_LINK_HMAC_SECRET` become unverifiable once rotated — this is intentional; treat pre-rotation links as revoked.
+4. **Redeploy clean**: rebuild and redeploy `api-server` from a known-good `main` commit rather than restarting the compromised instance, in case of a persisted backdoor.
+5. **Audit**: pull request logs (rate limiter / DDoS protection middleware logs, see `api-server/src/middleware/`) for the suspected compromise window to scope what the attacker could have read (the search index is read-only relative to credential data — nothing in it grants issuance/attestation rights) or done (forged signatures on outbound requests).
+6. **Post-incident**: log cause and resolution per Step 5 of the [Recovery Runbook](#3-recovery-runbook); if the compromise involved a code-level vulnerability, follow the coordinated disclosure process in [SECURITY.md](../SECURITY.md).
+
+### 1.7 Contract Bug Discovery — Emergency Pause
+
+Use this procedure the moment a contract bug is discovered that could be exploited before a fix ships — do not wait for a full root-cause before pausing.
+
+1. **Pause immediately.** Two mechanisms exist; prefer the circuit breaker unless you need the simpler binary pause:
+   - `soroban contract invoke -- emergency_pause --admin <ADMIN> --reason "<short description>"` — moves the contract to `CircuitBreakerState::Paused`, blocks all mutating calls, and is logged as a `CircuitBreaker` event with the reason attached.
+   - `soroban contract invoke -- pause --admin <ADMIN>` — the simpler legacy binary pause flag (`is_paused()`), does not carry a reason and is not part of the circuit breaker state machine. Prefer `emergency_pause` for anything worth a postmortem.
+   - A lighter option for issues that only need writes slowed, not stopped, is `emergency_degrade --admin <ADMIN> --reason "..."` (`CircuitBreakerState::Degraded`), which rate-limits writes per ledger instead of blocking them entirely — use this for suspected-but-unconfirmed issues where halting the system entirely is a disproportionate response.
+   - Both circuit breaker states auto-recover after `ttl_seconds` if `auto_recover` is enabled in `CircuitBreakerConfig` — check `get_circuit_breaker_state()` and do not assume a pause is permanent without also disabling auto-recovery or tracking the TTL.
+2. **Confirm the pause took effect**: `soroban contract invoke -- get_circuit_breaker_state` (or `is_paused` for the legacy flag) before communicating "system is safe" to anyone.
+3. **Assess exploitability**: can the bug be triggered by a read-only call, or does it require a mutating call that is now blocked? A read-path bug is not mitigated by pausing writes.
+4. **Fix, test, redeploy**: develop the fix against a testnet fork, run the full contract test suite plus a regression test that reproduces the original bug, then follow §1.2 (Contract Redeployment).
+5. **Resume**: `soroban contract invoke -- resume --admin <ADMIN>` once the fix is live and verified — or `unpause` if the legacy flag was used. Do not resume on a timer; resume only after the fix is confirmed deployed.
+6. **Disclose** per [SECURITY.md](../SECURITY.md)'s embargo guidance once affected users have had a chance to act.
+
+#### Emergency Withdrawal Considerations
+
+There is **no separate "emergency withdrawal" function that bypasses the pause** — attestor stake withdrawal (`withdraw_attestor_stake`) itself calls `require_not_paused`, so **pausing the contract also blocks attestors from withdrawing their bonded stake** until it is unpaused or degraded-mode-only writes are re-enabled. This is a deliberate trade-off (a paused contract must not leak funds through any path, including withdrawal, while its integrity is in question) but it means:
+
+- Do not pause and then leave the contract paused indefinitely while attestors have funds locked — resolve the bug and resume as quickly as safely possible.
+- If a bug is scoped narrowly enough that stake withdrawal is definitely unaffected, prefer `emergency_degrade` over a full `emergency_pause` so legitimate withdrawals can continue at a rate-limited pace while the issue is investigated.
+- Communicate the pause and its expected duration to attestors — locked stake during an active pause is expected operator communication, not a silent freeze.
+
+### 1.8 Credential Database / Search Index Corruption
+
+QuorumProof has no traditional off-chain database of record — the source of truth is always on-chain contract state. "Database corruption" in this system means the **search index** (`api-server/src/searchIndex.ts`) or a **local state snapshot** (§2.1) diverging from on-chain truth, not corruption of a SQL/NoSQL store.
+
+1. **Detect**: `./scripts/verify_snapshot.sh` (§2.2) or a manual comparison of `get_credential_count()` against the search index's indexed count surfaces divergence.
+2. **Do not trust the index for verification decisions** while corruption is suspected — `verify_engineer` and other verification paths ultimately check on-chain state via cross-contract calls, but any API-server-side caching or search results should be treated as advisory only until rebuilt.
+3. **Rebuild from chain**: the search index is derived data, not authoritative — take the affected `api-server` instance out of rotation, clear its in-memory/cached index, and rebuild it by replaying on-chain credential/slice/attestation state from genesis (or from the last known-good snapshot per §2.1, then catching up from the current ledger).
+4. **Verify**: re-run `./scripts/verify_snapshot.sh` and spot-check a sample of credentials via `get_credential` directly against the contract to confirm the rebuilt index matches chain state.
+5. **Root-cause** before returning to service if the divergence was caused by an API-server bug (e.g. a missed event) rather than an infrastructure fault — otherwise the rebuilt index will drift again.
+
 ---
 
 ## 2. Backup Strategy
@@ -113,6 +160,34 @@ The verifier checks:
 - Credential count matches `get_credential_count()` on-chain
 - Slice count matches `get_slice_count()` on-chain
 - No credential IDs are missing from the sequence
+
+### 2.3 Recovery Time & Recovery Point Objectives (RTO/RPO)
+
+RTO is the target time to restore service; RPO is the maximum acceptable
+data loss, measured in time since the last durable backup/state. Because
+credential and attestation data is written directly to the Stellar chain,
+on-chain data has an effective RPO of zero — it is never behind a backup
+cadence. RPO only applies to off-chain supporting state (snapshots, search
+index, frontend deployments) that is not itself blockchain-native.
+
+| Scenario | RTO (target) | RPO (target) | Basis |
+|---|---|---|---|
+| Lost deployer/admin key (backup key exists) | < 1 hour | 0 (no data loss — on-chain state untouched) | §1.1 |
+| Lost deployer/admin key (no backup) | Not recoverable — full redeploy + re-issuance | Full loss of on-chain credential history under the old contract address | §1.1 |
+| Contract redeployment (bug fix) | 2–4 hours (build, deploy, restore state) | 0 for chain data; up to 24h for off-chain snapshot freshness | §1.2, §3 |
+| RPC / network outage | < 15 minutes (config change only) | 0 | §1.3 |
+| Migration interrupted mid-run | < 30 minutes (resume from cursor) | 0 — cursor lives on-chain | §1.4 |
+| Frontend / dashboard outage | < 1 hour | 0 (stateless, redeployed from source) | §1.5 |
+| API server compromise | < 1 hour to contain + rotate secrets; full redeploy within 4 hours | 0 for chain data; search index rebuild time is separate (see below) | §1.6 |
+| Contract bug — emergency pause | < 15 minutes to pause; fix timeline varies by severity | 0 (pause blocks writes, does not lose data) | §1.7 |
+| Credential DB / search index corruption | 1–4 hours to rebuild from chain, depending on total credential count | 0 — index is fully derivable from on-chain state | §1.8 |
+| State snapshot loss (off-chain backup) | N/A — snapshots are a convenience, not authoritative | Up to 24 hours (daily snapshot cadence, §2) — acceptable because chain data itself is not lost | §2 |
+
+These targets assume the backup key, contract IDs, and off-chain snapshots
+required by §2 are actually in place and current — an untested or missing
+backup key changes the "lost key" row from < 1 hour to "not recoverable."
+Recovery drills (§4) exist specifically to validate these targets are
+achievable, not just aspirational.
 
 ---
 
@@ -191,7 +266,21 @@ Run recovery drills on testnet. Do **not** use mainnet for drills.
 2. Run `cargo test` and confirm all contract interactions succeed.
 3. Restore the primary RPC URL.
 
-### 4.5 Checklist
+### 4.5 Emergency Pause Drill (quarterly)
+
+1. On testnet, call `emergency_pause` with a test reason and confirm `get_circuit_breaker_state()` returns `Paused`.
+2. Confirm a mutating call (e.g. `issue_credential`) is rejected while paused.
+3. Confirm `withdraw_attestor_stake` is also rejected while paused (see §1.7, Emergency Withdrawal Considerations) — this is expected behavior, not a bug.
+4. Call `resume` and confirm normal operation returns, including that a previously-blocked withdrawal now succeeds.
+5. Repeat with `emergency_degrade` and confirm writes are rate-limited rather than fully blocked.
+
+### 4.6 API Secret Rotation Drill (quarterly)
+
+1. On a non-production `api-server` instance, rotate `HMAC_SIGNING_SECRET` per §1.6.
+2. Confirm requests signed with the old secret are rejected and requests signed with the new secret succeed.
+3. Confirm the rotation process (secret store update → redeploy) completes within the §2.3 RTO target for API server compromise.
+
+### 4.7 Checklist
 
 - [ ] Deployer key backup verified in cold storage
 - [ ] Contract IDs recorded and accessible to the team
@@ -200,4 +289,6 @@ Run recovery drills on testnet. Do **not** use mainnet for drills.
 - [ ] RPC failover endpoint confirmed reachable
 - [ ] Latest snapshot verified and uploaded to off-chain storage
 - [ ] Restore drill completed successfully on testnet
+- [ ] Emergency pause/resume drill completed, including withdrawal-blocked-while-paused check
+- [ ] API secret rotation drill completed within RTO target
 - [ ] Recovery drill results logged with date and outcome

--- a/docs/perf-regression.md
+++ b/docs/perf-regression.md
@@ -1,0 +1,155 @@
+# Performance Regression Testing
+
+## Overview
+
+QuorumProof's performance-critical code is the Soroban smart contracts
+(`contracts/quorum_proof`, `contracts/sbt_registry`, `contracts/zk_verifier`).
+For a smart contract, "performance" means **on-chain resource consumption**
+(CPU instructions and memory bytes, metered deterministically by
+`soroban-sdk`'s budget system) rather than wall-clock time — wall-clock
+benchmarking (e.g. the `criterion` crate) measures something contracts don't
+actually pay for on-chain, and would not catch a regression that costs real
+gas while running fast on a benchmarking machine. This is why the project's
+performance regression suite (`benches/`) is built directly on
+`env.budget()` instead of `criterion`: it measures the same units the chain
+itself enforces.
+
+This document describes the existing baseline/regression system, how to run
+and extend it, and where its coverage currently stops.
+
+## What Is Measured
+
+`benches/tests/benchmarks.rs` measures CPU instructions and memory bytes for:
+
+- `issue_credential`, `create_slice`, `attest`, `revoke_credential`
+- `mint_sbt`, `burn_sbt` (sbt_registry)
+- `verify_claim`, `verify_plonk_proof`, `verify_aggregate_proof` (zk_verifier)
+- `verify_engineer` (full cross-contract QuorumProof → SbtRegistry → ZkVerifier path)
+- `batch_issue_credentials`, `verify_attestations_batch` (batch operations)
+
+Each measurement resets the budget (`env.budget().reset_default()`), runs
+the operation once, and reads `cpu_instruction_cost()` /
+`memory_bytes_cost()` — see the `measure()` helper near the top of
+`benches/tests/benchmarks.rs`.
+
+## Regression Thresholds (Fixed Gate)
+
+Every operation above has a `const THRESHOLD_*_CPU` / `THRESHOLD_*_MEM` in
+`benches/tests/benchmarks.rs`, set at **measured baseline × 1.10** (a strict
+10% regression budget). A test `assert!`s that the measured cost stays at or
+under its threshold; if not, the test fails.
+
+**Raise a threshold only with a written justification in the PR** — a
+threshold bump silently hides a regression from every future run.
+
+Run the fixed-threshold suite:
+
+```bash
+cargo test -p quorum-proof-benches --test benchmarks -- --nocapture
+```
+
+`scripts/benchmark_compare.sh` wraps this and extracts the printed
+`cpu=... mem=...` lines into `benchmark-results.json` for comparison against
+a stored baseline file. `scripts/profile_contracts.sh` runs the same suite
+and produces a Markdown hotspot report (`target/profile_report.md`),
+flagging any operation using >80% of its threshold even though it hasn't
+failed yet.
+
+## Scaling / Complexity-Class Gate (Trend Detection)
+
+The fixed-threshold gate above catches a single run's absolute cost, but not
+a *shape* regression that creeps in gradually (e.g. an O(n) loop becoming
+O(n²) while staying under threshold at today's n). `bench_*_scaling` tests
+in the same file run an operation across a range of `n` (capped at the
+contract's own limits — `MAX_ATTESTORS_PER_SLICE` = 20,
+`MAX_BATCH_SIZE` = 50 — since no real call can exceed those) and record each
+`(n, cpu, mem)` point via `quorum_proof_benches::scaling::record_point`.
+
+`benches/src/bin/scaling_report.rs` then:
+
+1. Fits `cost ≈ a·n^b` by OLS log-log regression per operation
+   (`benches/src/complexity.rs`) and classifies the exponent `b` as
+   `LinearOrBetter` (b < 1.2), `Superlinear` (1.2 ≤ b < 1.8, flagged but not
+   gate-failing), or `QuadraticOrWorse` (b ≥ 1.8, **fails the gate**).
+2. Appends the fit to `benches/history/<op>.jsonl` (`benches/src/history.rs`)
+   — one line per CI run, committed to the repo so history is diffable via
+   normal `git log` rather than living only in CI artifact retention — and
+   compares the new exponent against the prior entry to surface drift even
+   when the current run alone doesn't fail.
+3. Renders `benches/target/bench-scaling-report.md`.
+
+Run both steps together:
+
+```bash
+./scripts/scaling_benchmark_report.sh
+```
+
+### CI Wiring
+
+`.github/workflows/benchmarks.yml` runs `scripts/scaling_benchmark_report.sh`
+on every PR/push touching `contracts/**` or `benches/**`, uploads the
+report and raw data as a build artifact, and **fails the job** if the
+complexity gate reports a failure.
+
+Note: `benches` is intentionally excluded from the root Cargo workspace
+(`Cargo.toml`'s `exclude = [...]`), so the main `ci.yml`'s
+`cargo test --workspace` does **not** run these benchmarks — coverage comes
+entirely from the dedicated `benchmarks.yml` workflow above. Keep this in
+mind if `benches/Cargo.toml` or its dependency versions ever drift from the
+root workspace's `soroban-sdk` version; there's no single `cargo test` run
+that would catch a mismatch.
+
+## Historical Baselines
+
+Recorded 2025-05, `soroban-sdk` 21.x testutils (see the header comment in
+`benches/tests/benchmarks.rs` for the authoritative, currently-maintained
+copy):
+
+| Operation | CPU (baseline) | Memory (baseline) |
+|---|---|---|
+| `issue_credential` | ~1,500,000 | ~1,500,000 |
+| `create_slice` | ~1,500,000 | ~1,500,000 |
+| `attest` | ~1,500,000 | ~1,500,000 |
+| `revoke_credential` | ~1,100,000 | ~1,100,000 |
+| `mint_sbt` | ~2,600,000 | ~2,600,000 |
+| `burn_sbt` | ~1,500,000 | ~1,500,000 |
+| `verify_claim` | ~1,100,000 | ~1,100,000 |
+| `verify_engineer` (cross-contract) | ~4,000,000 | ~4,000,000 |
+| `batch_issue` (5) | ~9,000,000 | ~9,000,000 |
+| `batch_verify` (5) | ~3,000,000 | ~3,000,000 |
+
+Each CI-enforced threshold in `benches/tests/benchmarks.rs` is this baseline
+× 1.10.
+
+## Large-Scale / High-Volume Coverage
+
+The scaling tests above already exercise the full range reachable through
+the public contract API for batch operations (`n` up to `MAX_BATCH_SIZE`,
+i.e. 50 — a real transaction cannot request a larger batch, so testing
+beyond that measures something no caller can trigger).
+
+`benches/load_test_batch_operations.rs` is a separate file intended to
+stress-test **1000+ sequential credential issuances** (i.e. cumulative
+system-wide volume, not a single oversized batch call) using
+`libfuzzer-sys`/`arbitrary`. **This file is currently unwired**: it is not
+declared as a `[[bin]]` target in `benches/Cargo.toml` (which has neither
+`libfuzzer-sys` nor `arbitrary` as a dependency), nor in `fuzz/Cargo.toml`'s
+`[[bin]]` list alongside the other fuzz targets in `fuzz/fuzz_targets/`. As
+written, it cannot currently be built or run — recorded here rather than
+silently left to look like working coverage. Wiring it up (moving it under
+`fuzz/fuzz_targets/` and adding a matching `[[bin]]` entry, or converting it
+to a `benches/tests/`-style integration test against a loop of 1000+
+`issue_credential` calls) is tracked as follow-up scope, not included in
+this documentation pass.
+
+## Adding a New Benchmark
+
+1. Add a `#[test] fn bench_<operation>()` to `benches/tests/benchmarks.rs`
+   following the existing pattern: `measure(&env, || { ... })`, print
+   `cpu=... mem=...`, `assert!` against a new `THRESHOLD_*` constant set to
+   the measured baseline × 1.10.
+2. If the operation takes an `n`-sized input, add a matching
+   `bench_<operation>_scaling` test capped at the relevant contract-enforced
+   maximum, calling `scaling::record_point`.
+3. Run `./scripts/scaling_benchmark_report.sh` locally to confirm the new
+   operation gets a clean complexity-class fit before opening a PR.


### PR DESCRIPTION
## Summary

Four documentation/ops tasks resolved in this PR:

- **SECURITY.md** — responsible disclosure policy, bug reporting process, embargo periods scaled by severity, credit acknowledgments, `security@quorumproof.io` contact, and links to the existing threat model, security best practices, audit checklist, and known-limitations docs.
- **docs/claim-types.md** — canonical registry for the `ClaimType` enum shared by `contracts/quorum_proof` and `contracts/zk_verifier` (`HasDegree`, `HasLicense`, `HasEmploymentHistory`, `HasCertification`, `HasResearchPublication`), proof circuit design per type, a versioning strategy (additive-only, both contracts move together, no discriminant reuse), and the process for proposing new types such as `experience_years`/`employer_verification` — which don't exist as standard types today and are documented as a process, not implemented as new enum variants.
- **docs/disaster-recovery.md** — extends the existing runbook with procedures for API server compromise (secret rotation, containment), contract bug discovery (`emergency_pause` vs `emergency_degrade`, the circuit breaker's auto-recovery TTL, and the interaction where `withdraw_attestor_stake` is itself blocked while paused), and credential/search-index corruption (rebuild from on-chain state, since there is no traditional off-chain database). Adds an RTO/RPO table covering every recovery scenario, and two new recovery drills (emergency pause, API secret rotation) plus checklist items.
- **docs/perf-regression.md** — documents the existing budget-based benchmark suite (`benches/`), explains why it measures on-chain CPU/mem via `env.budget()` instead of using `criterion` (criterion measures wall-clock time, which contracts don't pay gas for), the fixed 10% regression-threshold gate, the scaling/complexity-class drift gate and its `benches/history/*.jsonl` trend tracking, and how `benchmarks.yml` gates CI. Also documents that `benches/load_test_batch_operations.rs` (a 1000+ sequential-issuance load test) is not currently wired into any `Cargo.toml` `[[bin]]` target and cannot be built as-is — flagged as a real gap rather than claimed as working coverage.

Closes #1004
Closes #1005
Closes #1006
Closes #1007

## Test plan

- [x] Docs-only change; no code paths affected.
- [x] Cross-checked all referenced contract functions (`pause`, `unpause`, `emergency_pause`, `emergency_degrade`, `resume`, `withdraw_attestor_stake`, `ClaimType` enum discriminants) directly against `contracts/quorum_proof/src/lib.rs` and `contracts/zk_verifier/src/lib.rs` for accuracy.
- [x] Verified `benches/load_test_batch_operations.rs` is genuinely unwired (absent from both `benches/Cargo.toml` and `fuzz/Cargo.toml` `[[bin]]` lists) before documenting it as a gap.