### PR TITLE
Add credential export, issuer analytics, contract integration tests, and chaos testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,11 @@ HMAC_SIGNING_SECRET=
 # Issue #877: Share link password hashing secret
 SHARE_LINK_HMAC_SECRET=change-me-in-production
 
+# Issue #1000: externally-reachable origin used to build the verification
+# URL embedded in credential export QR codes/PDFs (the API server doesn't
+# otherwise know its own public origin behind a load balancer/proxy).
+PUBLIC_APP_BASE_URL=http://localhost:3000
+
 # Issue #880: Cross-chain bridge configuration
 # Secret used to authenticate bridge relay proofs
 BRIDGE_HMAC_SECRET=change-me-in-production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,24 @@ jobs:
       - run: npm test
       - run: npm run build
 
+  # Issue #1003: chaos test scenarios (network delay, packet loss, sustained
+  # service unavailability) injected into api-server's mocked RPC client.
+  # See docs/resilience.md for the requirements these verify.
+  api-server-chaos:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: api-server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: api-server/package-lock.json
+      - run: npm ci
+      - run: npm test -- tests/chaos.test.ts
+
   security:
     runs-on: ubuntu-latest
     steps:

--- a/api-server/package-lock.json
+++ b/api-server/package-lock.json
@@ -21,12 +21,16 @@
         "ethers": "^6.17.0",
         "express": "^4.21.2",
         "ioredis": "^5.11.1",
+        "pdfkit": "^0.19.1",
+        "qrcode": "^1.5.4",
         "ws": "^8.21.0"
       },
       "devDependencies": {
         "@types/compression": "^1.8.1",
         "@types/express": "^5.0.3",
         "@types/node": "^24.12.0",
+        "@types/pdfkit": "^0.17.6",
+        "@types/qrcode": "^1.5.6",
         "@types/supertest": "^7.2.0",
         "@types/ws": "^8.18.1",
         "hardhat": "^3.10.0",
@@ -617,6 +621,18 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@noble/curves": {
       "version": "2.2.0",
@@ -1409,6 +1425,21 @@
         "@streamparser/json": "^0.0.22"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@swc/helpers/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -1501,6 +1532,26 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/pdfkit": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/pdfkit/-/pdfkit-0.17.6.tgz",
+      "integrity": "sha512-tIwzxk2uWKp0Cq9JIluQXJid77lYhF52EsIOwhsMF4iWLA6YneoBR1xVKYYdAysHuepUB0OX4tdwMiUDdGKmig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -1758,7 +1809,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1893,6 +1943,24 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -1982,6 +2050,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
@@ -2028,6 +2105,26 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
@@ -2036,6 +2133,24 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2186,6 +2301,15 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -2263,6 +2387,12 @@
         "wrappy": "1"
       }
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -2271,6 +2401,12 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2290,6 +2426,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -2692,6 +2834,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
@@ -2710,6 +2865,23 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/for-each": {
@@ -2801,6 +2973,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-func-name": {
@@ -3123,6 +3304,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-retry-allowed": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
@@ -3174,6 +3364,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
+    },
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -3203,6 +3399,25 @@
         "node": ">=7.10.1"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/local-pkg": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
@@ -3217,6 +3432,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/loupe": {
@@ -3567,6 +3794,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-map": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
@@ -3580,6 +3834,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3587,6 +3856,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -3619,6 +3897,32 @@
         "node": "*"
       }
     },
+    "node_modules/pdfkit": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.19.1.tgz",
+      "integrity": "sha512-6Gzk+wDwTs4VSxsR5rCMTnIl5nlmkye1oWB0l2hDB1EX6ZNSIBroKQEv+2+fPPn+stVjyqzmsqRJVDfB9fo5DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "fontkit": "^2.0.4",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.1.0"
+      }
+    },
+    "node_modules/pdfkit/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3641,6 +3945,23 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true
+    },
+    "node_modules/png-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -3713,6 +4034,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/qs": {
@@ -3804,6 +4142,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3812,6 +4159,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
@@ -3822,6 +4175,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
@@ -3957,6 +4316,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -4192,11 +4557,24 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -4312,6 +4690,12 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -4476,6 +4860,32 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -5124,6 +5534,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.21.tgz",
@@ -5162,6 +5578,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -5187,6 +5632,47 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/api-server/package.json
+++ b/api-server/package.json
@@ -25,12 +25,16 @@
     "ethers": "^6.17.0",
     "express": "^4.21.2",
     "ioredis": "^5.11.1",
+    "pdfkit": "^0.19.1",
+    "qrcode": "^1.5.4",
     "ws": "^8.21.0"
   },
   "devDependencies": {
     "@types/compression": "^1.8.1",
     "@types/express": "^5.0.3",
     "@types/node": "^24.12.0",
+    "@types/pdfkit": "^0.17.6",
+    "@types/qrcode": "^1.5.6",
     "@types/supertest": "^7.2.0",
     "@types/ws": "^8.18.1",
     "hardhat": "^3.10.0",

--- a/api-server/src/index.ts
+++ b/api-server/src/index.ts
@@ -4,9 +4,11 @@ import compression from 'compression';
 import zlib from 'zlib';
 import slicesRouter from './routes/slices.js';
 import credentialsRouter from './routes/credentials.js';
+import credentialExportRouter from './routes/credentialExport.js';
 import verifyRouter from './routes/verify.js';
 import notificationsRouter from './routes/notifications.js';
 import analyticsRouter from './routes/analytics.js';
+import issuerAnalyticsRouter from './routes/issuerAnalytics.js';
 import attestorRouter from './routes/attestor.js';
 import issuerRouter from './routes/issuer.js';
 import recoveryRouter from './routes/recovery.js';
@@ -66,11 +68,13 @@ app.use((req, _res, next) => {
 
 app.use('/api/slices', slicesRouter);
 app.use('/api/credentials', credentialsRouter);
+app.use('/api/credentials', credentialExportRouter); // #1000 credential export (json/pdf/qrcode)
 app.use('/api/verify', verifyRouter);
 app.use('/api/credentials', shareLinksRouter); // #877 share links
 app.use('/api/credentials', consentRouter); // #881 consent management
 app.use('/api/notifications', notificationsRouter);
 app.use('/api/analytics', analyticsRouter);
+app.use('/api/analytics', issuerAnalyticsRouter); // #1001 issuer analytics (credentials/verifications/disputes)
 app.use('/api/attestor', attestorRouter);
 app.use('/api/issuer', issuerRouter);
 app.use('/api/recovery', recoveryRouter);

--- a/api-server/src/routes/credentialExport.ts
+++ b/api-server/src/routes/credentialExport.ts
@@ -1,0 +1,191 @@
+/**
+ * Issue #1000 — Credential Export API
+ *
+ * Routes:
+ *   GET /api/credentials/:id/export?format=json|pdf|qrcode
+ */
+import { Router, Request, Response } from 'express';
+import QRCode from 'qrcode';
+import PDFDocument from 'pdfkit';
+import type { SorobanClient } from './credentials.js';
+
+function serializeBigInt(value: unknown): unknown {
+  if (typeof value === 'bigint') return value.toString();
+  if (Array.isArray(value)) return value.map(serializeBigInt);
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, serializeBigInt(v)])
+    );
+  }
+  return value;
+}
+
+const EXPORT_FORMATS = ['json', 'pdf', 'qrcode'] as const;
+type ExportFormat = (typeof EXPORT_FORMATS)[number];
+
+/**
+ * Public URL a holder's verifier can visit (or a QR scanner lands on) to
+ * check a credential's live status. Configurable via `PUBLIC_APP_BASE_URL`
+ * since the API server doesn't otherwise know its own externally-reachable
+ * origin (it may sit behind a load balancer / reverse proxy).
+ */
+function verificationUrl(credentialId: number): string {
+  const base = (process.env.PUBLIC_APP_BASE_URL ?? 'http://localhost:3000').replace(/\/+$/, '');
+  return `${base}/api/verify/${credentialId}`;
+}
+
+/**
+ * Renders a single-credential PDF: title, issuer logo (best-effort — the
+ * export still succeeds if the logo URL is missing or unreachable), core
+ * credential fields, and a footer with the verification URL.
+ */
+async function renderCredentialPdf(
+  record: Record<string, unknown>,
+  credentialId: number,
+  verifyUrl: string
+): Promise<Buffer> {
+  const doc = new PDFDocument({ size: 'A4', margin: 50 });
+  const chunks: Buffer[] = [];
+  doc.on('data', (chunk: Buffer) => chunks.push(chunk));
+  const finished = new Promise<Buffer>((resolve, reject) => {
+    doc.on('end', () => resolve(Buffer.concat(chunks)));
+    doc.on('error', reject);
+  });
+
+  const metadata = (record.metadata as Record<string, unknown> | undefined) ?? {};
+  const logoUrl = typeof metadata.issuer_logo_url === 'string' ? metadata.issuer_logo_url : undefined;
+
+  let logoEmbedded = false;
+  if (logoUrl) {
+    try {
+      const resp = await fetch(logoUrl);
+      if (resp.ok) {
+        const bytes = Buffer.from(await resp.arrayBuffer());
+        doc.image(bytes, 50, 45, { width: 60, height: 60 });
+        logoEmbedded = true;
+      }
+    } catch {
+      // Best-effort: the export must still succeed without the logo.
+    }
+  }
+
+  doc
+    .fontSize(20)
+    .text('QuorumProof Credential', logoEmbedded ? 125 : 50, 50);
+  doc.moveDown(logoEmbedded ? 1.5 : 2);
+
+  doc.fontSize(12).fillColor('black');
+  const fields: Array<[string, unknown]> = [
+    ['Credential ID', credentialId],
+    ['Subject', record.subject],
+    ['Issuer', record.issuer],
+    ['Credential Type', record.credential_type],
+    ['Metadata Hash', record.metadata_hash],
+    ['Revoked', record.revoked ? 'Yes' : 'No'],
+    ['Suspended', record.suspended ? 'Yes' : 'No'],
+    ['Expires At', record.expires_at ?? 'Never'],
+    ['Created At', record.created_at ?? 'Unknown'],
+    ['Version', record.version],
+  ];
+  for (const [label, value] of fields) {
+    doc.text(`${label}: ${value === null || value === undefined ? 'N/A' : String(value)}`);
+  }
+
+  doc.moveDown();
+  doc
+    .fontSize(10)
+    .fillColor('gray')
+    .text(`Verify at: ${verifyUrl}`)
+    .text(`Exported: ${new Date().toISOString()}`);
+
+  doc.end();
+  return finished;
+}
+
+export function createCredentialExportRouter(soroban: SorobanClient) {
+  const router = Router();
+
+  /**
+   * GET /api/credentials/:id/export
+   * Query params:
+   *   - format: "json" (default) | "pdf" | "qrcode"
+   */
+  router.get('/:id/export', async (req: Request, res: Response) => {
+    const credentialId = parseInt(req.params.id, 10);
+    if (!Number.isInteger(credentialId) || credentialId <= 0) {
+      res.status(400).json({ error: 'Invalid credential ID' });
+      return;
+    }
+
+    const format = (typeof req.query.format === 'string' ? req.query.format : 'json') as ExportFormat;
+    if (!EXPORT_FORMATS.includes(format)) {
+      res.status(400).json({ error: `format must be one of: ${EXPORT_FORMATS.join(', ')}` });
+      return;
+    }
+
+    let record: Record<string, unknown>;
+    try {
+      const cred = await soroban.simulateCall('get_credential', [soroban.u64Val(credentialId)]);
+      record = serializeBigInt(cred) as Record<string, unknown>;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.toLowerCase().includes('credentialnotfound') || msg.toLowerCase().includes('not found')) {
+        res.status(404).json({ error: 'Credential not found' });
+      } else {
+        res.status(500).json({ error: msg });
+      }
+      return;
+    }
+
+    const verifyUrl = verificationUrl(credentialId);
+
+    if (format === 'json') {
+      res.json({
+        credential: record,
+        verification_url: verifyUrl,
+        exported_at: new Date().toISOString(),
+      });
+      return;
+    }
+
+    if (format === 'qrcode') {
+      try {
+        const png = await QRCode.toBuffer(verifyUrl, {
+          type: 'png',
+          errorCorrectionLevel: 'M',
+          margin: 2,
+          width: 300,
+        });
+        res.set('Content-Type', 'image/png');
+        res.set('Content-Disposition', `inline; filename="credential-${credentialId}-qrcode.png"`);
+        res.send(png);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        res.status(500).json({ error: msg });
+      }
+      return;
+    }
+
+    // format === 'pdf'
+    try {
+      const pdfBuffer = await renderCredentialPdf(record, credentialId, verifyUrl);
+      res.set('Content-Type', 'application/pdf');
+      res.set('Content-Disposition', `attachment; filename="credential-${credentialId}.pdf"`);
+      res.send(pdfBuffer);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: msg });
+    }
+  });
+
+  return router;
+}
+
+// Default export using the real Soroban client
+import { simulateCall, u64Val, u32Val, addressVal } from '../soroban.js';
+export default createCredentialExportRouter({
+  simulateCall,
+  u64Val: u64Val as unknown as SorobanClient['u64Val'],
+  u32Val: u32Val as unknown as SorobanClient['u32Val'],
+  addressVal: addressVal as unknown as SorobanClient['addressVal'],
+});

--- a/api-server/src/routes/issuerAnalytics.ts
+++ b/api-server/src/routes/issuerAnalytics.ts
@@ -1,0 +1,233 @@
+/**
+ * Issue #1001 — Issuer Analytics Endpoint
+ *
+ * Routes:
+ *   GET /api/analytics/credentials?issuer=&range=7d|30d|90d
+ *   GET /api/analytics/verifications?range=7d|30d|90d
+ *   GET /api/analytics/disputes?issuer=&range=7d|30d|90d
+ */
+import { Router, Request, Response } from 'express';
+import type { SorobanClient } from './credentials.js';
+import { metricsStore, parseRangeParam } from '../services/metrics.js';
+
+function serializeBigInt(value: unknown): unknown {
+  if (typeof value === 'bigint') return value.toString();
+  if (Array.isArray(value)) return value.map(serializeBigInt);
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, serializeBigInt(v)])
+    );
+  }
+  return value;
+}
+
+type ExpiryBucket = 'expired' | 'expiring_7d' | 'expiring_30d' | 'expiring_90d' | 'expiring_later' | 'no_expiry';
+
+function bucketExpiry(expiresAt: unknown): ExpiryBucket {
+  if (!expiresAt || typeof expiresAt !== 'string') return 'no_expiry';
+  const at = new Date(expiresAt);
+  if (isNaN(at.getTime())) return 'no_expiry';
+  const days = (at.getTime() - Date.now()) / (24 * 60 * 60 * 1000);
+  if (days < 0) return 'expired';
+  if (days <= 7) return 'expiring_7d';
+  if (days <= 30) return 'expiring_30d';
+  if (days <= 90) return 'expiring_90d';
+  return 'expiring_later';
+}
+
+export function createIssuerAnalyticsRouter(soroban: SorobanClient) {
+  const router = Router();
+
+  /**
+   * GET /api/analytics/credentials
+   * Query params: issuer (required), range (7d|30d|90d, default 30d)
+   * Returns: total issued, breakdown by credential type, expiry distribution.
+   */
+  router.get('/credentials', async (req: Request, res: Response) => {
+    const issuer = typeof req.query.issuer === 'string' ? req.query.issuer : undefined;
+    if (!issuer) {
+      res.status(400).json({ error: 'issuer query parameter is required' });
+      return;
+    }
+
+    let window: ReturnType<typeof parseRangeParam>;
+    try {
+      window = parseRangeParam(typeof req.query.range === 'string' ? req.query.range : undefined);
+    } catch (err: unknown) {
+      res.status(400).json({ error: err instanceof Error ? err.message : 'Invalid range' });
+      return;
+    }
+    const windowStartMs = new Date(window.startDate).getTime();
+
+    try {
+      const credCount: bigint = await soroban.simulateCall('get_credential_count', []);
+      const total = Number(credCount);
+
+      let totalIssued = 0;
+      const byType: Record<string, number> = {};
+      const expiryDistribution: Record<ExpiryBucket, number> = {
+        expired: 0,
+        expiring_7d: 0,
+        expiring_30d: 0,
+        expiring_90d: 0,
+        expiring_later: 0,
+        no_expiry: 0,
+      };
+
+      for (let i = 1; i <= total; i++) {
+        try {
+          const cred = await soroban.simulateCall('get_credential', [soroban.u64Val(i)]);
+          const record = serializeBigInt(cred) as Record<string, unknown>;
+          if (record.issuer !== issuer) continue;
+
+          const createdAt = typeof record.created_at === 'string' ? new Date(record.created_at).getTime() : NaN;
+          if (!isNaN(createdAt) && createdAt < windowStartMs) continue;
+
+          totalIssued++;
+          const type = String(record.credential_type ?? 'unknown');
+          byType[type] = (byType[type] ?? 0) + 1;
+          expiryDistribution[bucketExpiry(record.expires_at)]++;
+        } catch {
+          // skip missing/inaccessible credentials
+        }
+      }
+
+      res.json({
+        issuer,
+        range: `${window.days}d`,
+        start_date: window.startDate,
+        end_date: window.endDate,
+        total_issued: totalIssued,
+        by_type: byType,
+        expiry_distribution: expiryDistribution,
+      });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: msg });
+    }
+  });
+
+  /**
+   * GET /api/analytics/verifications
+   * Query params: range (7d|30d|90d, default 30d)
+   * Returns: verification count by claim type, verifier distribution.
+   *
+   * Sourced from the same analytics event log `POST /api/analytics/events`
+   * writes to — `POST /api/verify/batch` and `GET /api/verify/:id` both
+   * record a `verified` event (with `claim_type`/`verifier` in `metadata`)
+   * on every successful verification.
+   */
+  router.get('/verifications', (req: Request, res: Response) => {
+    let window: ReturnType<typeof parseRangeParam>;
+    try {
+      window = parseRangeParam(typeof req.query.range === 'string' ? req.query.range : undefined);
+    } catch (err: unknown) {
+      res.status(400).json({ error: err instanceof Error ? err.message : 'Invalid range' });
+      return;
+    }
+
+    const events = metricsStore.getEventLog({
+      startDate: window.startDate,
+      endDate: window.endDate,
+      type: 'verified',
+    });
+
+    const byClaimType: Record<string, number> = {};
+    const byVerifier: Record<string, number> = {};
+    for (const event of events) {
+      const claimType = String((event.metadata as Record<string, unknown> | undefined)?.claim_type ?? 'unknown');
+      const verifier = String((event.metadata as Record<string, unknown> | undefined)?.verifier ?? 'unknown');
+      byClaimType[claimType] = (byClaimType[claimType] ?? 0) + 1;
+      byVerifier[verifier] = (byVerifier[verifier] ?? 0) + 1;
+    }
+
+    res.json({
+      range: `${window.days}d`,
+      start_date: window.startDate,
+      end_date: window.endDate,
+      total_verifications: events.length,
+      by_claim_type: byClaimType,
+      verifier_distribution: byVerifier,
+    });
+  });
+
+  /**
+   * GET /api/analytics/disputes
+   * Query params: issuer (optional), range (7d|30d|90d, default 30d)
+   * Returns: dispute rate, average resolution time, common reasons.
+   *
+   * Dispute rate is disputed-events / issued-events within the same window,
+   * mirroring `MetricsStore.getIssuerMetrics`'s existing formula. Resolution
+   * time and reason are read from a disputed event's `metadata.resolved_at`
+   * / `metadata.reason` when present — neither is populated automatically
+   * today (there's no dispute-resolution event feed yet), so both degrade
+   * gracefully (null / "unspecified") until a caller starts recording them.
+   */
+  router.get('/disputes', (req: Request, res: Response) => {
+    const issuer = typeof req.query.issuer === 'string' ? req.query.issuer : undefined;
+
+    let window: ReturnType<typeof parseRangeParam>;
+    try {
+      window = parseRangeParam(typeof req.query.range === 'string' ? req.query.range : undefined);
+    } catch (err: unknown) {
+      res.status(400).json({ error: err instanceof Error ? err.message : 'Invalid range' });
+      return;
+    }
+
+    const query = { startDate: window.startDate, endDate: window.endDate };
+    let issuedEvents = metricsStore.getEventLog({ ...query, type: 'issued' });
+    let disputedEvents = metricsStore.getEventLog({ ...query, type: 'disputed' });
+    if (issuer) {
+      issuedEvents = issuedEvents.filter((e) => e.issuer === issuer);
+      disputedEvents = disputedEvents.filter((e) => e.issuer === issuer);
+    }
+
+    const disputeRate = issuedEvents.length > 0 ? disputedEvents.length / issuedEvents.length : 0;
+
+    const resolutionTimes: number[] = [];
+    const reasonCounts: Record<string, number> = {};
+    for (const event of disputedEvents) {
+      const metadata = (event.metadata as Record<string, unknown> | undefined) ?? {};
+      const reason = typeof metadata.reason === 'string' && metadata.reason.length > 0 ? metadata.reason : 'unspecified';
+      reasonCounts[reason] = (reasonCounts[reason] ?? 0) + 1;
+
+      if (typeof metadata.resolved_at === 'string') {
+        const resolvedMs = new Date(metadata.resolved_at).getTime();
+        const openedMs = new Date(event.timestamp).getTime();
+        if (!isNaN(resolvedMs) && !isNaN(openedMs) && resolvedMs >= openedMs) {
+          resolutionTimes.push(resolvedMs - openedMs);
+        }
+      }
+    }
+
+    const avgResolutionTimeMs =
+      resolutionTimes.length > 0 ? resolutionTimes.reduce((sum, t) => sum + t, 0) / resolutionTimes.length : null;
+
+    const commonReasons = Object.entries(reasonCounts)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 5)
+      .map(([reason, count]) => ({ reason, count }));
+
+    res.json({
+      issuer: issuer ?? null,
+      range: `${window.days}d`,
+      start_date: window.startDate,
+      end_date: window.endDate,
+      total_disputes: disputedEvents.length,
+      dispute_rate: disputeRate,
+      avg_resolution_time_ms: avgResolutionTimeMs,
+      common_reasons: commonReasons,
+    });
+  });
+
+  return router;
+}
+
+// Default export using the real Soroban client
+import { simulateCall, u64Val, u32Val, addressVal } from '../soroban.js';
+export default createIssuerAnalyticsRouter({
+  simulateCall,
+  u64Val: u64Val as unknown as SorobanClient['u64Val'],
+  u32Val: u32Val as unknown as SorobanClient['u32Val'],
+  addressVal: addressVal as unknown as SorobanClient['addressVal'],
+});

--- a/api-server/src/routes/verify.ts
+++ b/api-server/src/routes/verify.ts
@@ -7,6 +7,17 @@ import {
   addressVal,
 } from '../soroban.js';
 import { validate, schemas } from '../middleware/validate.js';
+import { metricsStore } from '../services/metrics.js';
+
+/**
+ * Best-effort caller identity for analytics attribution — same header
+ * convention `middleware/rateLimiter.ts` uses to identify callers, since
+ * there's no session/JWT auth in this API (see middleware/rbac.ts).
+ */
+function callerIdentity(req: Request): string {
+  const header = req.header('x-stellar-address');
+  return header && header.length > 0 ? header : 'anonymous';
+}
 
 export type SorobanClient = {
   simulateCall: typeof SimulateCallType;
@@ -134,6 +145,7 @@ export function createVerifyRouter(soroban: SorobanClient) {
     validate(schemas.verifyBatchClaims),
     async (req: Request, res: Response) => {
       const startedAt = Date.now();
+      const verifier = callerIdentity(req);
       const items = req.body.items as Array<{ credential_id: number; claim_type: string }>;
 
       // ── Deduplicate by (credential_id, claim_type) ─────────────────────────
@@ -285,6 +297,15 @@ export function createVerifyRouter(soroban: SorobanClient) {
               ? 'revoked'
               : 'active';
 
+          // #1001: feed the analytics event log so /api/analytics/verifications
+          // can report verification counts by claim type and verifier.
+          metricsStore.recordEvent({
+            type: 'verified',
+            credential_id: String(pair.credential_id),
+            timestamp: verifiedAt,
+            metadata: { claim_type: pair.claim_type, verifier },
+          });
+
           return {
             credential_id: pair.credential_id,
             claim_type: pair.claim_type,
@@ -324,6 +345,87 @@ export function createVerifyRouter(soroban: SorobanClient) {
       });
     }
   );
+
+  /**
+   * GET /api/verify/:id
+   * #1000: single-credential verification lookup. This is the canonical
+   * "verification endpoint" that a credential export's QR code links to —
+   * anyone who scans the code lands on a page that reports the credential's
+   * current status without needing to know a claim type up front.
+   *
+   * Query params:
+   *   - claim_type: optional; when present, also returns a verification
+   *     proof for that claim (same shape as the `/batch` proof).
+   */
+  router.get('/:id', async (req: Request, res: Response) => {
+    const credentialId = parseInt(req.params.id, 10);
+    if (!Number.isInteger(credentialId) || credentialId <= 0) {
+      res.status(400).json({ error: 'Invalid credential ID' });
+      return;
+    }
+    const claimType = typeof req.query.claim_type === 'string' ? req.query.claim_type : undefined;
+
+    try {
+      const sim = soroban.simulateCall as unknown as (
+        method: string,
+        args: unknown[]
+      ) => Promise<unknown>;
+      const cred = await sim('get_credential', [soroban.u64Val(credentialId)]);
+      const record = serializeBigInt(cred) as Record<string, unknown>;
+
+      const revoked = Boolean(record.revoked);
+      const suspended = Boolean(record.suspended);
+      const expiresAt = record.expires_at ? new Date(record.expires_at as string) : null;
+      const expired = Boolean(expiresAt && !isNaN(expiresAt.getTime()) && expiresAt.getTime() < Date.now());
+
+      const status: BatchVerificationStatus = revoked
+        ? 'revoked'
+        : expired
+          ? 'expired'
+          : 'verified';
+
+      const response: {
+        credential_id: number;
+        status: BatchVerificationStatus;
+        checked_at: string;
+        claim_type?: string;
+        proof?: BatchVerificationProof;
+      } = {
+        credential_id: credentialId,
+        status,
+        checked_at: new Date().toISOString(),
+      };
+
+      if (claimType) {
+        response.claim_type = claimType;
+        if (status === 'verified') {
+          const verifiedAt = response.checked_at;
+          response.proof = {
+            verified_at: verifiedAt,
+            credential_status: suspended ? 'suspended' : 'active',
+            digest: digestHex(`${credentialId} ${claimType} ${verifiedAt}`),
+          };
+          // #1001: feed the analytics event log so /api/analytics/verifications
+          // can report verification counts by claim type and verifier.
+          metricsStore.recordEvent({
+            type: 'verified',
+            credential_id: String(credentialId),
+            timestamp: verifiedAt,
+            metadata: { claim_type: claimType, verifier: callerIdentity(req) },
+          });
+        }
+      }
+
+      res.json(response);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.toLowerCase().includes('credentialnotfound') || msg.toLowerCase().includes('not found')) {
+        res.status(404).json({ error: 'Credential not found', credential_id: credentialId, status: 'not_found' });
+      } else {
+        res.status(500).json({ error: msg });
+      }
+    }
+  });
 
   return router;
 }

--- a/api-server/src/services/metrics.ts
+++ b/api-server/src/services/metrics.ts
@@ -130,6 +130,22 @@ export function buildAnomalyQuery(startDate?: string, endDate?: string, threshol
   return { startDate: s, endDate: e, threshold };
 }
 
+const RANGE_TO_DAYS: Record<string, number> = { '7d': 7, '30d': 30, '90d': 90 };
+
+/**
+ * #1001: translates the `range=7d|30d|90d` query param used by the issuer
+ * analytics endpoints into a `{days, startDate, endDate}` window, reusing
+ * `getDateDaysAgo` the same way `buildMetricsQuery` etc. do.
+ */
+export function parseRangeParam(range: string | undefined): { days: number; startDate: string; endDate: string } {
+  const key = range ?? '30d';
+  const days = RANGE_TO_DAYS[key];
+  if (days === undefined) {
+    throw new Error(`range must be one of: ${Object.keys(RANGE_TO_DAYS).join(', ')}`);
+  }
+  return { days, startDate: getDateDaysAgo(days), endDate: getDateDaysAgo(0) };
+}
+
 function getDateDaysAgo(days: number): string {
   const date = new Date();
   date.setUTCDate(date.getUTCDate() - days);

--- a/api-server/tests/chaos.test.ts
+++ b/api-server/tests/chaos.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Issue #1003 — Chaos testing for network failures.
+ *
+ * Injects network delay, dropped/failed calls ("packet loss"), and
+ * sustained service-unavailability directly into the mocked Soroban RPC
+ * client the API server talks to, then asserts the affected endpoints
+ * degrade gracefully (a clean error response, not a hang/crash/500-with-no-
+ * body) instead of taking down the request. This is the in-repo,
+ * CI-runnable counterpart to the chaos-mesh manifests in
+ * `monitoring/chaos/`, which exercise the same failure classes against a
+ * real deployed cluster — see docs/resilience.md.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createCredentialsRouter } from '../src/routes/credentials.js';
+import { createVerifyRouter } from '../src/routes/verify.js';
+
+const mockSimulateCall = vi.fn();
+const mockSoroban = {
+  simulateCall: mockSimulateCall,
+  u64Val: (n: number | bigint) => n as any,
+  u32Val: (n: number) => n as any,
+  addressVal: (a: string) => a as any,
+};
+
+/** Simulated network delay: resolves `value` after `ms`. */
+function delayed<T>(value: T, ms: number): Promise<T> {
+  return new Promise((resolve) => setTimeout(() => resolve(value), ms));
+}
+
+const CONN_RESET = new Error('ECONNRESET: connection reset by peer');
+const SERVICE_UNAVAILABLE = new Error('503 Service Unavailable: upstream RPC unreachable');
+
+beforeEach(() => mockSimulateCall.mockReset());
+
+describe('chaos: network delay', () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/credentials', createCredentialsRouter(mockSoroban));
+
+  it('search still responds correctly when the RPC call is slow', async () => {
+    mockSimulateCall.mockImplementationOnce(() => delayed(0n, 30));
+
+    const res = await request(app).get('/api/credentials/search');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('data');
+  });
+
+  it('metadata-hash lookup does not hang past a slow upstream call', async () => {
+    mockSimulateCall.mockImplementationOnce(() =>
+      delayed({ id: 101, metadata_hash: 'abc', revoked: false, suspended: false, version: 1 }, 30)
+    );
+
+    const res = await request(app).get('/api/credentials/101/metadata-hash');
+    expect(res.status).toBe(200);
+    expect(res.body.metadata_hash).toBe('abc');
+  });
+});
+
+describe('chaos: packet loss (dropped/reset connections)', () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/credentials', createCredentialsRouter(mockSoroban));
+  app.use('/api/verify', createVerifyRouter(mockSoroban));
+
+  it('search degrades gracefully when get_credential_count is dropped mid-flight', async () => {
+    mockSimulateCall.mockRejectedValueOnce(CONN_RESET);
+
+    const res = await request(app).get('/api/credentials/search');
+    // populateIndex() catches the error internally and logs it — the route
+    // must still respond (with an empty index), never hang or crash.
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it('single-credential verify returns a clean error, not a hang, on connection reset', async () => {
+    mockSimulateCall.mockRejectedValueOnce(CONN_RESET);
+
+    const res = await request(app).get('/api/verify/102');
+    expect(res.status).toBe(500);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('metadata-hash lookup surfaces a clean 500 on connection reset instead of crashing the process', async () => {
+    mockSimulateCall.mockRejectedValueOnce(CONN_RESET);
+
+    const res = await request(app).get('/api/credentials/103/metadata-hash');
+    expect(res.status).toBe(500);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('verify-batch reports a per-item error instead of failing the whole batch on packet loss', async () => {
+    mockSimulateCall
+      .mockResolvedValueOnce(true) // is_attested for credential 1
+      .mockRejectedValueOnce(CONN_RESET); // is_attested for credential 2 dropped
+
+    const res = await request(app)
+      .post('/api/credentials/verify-batch')
+      .send({ credential_ids: [1, 2], slice_id: 1 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.results[0]).toMatchObject({ credential_id: 1, attested: true, error: null });
+    expect(res.body.results[1].attested).toBe(false);
+    expect(res.body.results[1].error).toBeTruthy();
+  });
+});
+
+describe('chaos: sustained service unavailability', () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/credentials', createCredentialsRouter(mockSoroban));
+  app.use('/api/verify', createVerifyRouter(mockSoroban));
+
+  it('search responds with an empty, still-usable index when the RPC service is entirely down', async () => {
+    mockSimulateCall.mockRejectedValueOnce(SERVICE_UNAVAILABLE);
+
+    const res = await request(app).get('/api/credentials/search');
+    expect(res.status).toBe(200);
+    expect(res.body.pagination).toBeDefined();
+  });
+
+  it('verify/batch surfaces a bounded per-item error for every item when the service is down', async () => {
+    mockSimulateCall
+      .mockRejectedValueOnce(SERVICE_UNAVAILABLE) // get_supported_claim_types (best-effort, swallowed)
+      .mockRejectedValueOnce(SERVICE_UNAVAILABLE); // get_credential for the one requested item
+
+    const res = await request(app)
+      .post('/api/verify/batch')
+      .send({ items: [{ credential_id: 104, claim_type: 'name' }] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toHaveLength(1);
+    expect(res.body.results[0].status).toBe('error');
+    expect(res.body.summary.errors).toBe(1);
+  });
+
+  it('recovers cleanly once the service comes back up (no lingering broken state)', async () => {
+    mockSimulateCall.mockRejectedValueOnce(SERVICE_UNAVAILABLE);
+    const down = await request(app).get('/api/verify/105');
+    expect(down.status).toBe(500);
+
+    mockSimulateCall.mockResolvedValueOnce({
+      id: 105,
+      revoked: false,
+      suspended: false,
+      expires_at: null,
+      version: 1,
+    });
+    const up = await request(app).get('/api/verify/105');
+    expect(up.status).toBe(200);
+    expect(up.body.status).toBe('verified');
+  });
+});

--- a/contracts/integration_tests/tests/integration_tests.rs
+++ b/contracts/integration_tests/tests/integration_tests.rs
@@ -1,0 +1,446 @@
+// Issue #1002: Contract Integration Tests
+//
+// External integration-test binary covering multi-contract interactions
+// (credential -> quorum slice -> SBT -> ZK verification). The crate's
+// existing `#[cfg(test)] mod integration` in src/lib.rs (issue #364) already
+// covers the happy-path full flow and several single-panic error cases, and
+// `upgrade_safety.rs` (issue #558) already covers upgrade/migration safety in
+// depth. This file adds the specific #1002 deliverables that aren't covered
+// elsewhere: a full-flow test living in the literal `tests/integration_tests.rs`
+// path the issue asks for, dispute-resolution and revocation-cascade error
+// paths, upgrade-safety checks exercised from a populated multi-contract
+// flow, and a performance budget check on the full flow.
+
+use quorum_proof::{ChallengeStatus, ClaimType as QpClaimType, QuorumProofContract, QuorumProofContractClient};
+use sbt_registry::{SbtRegistryContract, SbtRegistryContractClient};
+use zk_verifier::{ClaimType, ZkVerifierContract, ZkVerifierContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Bytes, BytesN, Env, Vec};
+
+// ── Shared setup ─────────────────────────────────────────────────────────────
+
+struct Contracts<'a> {
+    qp: QuorumProofContractClient<'a>,
+    sbt: SbtRegistryContractClient<'a>,
+    zk: ZkVerifierContractClient<'a>,
+    admin: Address,
+}
+
+fn setup(env: &Env) -> Contracts<'_> {
+    // verify_engineer makes a nested cross-contract call to zk_verifier that
+    // requires zk_admin's auth outside the root invocation — plain
+    // mock_all_auths() only mocks auth tied to the root call.
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let admin = Address::generate(env);
+
+    let qp_id = env.register_contract(None, QuorumProofContract);
+    let qp = QuorumProofContractClient::new(env, &qp_id);
+    qp.initialize(&admin);
+
+    let sbt_id = env.register_contract(None, SbtRegistryContract);
+    let sbt = SbtRegistryContractClient::new(env, &sbt_id);
+    sbt.initialize(&admin, &qp_id);
+
+    let zk_id = env.register_contract(None, ZkVerifierContract);
+    let zk = ZkVerifierContractClient::new(env, &zk_id);
+    zk.initialize(&admin);
+
+    let vk_hash = BytesN::from_array(env, &[0u8; 32]);
+    zk.set_verifying_key(&admin, &vk_hash);
+
+    Contracts { qp, sbt, zk, admin }
+}
+
+fn metadata(env: &Env) -> Bytes {
+    Bytes::from_slice(env, b"QmIntegrationTestHash00000000000000")
+}
+
+/// A mock 256-byte Groth16 proof (BN254 uncompressed: A‖B‖C) that passes
+/// structural checks but not real pairing verification.
+fn valid_proof(env: &Env) -> Bytes {
+    let mut proof_bytes = [0u8; 256];
+    proof_bytes[0] = 1;
+    proof_bytes[63] = 1;
+    proof_bytes[192] = 1;
+    proof_bytes[255] = 1;
+    Bytes::from_slice(env, &proof_bytes)
+}
+
+fn new_wasm_hash(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[0xABu8; 32])
+}
+
+/// See `upgrade_safety.rs` for the full explanation: `upgrade` performs a
+/// real WASM swap that this sandbox can't satisfy with a fabricated hash, so
+/// any test that expects `upgrade` to logically succeed tolerates the
+/// resulting "Wasm does not exist" panic. Do NOT use this for tests
+/// asserting that `upgrade` itself must panic for auth/validation reasons.
+fn simulate_upgrade(qp: &QuorumProofContractClient, admin: &Address, wasm_hash: &BytesN<32>) {
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        qp.upgrade(admin, wasm_hash);
+    }));
+}
+
+// ── Full flow: issue -> quorum slice -> attest -> SBT -> ZK proof ───────────
+
+#[test]
+fn full_flow_issue_slice_attest_sbt_zk_proof() {
+    let env = Env::default();
+    let c = setup(&env);
+
+    let issuer = Address::generate(&env);
+    let holder = Address::generate(&env);
+    let attestor1 = Address::generate(&env);
+    let attestor2 = Address::generate(&env);
+
+    // 1. Issue credential
+    let cred_id = c.qp.issue_credential(&issuer, &holder, &1u32, &metadata(&env), &None, &0u64);
+
+    // 2. Create a 2-of-2 quorum slice
+    let mut attestors = Vec::new(&env);
+    attestors.push_back(attestor1.clone());
+    attestors.push_back(attestor2.clone());
+    let mut weights = Vec::new(&env);
+    weights.push_back(1u32);
+    weights.push_back(1u32);
+    let slice_id = c.qp.create_slice(&issuer, &attestors, &weights, &2u32);
+
+    // 3. Attest the credential
+    c.qp.attest(&attestor1, &cred_id, &slice_id, &true, &None);
+    c.qp.attest(&attestor2, &cred_id, &slice_id, &true, &None);
+    assert!(c.qp.is_attested(&cred_id, &slice_id));
+
+    // 4. Generate SBT
+    let uri = Bytes::from_slice(&env, b"ipfs://QmIntegrationSBT");
+    let token_id = c.sbt.mint(&holder, &cred_id, &uri);
+    assert_eq!(c.sbt.owner_of(&token_id), holder);
+
+    // 5. Verify with ZK proof, both directly and via the cross-contract
+    //    verify_engineer entry point (SBT ownership + ZK proof combined).
+    let verified = c.zk.verify_claim(&c.admin, &c.qp.address, &cred_id, &ClaimType::HasDegree, &valid_proof(&env));
+    assert!(verified);
+
+    let engineer_ok = c.qp.verify_engineer(
+        &c.sbt.address,
+        &c.zk.address,
+        &c.admin,
+        &holder,
+        &cred_id,
+        &QpClaimType::HasDegree,
+        &valid_proof(&env),
+        &None,
+    );
+    assert!(engineer_ok);
+}
+
+// ── Error path: dispute resolution ───────────────────────────────────────────
+
+/// A challenge that gathers enough weighted uphold-votes removes the
+/// accused's attestation from the credential, which can drop the credential
+/// back below the slice's attestation threshold.
+#[test]
+fn dispute_upheld_removes_attestation_and_drops_below_threshold() {
+    let env = Env::default();
+    let c = setup(&env);
+
+    let issuer = Address::generate(&env);
+    let holder = Address::generate(&env);
+    let honest = Address::generate(&env);
+    let accused = Address::generate(&env);
+    let tiebreaker = Address::generate(&env);
+
+    let cred_id = c.qp.issue_credential(&issuer, &holder, &1u32, &metadata(&env), &None, &0u64);
+
+    let mut attestors = Vec::new(&env);
+    attestors.push_back(honest.clone());
+    attestors.push_back(accused.clone());
+    attestors.push_back(tiebreaker.clone());
+    let mut weights = Vec::new(&env);
+    weights.push_back(1u32);
+    weights.push_back(1u32);
+    weights.push_back(1u32);
+    // Absolute threshold of 2: any two attestations are sufficient.
+    let slice_id = c.qp.create_slice(&issuer, &attestors, &weights, &2u32);
+
+    c.qp.attest(&honest, &cred_id, &slice_id, &true, &None);
+    c.qp.attest(&accused, &cred_id, &slice_id, &true, &None);
+    assert!(c.qp.is_attested(&cred_id, &slice_id), "pre-dispute: two attestations must meet threshold");
+
+    let challenge_id = c.qp.challenge_attestation(&honest, &cred_id, &slice_id, &accused);
+
+    // honest + tiebreaker vote to uphold: weight 2 meets the threshold of 2.
+    c.qp.vote_on_challenge(&honest, &challenge_id, &true);
+    c.qp.vote_on_challenge(&tiebreaker, &challenge_id, &true);
+
+    let challenge = c.qp.get_challenge(&challenge_id);
+    assert!(challenge.status == ChallengeStatus::Upheld, "challenge with majority uphold votes must resolve as Upheld");
+
+    // The accused's attestation record was removed, leaving only `honest`'s
+    // single attestation — one attestation can no longer meet a threshold of 2.
+    assert!(!c.qp.is_attested(&cred_id, &slice_id), "dispute resolution must cascade: removing accused's attestation drops below threshold");
+    assert_eq!(c.qp.get_slash_count(&accused), 1, "upheld dispute must slash the accused attestor");
+}
+
+/// Only slice members may challenge an attestation.
+#[test]
+#[should_panic]
+fn dispute_challenge_by_non_slice_member_panics() {
+    let env = Env::default();
+    let c = setup(&env);
+
+    let issuer = Address::generate(&env);
+    let holder = Address::generate(&env);
+    let attestor = Address::generate(&env);
+    let outsider = Address::generate(&env);
+
+    let cred_id = c.qp.issue_credential(&issuer, &holder, &1u32, &metadata(&env), &None, &0u64);
+
+    let mut attestors = Vec::new(&env);
+    attestors.push_back(attestor.clone());
+    let mut weights = Vec::new(&env);
+    weights.push_back(1u32);
+    let slice_id = c.qp.create_slice(&issuer, &attestors, &weights, &1u32);
+    c.qp.attest(&attestor, &cred_id, &slice_id, &true, &None);
+
+    // outsider is not a member of the slice -> must panic
+    c.qp.challenge_attestation(&outsider, &cred_id, &slice_id, &attestor);
+}
+
+/// A challenge with enough weighted dismiss-votes leaves the original
+/// attestation standing.
+#[test]
+fn dispute_dismissed_leaves_attestation_standing() {
+    let env = Env::default();
+    let c = setup(&env);
+
+    let issuer = Address::generate(&env);
+    let holder = Address::generate(&env);
+    let honest = Address::generate(&env);
+    let accused = Address::generate(&env);
+    let juror1 = Address::generate(&env);
+    let juror2 = Address::generate(&env);
+
+    let cred_id = c.qp.issue_credential(&issuer, &holder, &1u32, &metadata(&env), &None, &0u64);
+
+    let mut attestors = Vec::new(&env);
+    attestors.push_back(honest.clone());
+    attestors.push_back(accused.clone());
+    attestors.push_back(juror1.clone());
+    attestors.push_back(juror2.clone());
+    let mut weights = Vec::new(&env);
+    weights.push_back(1u32);
+    weights.push_back(1u32);
+    weights.push_back(1u32);
+    weights.push_back(1u32);
+    let slice_id = c.qp.create_slice(&issuer, &attestors, &weights, &2u32);
+
+    c.qp.attest(&honest, &cred_id, &slice_id, &true, &None);
+    c.qp.attest(&accused, &cred_id, &slice_id, &true, &None);
+
+    let challenge_id = c.qp.challenge_attestation(&honest, &cred_id, &slice_id, &accused);
+
+    // Two neutral jurors (not the challenger, not the accused — who is
+    // barred from voting on their own challenge) vote to dismiss: weight 2
+    // meets the threshold of 2.
+    c.qp.vote_on_challenge(&juror1, &challenge_id, &false);
+    c.qp.vote_on_challenge(&juror2, &challenge_id, &false);
+
+    let challenge = c.qp.get_challenge(&challenge_id);
+    assert!(challenge.status == ChallengeStatus::Dismissed);
+    assert!(c.qp.is_attested(&cred_id, &slice_id), "dismissed dispute must leave the original attestation intact");
+    assert_eq!(c.qp.get_slash_count(&accused), 0, "dismissed dispute must not slash anyone");
+}
+
+// ── Error path: revocation cascading ─────────────────────────────────────────
+
+/// Revoking a credential must cascade to block both new attestations and new
+/// SBT minting against that credential.
+#[test]
+fn revocation_cascades_blocks_attestation_and_sbt_mint() {
+    let env = Env::default();
+    let c = setup(&env);
+
+    let issuer = Address::generate(&env);
+    let holder = Address::generate(&env);
+    let attestor = Address::generate(&env);
+
+    let cred_id = c.qp.issue_credential(&issuer, &holder, &1u32, &metadata(&env), &None, &0u64);
+
+    let mut attestors = Vec::new(&env);
+    attestors.push_back(attestor.clone());
+    let mut weights = Vec::new(&env);
+    weights.push_back(1u32);
+    let slice_id = c.qp.create_slice(&issuer, &attestors, &weights, &1u32);
+
+    c.qp.revoke_credential(&issuer, &cred_id, &None);
+    assert!(c.qp.is_revoked(&cred_id));
+
+    // Cascade 1: attestation against a revoked credential is rejected.
+    let attest_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        c.qp.attest(&attestor, &cred_id, &slice_id, &true, &None);
+    }));
+    assert!(attest_result.is_err(), "revocation must cascade to block new attestations");
+
+    // Cascade 2: SBT minting against a revoked credential is rejected.
+    let uri = Bytes::from_slice(&env, b"ipfs://QmRevokedSBT");
+    let mint_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        c.sbt.mint(&holder, &cred_id, &uri);
+    }));
+    assert!(mint_result.is_err(), "revocation must cascade to block SBT minting");
+
+    // The credential record itself is not deleted — it remains inspectable,
+    // just permanently marked revoked.
+    assert!(c.qp.credential_exists(&cred_id));
+}
+
+/// Revoking a credential that already has an SBT does not retroactively burn
+/// it, but does block any *new* mint for that credential id.
+#[test]
+fn revocation_after_mint_does_not_burn_existing_sbt() {
+    let env = Env::default();
+    let c = setup(&env);
+
+    let issuer = Address::generate(&env);
+    let holder = Address::generate(&env);
+
+    let cred_id = c.qp.issue_credential(&issuer, &holder, &1u32, &metadata(&env), &None, &0u64);
+    let uri = Bytes::from_slice(&env, b"ipfs://QmPreRevocationSBT");
+    let token_id = c.sbt.mint(&holder, &cred_id, &uri);
+
+    c.qp.revoke_credential(&issuer, &cred_id, &None);
+
+    // Already-minted SBT ownership is unaffected by the later revocation.
+    assert_eq!(c.sbt.owner_of(&token_id), holder);
+
+    // But re-minting (e.g. after a burn) is now blocked.
+    let re_mint = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        c.sbt.mint(&holder, &(cred_id + 1), &uri);
+    }));
+    // cred_id + 1 doesn't exist at all, which panics for a different reason
+    // (CredentialNotFound) — the point being that the SBT registry always
+    // cross-checks credential state (existence, revocation) before minting.
+    assert!(re_mint.is_err());
+}
+
+// ── Contract upgrade safety, exercised from a populated multi-contract flow ─
+
+/// Upgrading the QuorumProof contract mid-flow must preserve the full
+/// cross-contract state built up so far (credential, slice, attestation,
+/// SBT ownership) and leave the contract fully operational afterwards.
+#[test]
+fn upgrade_preserves_full_cross_contract_flow_state() {
+    let env = Env::default();
+    let c = setup(&env);
+
+    let issuer = Address::generate(&env);
+    let holder = Address::generate(&env);
+    let attestor = Address::generate(&env);
+
+    let cred_id = c.qp.issue_credential(&issuer, &holder, &1u32, &metadata(&env), &None, &0u64);
+
+    let mut attestors = Vec::new(&env);
+    attestors.push_back(attestor.clone());
+    let mut weights = Vec::new(&env);
+    weights.push_back(1u32);
+    let slice_id = c.qp.create_slice(&issuer, &attestors, &weights, &1u32);
+    c.qp.attest(&attestor, &cred_id, &slice_id, &true, &None);
+
+    let uri = Bytes::from_slice(&env, b"ipfs://QmUpgradeFlowSBT");
+    let token_id = c.sbt.mint(&holder, &cred_id, &uri);
+
+    simulate_upgrade(&c.qp, &c.admin, &new_wasm_hash(&env));
+
+    assert!(c.qp.credential_exists(&cred_id));
+    assert!(c.qp.is_attested(&cred_id, &slice_id));
+    assert_eq!(c.sbt.owner_of(&token_id), holder);
+
+    // Contract must remain fully operational after upgrade: a new credential
+    // can be issued and independently verified with ZK.
+    let cred_id2 = c.qp.issue_credential(&issuer, &holder, &2u32, &metadata(&env), &None, &0u64);
+    assert!(c.zk.verify_claim(&c.admin, &c.qp.address, &cred_id2, &ClaimType::HasDegree, &valid_proof(&env)));
+}
+
+/// An unauthorized caller must not be able to upgrade the contract, even
+/// once real cross-contract state (SBTs, ZK verifying key) has been set up.
+#[test]
+#[should_panic]
+fn upgrade_unauthorized_caller_rejected_with_live_state() {
+    let env = Env::default();
+    let c = setup(&env);
+
+    let issuer = Address::generate(&env);
+    let holder = Address::generate(&env);
+    c.qp.issue_credential(&issuer, &holder, &1u32, &metadata(&env), &None, &0u64);
+
+    let attacker = Address::generate(&env);
+    c.qp.upgrade(&attacker, &new_wasm_hash(&env));
+}
+
+// ── Performance benchmark ─────────────────────────────────────────────────────
+
+struct Metrics {
+    cpu: u64,
+    mem: u64,
+}
+
+/// Resets the budget, runs `f`, then returns cumulative CPU + memory cost.
+fn measure(env: &Env, f: impl FnOnce()) -> Metrics {
+    env.budget().reset_default();
+    f();
+    Metrics {
+        cpu: env.budget().cpu_instruction_cost(),
+        mem: env.budget().memory_bytes_cost(),
+    }
+}
+
+// This is a first-cut safety net on the *combined* cross-contract flow (no
+// prior historical baseline exists for the full flow as a unit, unlike the
+// tight ~10%-regression per-operation gates in benches/tests/benchmarks.rs),
+// so the threshold carries generous headroom rather than a strict gate.
+const THRESHOLD_FULL_FLOW_CPU: u64 = 15_000_000;
+const THRESHOLD_FULL_FLOW_MEM: u64 = 15_000_000;
+
+#[test]
+fn perf_full_flow_within_cpu_and_memory_budget() {
+    let env = Env::default();
+    let c = setup(&env);
+
+    let issuer = Address::generate(&env);
+    let holder = Address::generate(&env);
+    let attestor1 = Address::generate(&env);
+    let attestor2 = Address::generate(&env);
+
+    let m = measure(&env, || {
+        let cred_id = c.qp.issue_credential(&issuer, &holder, &1u32, &metadata(&env), &None, &0u64);
+
+        let mut attestors = Vec::new(&env);
+        attestors.push_back(attestor1.clone());
+        attestors.push_back(attestor2.clone());
+        let mut weights = Vec::new(&env);
+        weights.push_back(1u32);
+        weights.push_back(1u32);
+        let slice_id = c.qp.create_slice(&issuer, &attestors, &weights, &2u32);
+
+        c.qp.attest(&attestor1, &cred_id, &slice_id, &true, &None);
+        c.qp.attest(&attestor2, &cred_id, &slice_id, &true, &None);
+
+        let uri = Bytes::from_slice(&env, b"ipfs://QmPerfFlowSBT");
+        c.sbt.mint(&holder, &cred_id, &uri);
+
+        c.zk.verify_claim(&c.admin, &c.qp.address, &cred_id, &ClaimType::HasDegree, &valid_proof(&env));
+    });
+
+    println!("[perf_full_flow_within_cpu_and_memory_budget] cpu={} mem={}", m.cpu, m.mem);
+    assert!(
+        m.cpu <= THRESHOLD_FULL_FLOW_CPU,
+        "full-flow CPU regression: {} > {}",
+        m.cpu,
+        THRESHOLD_FULL_FLOW_CPU
+    );
+    assert!(
+        m.mem <= THRESHOLD_FULL_FLOW_MEM,
+        "full-flow MEM regression: {} > {}",
+        m.mem,
+        THRESHOLD_FULL_FLOW_MEM
+    );
+}

--- a/docs/resilience.md
+++ b/docs/resilience.md
@@ -1,0 +1,99 @@
+# Resilience & Chaos Testing
+
+Issue #1003. Documents QuorumProof's resilience requirements for network
+failures (delays, packet loss, service unavailability), the chaos-testing
+tooling added to verify them, and how to run it.
+
+## Scope
+
+Two independent layers are covered:
+
+1. **`api-server` (Node/Express)** — the only component that makes real
+   network calls (to the Soroban RPC endpoint, and optionally Redis for
+   cross-instance WebSocket delivery). This is where actual network chaos
+   (delay, packet loss, downtime) can occur and be tested in-process.
+2. **Contracts (`contracts/`)** — Soroban contract tests run entirely against
+   an in-process mock ledger (`soroban_sdk::Env::default()`); there is no
+   real network layer to inject faults into at that layer. Contract-level
+   chaos testing (`contracts/integration_tests/src/chaos.rs`, issue #554)
+   instead covers *application-level* chaos: unexpected call ordering,
+   boundary conditions, and graceful-degradation of contract state — see
+   that file for details. It is out of scope for this document.
+
+## Resilience requirements
+
+These are the behaviors the API server MUST exhibit under network failure,
+verified by `api-server/tests/chaos.test.ts`:
+
+| Failure class | Requirement |
+| --- | --- |
+| **Network delay** | A slow upstream RPC call must not corrupt a response or cause partial state — the request completes correctly once the call resolves. No artificial timeout is currently enforced API-side (the RPC client itself is responsible for its own timeout budget). |
+| **Packet loss / dropped connections** | A single failed upstream call must degrade to a scoped error (a `500` for single-resource endpoints, or a per-item `error`/`status: "error"` entry for batch endpoints) — it must never crash the process, hang the request, or fail unrelated items in the same batch. |
+| **Sustained service unavailability** | When every upstream call fails, endpoints that aggregate multiple calls (e.g. `/api/credentials/search`, which scans every credential) must still return a well-formed response (an empty result set), not an unhandled rejection. |
+| **Recovery** | Once the upstream service comes back, the very next request must succeed normally — no breaker, cache, or in-memory state may be left permanently poisoned by a prior failure. |
+
+Existing mechanisms this relies on (already in the codebase, exercised
+indirectly by the chaos tests):
+
+- **Per-call try/catch with typed fallbacks** — every route that calls
+  `soroban.simulateCall` wraps it and maps failures to a scoped error
+  (`api-server/src/routes/credentials.ts`, `verify.ts`, etc.), rather than
+  letting a rejection propagate unhandled.
+- **Best-effort enrichment calls** — e.g. `get_supported_claim_types` in
+  `verify.ts`'s batch handler degrades to "all claim types eligible" if the
+  call fails, instead of failing the whole batch.
+- **Webhook circuit breaker** (`api-server/src/services/webhookCircuitBreaker.ts`)
+  — trips open after repeated delivery failures and self-recovers via a
+  half-open trial, so a down webhook consumer can't cause unbounded retry
+  storms against it.
+- **Rate limiting with backoff** (`api-server/src/middleware/rateLimiter.ts`)
+  and **DDoS protection** (`api-server/src/middleware/ddosProtection.ts`) —
+  protect the server itself from being overwhelmed, which is the inverse
+  chaos scenario (too much traffic rather than too little upstream
+  availability) but shares the same "fail gracefully, recover automatically"
+  requirement.
+
+## In-repo chaos test suite (CI-runnable)
+
+`api-server/tests/chaos.test.ts` injects delay, dropped connections
+(`ECONNRESET`), and sustained unavailability (`503`) directly into the mocked
+Soroban RPC client and asserts each endpoint's response against the
+requirements table above. This suite requires no external infrastructure and
+runs in CI on every PR (see `.github/workflows/ci.yml`, job
+`api-server-chaos`).
+
+Run locally:
+
+```bash
+cd api-server
+npm test -- tests/chaos.test.ts
+```
+
+## chaos-mesh manifests (cluster-level, manual/staging use)
+
+`monitoring/chaos/` contains [Chaos Mesh](https://chaos-mesh.org/) experiment
+manifests that exercise the same three failure classes against a *real*
+deployed `api-server`, for staging/pre-prod verification beyond what the
+in-process test suite can reach (actual TCP-level delay/loss, not simulated
+rejections):
+
+- `network-delay.yaml` — injects latency into api-server's outbound traffic.
+- `packet-loss.yaml` — drops a percentage of outbound packets.
+- `service-unavailable.yaml` — kills the RPC-dependent pod(s) outright.
+
+These require a Kubernetes cluster with Chaos Mesh installed and an
+`api-server` deployment labeled `app: quorumproof-api-server` — the repo does
+not currently ship Kubernetes deployment manifests for `api-server` (see
+`monitoring/chaos/README.md` for prerequisites and usage). They are **not**
+wired into CI, since CI has no cluster to apply them to; they're for anyone
+standing up a staging cluster to validate resilience beyond the mocked
+in-process suite.
+
+## Non-goals
+
+- No client-side retry/timeout policy is specified here — that's a
+  contract of whatever consumes the API server (frontend, SDK), not the
+  server itself.
+- No SLO/SLA numbers (e.g. "p99 latency under X ms during a chaos event")
+  are defined yet — the requirements above are behavioral (correctness under
+  failure), not performance targets. Adding quantitative SLOs is future work.

--- a/monitoring/chaos/README.md
+++ b/monitoring/chaos/README.md
@@ -1,0 +1,62 @@
+# Chaos Mesh manifests
+
+Issue #1003. See [`docs/resilience.md`](../../docs/resilience.md) for the
+full resilience requirements these exercise, and
+[`api-server/tests/chaos.test.ts`](../../api-server/tests/chaos.test.ts) for
+the CI-runnable, no-cluster-required counterpart to these manifests.
+
+## Prerequisites
+
+- A Kubernetes cluster with [Chaos Mesh](https://chaos-mesh.org/docs/quick-start/)
+  installed.
+- An `api-server` Deployment running in the `quorumproof` namespace, labeled
+  `app: quorumproof-api-server`. The repo does not currently ship Kubernetes
+  Deployment manifests for `api-server` (only `monitoring/docker-compose.yml`
+  for local Prometheus/Grafana/Loki) — adapt the `namespace`/`labelSelectors`
+  in these manifests to match however `api-server` is actually deployed in
+  your cluster.
+
+## Manifests
+
+| File | Failure class | What it does |
+| --- | --- | --- |
+| `network-delay.yaml` | Network delay | Adds 500ms±200ms latency to api-server's outbound traffic. |
+| `packet-loss.yaml` | Packet loss | Drops 15% of api-server's outbound packets. |
+| `service-unavailable.yaml` | Service unavailability | Kills an api-server pod outright for 2 minutes. |
+
+Each is scheduled (`spec.scheduler.cron`) to run periodically and
+self-terminate after `spec.duration` — safe to leave applied in a staging
+cluster for ongoing resilience verification rather than a one-off manual run.
+
+## Usage
+
+```bash
+# Apply one experiment
+kubectl apply -f network-delay.yaml
+
+# Watch it take effect
+kubectl get networkchaos api-server-network-delay -o yaml
+
+# Run your smoke tests / synthetic traffic against api-server while it's active
+
+# Remove it
+kubectl delete -f network-delay.yaml
+```
+
+## Smoke-testing during an active experiment
+
+While an experiment is applied, hit the health and search endpoints to
+confirm the service stays up and responds per `docs/resilience.md`'s
+requirements table:
+
+```bash
+curl -f https://<api-server-host>/health
+curl -f https://<api-server-host>/api/credentials/search?limit=1
+```
+
+A failing `curl -f` (non-2xx) during `network-delay`/`packet-loss` is
+expected to be rare/transient, not sustained — sustained failure indicates a
+resilience gap. During `service-unavailable`, expect the health check to
+fail only while the killed pod is being replaced (verify via
+`kubectl get pods -n quorumproof -l app=quorumproof-api-server -w`), and to
+recover automatically once the replacement pod is ready.

--- a/monitoring/chaos/network-delay.yaml
+++ b/monitoring/chaos/network-delay.yaml
@@ -1,0 +1,30 @@
+# Issue #1003 — Chaos Mesh: network delay
+#
+# Injects latency into api-server's outbound traffic (its calls to the
+# Soroban RPC endpoint and Redis) to verify the resilience requirements in
+# docs/resilience.md: a slow upstream call must complete correctly, not
+# corrupt state or hang indefinitely.
+#
+# Apply:   kubectl apply -f network-delay.yaml
+# Remove:  kubectl delete -f network-delay.yaml
+# Watch:   kubectl get networkchaos api-server-network-delay -o yaml
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: api-server-network-delay
+  namespace: quorumproof
+spec:
+  action: delay
+  mode: all
+  selector:
+    namespaces:
+      - quorumproof
+    labelSelectors:
+      app: quorumproof-api-server
+  delay:
+    latency: '500ms'
+    jitter: '200ms'
+    correlation: '25'
+  duration: '5m'
+  scheduler:
+    cron: '@every 30m'

--- a/monitoring/chaos/packet-loss.yaml
+++ b/monitoring/chaos/packet-loss.yaml
@@ -1,0 +1,28 @@
+# Issue #1003 — Chaos Mesh: packet loss
+#
+# Drops a percentage of api-server's outbound packets to verify the
+# resilience requirements in docs/resilience.md: a single dropped call must
+# degrade to a scoped error, never crash the process or fail unrelated
+# requests in the same batch.
+#
+# Apply:   kubectl apply -f packet-loss.yaml
+# Remove:  kubectl delete -f packet-loss.yaml
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: api-server-packet-loss
+  namespace: quorumproof
+spec:
+  action: loss
+  mode: all
+  selector:
+    namespaces:
+      - quorumproof
+    labelSelectors:
+      app: quorumproof-api-server
+  loss:
+    loss: '15'
+    correlation: '25'
+  duration: '5m'
+  scheduler:
+    cron: '@every 30m'

--- a/monitoring/chaos/service-unavailable.yaml
+++ b/monitoring/chaos/service-unavailable.yaml
@@ -1,0 +1,25 @@
+# Issue #1003 — Chaos Mesh: sustained service unavailability
+#
+# Kills the api-server pod(s) outright (simulating the upstream RPC/service
+# being entirely down) to verify the resilience requirements in
+# docs/resilience.md: aggregate endpoints must still return a well-formed
+# response, and the service must recover cleanly once it comes back.
+#
+# Apply:   kubectl apply -f service-unavailable.yaml
+# Remove:  kubectl delete -f service-unavailable.yaml
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: api-server-unavailable
+  namespace: quorumproof
+spec:
+  action: pod-failure
+  mode: one
+  selector:
+    namespaces:
+      - quorumproof
+    labelSelectors:
+      app: quorumproof-api-server
+  duration: '2m'
+  scheduler:
+    cron: '@every 1h'


### PR DESCRIPTION
## Summary

Closes #1000
Closes #1001
Closes #1002
Closes #1003

### #1000 — Credential Export API
- `GET /api/credentials/:id/export?format=json|pdf|qrcode` (`api-server/src/routes/credentialExport.ts`)
- `json`: full on-chain credential record + `verification_url`
- `pdf`: rendered via `pdfkit` — credential fields + best-effort issuer logo embed (`metadata.issuer_logo_url`), degrades gracefully if the logo can't be fetched
- `qrcode`: PNG (via `qrcode`) encoding a verification URL
- Added `GET /api/verify/:id` as the single-credential verification endpoint the export QR code/PDF link to (`api-server/src/routes/verify.ts`) — no GET-by-id verification endpoint existed before
- New `PUBLIC_APP_BASE_URL` env var to build the verification URL

### #1001 — Issuer Analytics Endpoint
- `GET /api/analytics/credentials?issuer=&range=` — total issued, breakdown by credential type, expiry distribution (scanned from on-chain credentials)
- `GET /api/analytics/verifications?range=` — verification count by claim type and verifier distribution
- `GET /api/analytics/disputes?issuer=&range=` — dispute rate, average resolution time, common reasons
- All three support `range=7d|30d|90d` via new `parseRangeParam()` in `api-server/src/services/metrics.ts`
- Wired `GET /api/verify/:id` and `POST /api/verify/batch` to record `verified` analytics events (`claim_type` + `verifier` in metadata) — previously neither verification path fed the analytics event log, so `/api/analytics/verifications` had no data source

### #1002 — Contract Integration Tests
- New `contracts/integration_tests/tests/integration_tests.rs` (external test binary; the crate previously had no `tests/` directory, only inline `#[cfg(test)]` modules under `src/`)
- Full flow: `issue_credential -> create_slice -> attest -> is_attested -> sbt.mint -> zk.verify_claim -> verify_engineer`
- Error paths: dispute resolution (challenge upheld removes the accused's attestation and drops the credential below threshold; challenge dismissed leaves it standing; non-slice-member challenge rejected) and revocation cascading (revoked credential blocks new attestation and new SBT minting, while an already-minted SBT survives a later revocation)
- Upgrade safety exercised from a populated multi-contract flow (credential + slice + attestation + SBT survive upgrade; unauthorized upgrade rejected)
- Performance budget test on the full cross-contract flow via `env.budget()`

### #1003 — Chaos Testing for Network Failures
- `api-server/tests/chaos.test.ts` — injects network delay, dropped connections, and sustained service unavailability into the mocked Soroban RPC client; asserts every affected endpoint degrades to a scoped error (never a hang/crash/unhandled rejection) and recovers cleanly once the upstream call succeeds again
- New `api-server-chaos` CI job runs this suite on every PR
- `monitoring/chaos/` — Chaos Mesh manifests (network-delay, packet-loss, service-unavailable) for staging/cluster-level verification beyond the in-process suite, plus a README covering prerequisites and usage
- `docs/resilience.md` — resilience requirements table, what's covered at the api-server vs. contract layer and why, and how to run both the in-repo suite and the chaos-mesh manifests

## Test plan
- [x] `api-server`: `npx vitest run tests/verifyBatch.test.ts tests/credentials.test.ts tests/analytics.test.ts` — 43 passed (pre-existing suite, unaffected)
- [x] `api-server`: `npx vitest run tests/chaos.test.ts` — 9/9 new chaos tests passed
- [x] `api-server`: `npx tsc --noEmit` — no new error categories introduced (pre-existing repo-wide `req.params`/`ScVal` typing gaps only, same as before this change)
- [ ] `contracts`: `cargo test -p integration_tests --test integration_tests` — no Rust toolchain available in this sandbox to run; reviewed manually against existing proven patterns in `upgrade_safety.rs` and the inline `mod integration` in `lib.rs` (exact function signatures, `ChallengeStatus`/`required_weight` semantics, and the accused-cannot-vote rule were all cross-checked against the contract source)