### PR TITLE
Docs/adr zk bbs mainnet guides

### DIFF
--- a/contracts/bbs_plus_v1/src/lib.rs
+++ b/contracts/bbs_plus_v1/src/lib.rs
@@ -1,5 +1,9 @@
 #![no_std]
 #![doc = include_str!("../README.md")]
+// Rationale for choosing BBS+ over Merkle-redaction or generic zk-SNARK-wrapped
+// signatures for selective disclosure is recorded in
+// docs/adr/adr-007-bbs-plus-selective-disclosure.md. See also
+// docs/bbs-plus-tutorial.md for a developer-facing usage guide.
 
 extern crate alloc;
 

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -1,4 +1,9 @@
 #![no_std]
+// The quorum-slice / weighted-threshold trust model implemented in this crate
+// (see the `QuorumSlice*` types and `threshold` fields below) follows the
+// Federated Byzantine Agreement design recorded in
+// docs/adr/adr-001-fba-trust-model.md — consult it before changing slice or
+// threshold semantics.
 
 #[cfg(test)]
 extern crate std;

--- a/contracts/sbt_registry/src/lib.rs
+++ b/contracts/sbt_registry/src/lib.rs
@@ -1,4 +1,8 @@
 #![no_std]
+// Design rationale for the non-transferability enforced throughout this contract
+// (see `transfer()` below and `ContractError::SoulboundNonTransferable`) is recorded
+// in docs/adr/adr-002-sbt-non-transferability.md — read that before changing the
+// transfer/burn/recovery semantics.
 
 #[cfg(test)]
 extern crate std;
@@ -734,6 +738,7 @@ impl SbtRegistryContract {
     }
 
     pub fn transfer(env: Env, _from: Address, _to: Address, _token_id: u64) {
+        // Always rejected by design — see docs/adr/adr-002-sbt-non-transferability.md.
         panic_with_error!(&env, ContractError::SoulboundNonTransferable);
     }
 

--- a/docs/adr/0000-adr-template.md
+++ b/docs/adr/0000-adr-template.md
@@ -1,0 +1,57 @@
+# ADR-NNNN: <Short Title of Decision>
+
+## Status
+Proposed | Accepted | Deprecated | Superseded by ADR-NNNN
+
+## Context
+What is the issue that we're seeing that is motivating this decision or change? Describe the forces at play (technical, business, regulatory) in a value-neutral way.
+
+## Problem Statement
+A concise statement of the question this ADR answers. Enumerate the constraints the solution must satisfy.
+
+## Alternatives Considered
+
+### 1. <Alternative Name>
+- **Description**:
+- **Pros**:
+- **Cons**:
+
+### 2. <Alternative Name>
+- **Description**:
+- **Pros**:
+- **Cons**:
+
+### N. <Chosen Alternative> ✓ **CHOSEN**
+- **Description**:
+- **Pros**:
+- **Cons**:
+
+## Decision
+State the decision in full sentences: "We will …".
+
+## Rationale
+Explain why the chosen alternative wins against the others, tied back to the problem statement's constraints.
+
+## Consequences
+
+### Positive
+- ...
+
+### Negative
+- ...
+
+## Implementation Notes
+Concrete details: data structures, module boundaries, contract entry points, migration steps.
+
+## References
+- Links to related ADRs, whitepapers, or code (`../path/to/file.rs`).
+
+---
+**How to use this template**
+
+1. Copy this file to `NNNN-short-title.md`, where `NNNN` is the next unused, zero-padded sequence number in this directory (check [README.md](./README.md) for the current index — do not reuse a number even if an old ADR was deprecated).
+2. Fill in every section. Do not delete a section just because it feels redundant for a small decision — write "N/A" instead so future readers know it was considered.
+3. Set `Status` to `Proposed` and open a pull request for review.
+4. Once the team agrees, change `Status` to `Accepted` and merge.
+5. Add a row to the index table in [README.md](./README.md).
+6. If code implements this decision, add a short comment near the implementation pointing back to the ADR (e.g. `// See docs/adr/0007-bbs-plus-selective-disclosure.md for rationale`).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,6 +15,11 @@ An ADR is a short document that captures *why* a decision was made, not just *wh
 | [003](./adr-003-zk-verification.md) | Zero-Knowledge Verification Approach | Accepted | 2024-02-01 |
 | [004](./adr-004-soroban-platform.md) | Soroban Platform Choice | Accepted | 2026-06-26 |
 | [005](./adr-005-registry-attestation-proof.md) | Registry Attestation Proof for Licensing Body Integrations | Accepted | 2026-07-20 |
+| [006](./adr-006-economic-security-model.md) | Economic Security Model | Accepted | 2026-07-21 |
+| [006](./adr-006-quorum-intersection-verification.md) | Quorum Intersection Verification | Accepted | 2026-07-21 |
+| [007](./adr-007-bbs-plus-selective-disclosure.md) | BBS+ Signatures for Selective Disclosure | Accepted | 2026-07-26 |
+
+> Note: two ADRs were numbered `006` independently before this index was reconciled. Both are kept under their original filenames for stable links; do not reuse `006` or `007` for new ADRs — the next available number is `008`.
 
 ## How to Add a New ADR
 

--- a/docs/adr/adr-007-bbs-plus-selective-disclosure.md
+++ b/docs/adr/adr-007-bbs-plus-selective-disclosure.md
@@ -1,0 +1,85 @@
+# ADR-007: BBS+ Signatures for Selective Disclosure
+
+## Status
+Accepted
+
+## Context
+QuorumProof issues verifiable credentials (degrees, licenses, employment history) that engineers present to third parties (employers, licensing boards, immigration authorities) to prove professional standing. A single credential typically bundles many attributes: full name, date of birth, institution, graduation year, GPA, license number, jurisdiction, etc.
+
+Presenting a credential today, with a conventional digital signature (ECDSA/Ed25519), means presenting the entire signed payload — the verifier receives every attribute even when only one or two are relevant (e.g. "is this person licensed in this jurisdiction?" does not require revealing their date of birth or GPA). This is a data minimization problem: engineers are forced to over-share personal data to prove a narrow claim, and every verifier who receives a full credential becomes a copy of the individual's complete professional record sitting in a third party's database.
+
+## Problem Statement
+How should QuorumProof let a credential holder prove a subset of attested claims to a verifier while:
+1. Not revealing the other attributes contained in the credential
+2. Preserving unforgeability — the verifier must be convinced the disclosed attributes were signed by a legitimate issuer, without contacting the issuer
+3. Preventing the presentation itself from becoming a new tracking identifier (unlinkability across multiple presentations of the same credential)
+4. Remaining feasible to verify inside a Soroban smart contract, which has tight CPU-instruction and memory budgets
+
+## Alternatives Considered
+
+### 1. Plain Signatures + Redaction
+- **Description**: Sign the full attribute set with Ed25519/ECDSA; holder redacts fields before sending, verifier only checks the signature over the *original, unredacted* bytes (which it never sees) — i.e. this doesn't actually work without a Merkle structure.
+- **Pros**: No new cryptography, reuses existing Soroban primitives
+- **Cons**: A plain signature is over one fixed byte string. Removing any byte invalidates it. Cannot support selective disclosure at all without an auxiliary structure.
+
+### 2. Merkle-Tree Credentials (Hash-Based Selective Disclosure)
+- **Description**: Each attribute is hashed into a leaf of a Merkle tree; the issuer signs the root. Holder discloses a subset of leaves plus the Merkle proof path.
+- **Pros**: Simple, uses only hash functions (cheap on-chain), no exotic curve arithmetic
+- **Cons**: Reveals the *number* and *tree position* of undisclosed attributes (a fixed-shape tree leaks schema information), presentations of the same credential to different verifiers are trivially linkable (same root, same undisclosed-leaf hashes reappear), and does not support proving predicates over hidden values (e.g. "age > 18") without revealing the value itself.
+
+### 3. zk-SNARK over a Generic Signature (Groth16-wrapped Ed25519)
+- **Description**: Sign attributes normally, then have the holder prove in zero-knowledge "I know a valid signature over a superset of attributes that includes these disclosed ones."
+- **Pros**: Maximum flexibility, can prove arbitrary predicates
+- **Cons**: Requires a full R1CS circuit for Ed25519/ECDSA verification, which is expensive to prove client-side (seconds, not milliseconds) and requires a trusted setup per circuit. Massive overkill for the common case of "just reveal a subset of fields."
+
+### 4. BBS+ Signatures ✓ **CHOSEN**
+- **Description**: A pairing-based multi-message signature scheme (Au, Susilo, Mu; standardized in the IETF `draft-irtf-cfrg-bbs-signatures`) where the issuer signs a *vector* of messages under one signature. The holder can later derive a zero-knowledge proof of knowledge of a valid signature that discloses an arbitrary subset of the messages while keeping the rest, and the signature itself, hidden.
+- **Pros**:
+  - Native selective disclosure — no auxiliary Merkle structure or generic circuit needed
+  - Proof size and disclosed message count are independent of the number of hidden messages (constant-size core proof)
+  - Presentations are unlinkable: each derived proof is randomized, so two presentations of the same credential to two verifiers (or the same verifier twice) cannot be correlated by the signature material itself
+  - Supports proof-of-knowledge extensions (range proofs, predicates) built on the same pairing group, which QuorumProof already uses for its other ZK circuits
+  - Well-studied security proofs under the q-SDH / DDH assumption in the pairing setting
+- **Cons**:
+  - Requires pairing-friendly curve arithmetic (BLS12-381) inside the Soroban contract, which is more expensive per operation than a hash-based check
+  - Newer standard (still in IETF draft) than plain signatures; smaller ecosystem of audited implementations
+  - Issuer must commit to the maximum message vector length at signing time (schema must be fixed per credential type)
+
+## Decision
+**Adopt BBS+ signatures as the credential signing and presentation scheme for selective disclosure in QuorumProof**, implemented in `contracts/bbs_plus_v1`.
+
+Each credential is signed as a vector of messages (one per attribute). Holders derive presentation proofs off-chain (or via a helper contract call) that disclose only the attributes required by a given verifier; the `bbs_plus_v1` contract verifies the resulting proof of knowledge on-chain without ever learning the hidden attribute values.
+
+## Rationale
+
+1. **Purpose-built for the problem**: Unlike Merkle redaction or generic SNARK wrapping, BBS+ was designed specifically for multi-message selective disclosure, so it directly minimizes the amount of new cryptographic machinery QuorumProof has to build and audit.
+2. **Unlinkability by default**: Each derived proof re-randomizes the signature commitment, so verifiers and issuers cannot correlate separate presentations of the same underlying credential — a requirement for cross-border credential use where an engineer may present to dozens of independent verifiers.
+3. **Reuses existing pairing infrastructure**: QuorumProof already implements pairing operations (`primitives::pairing`, `G1`/`G2`/`Gt` arithmetic) for its ZK verifier stack (see [ADR-003](./adr-003-zk-verification.md)); BBS+ shares this arithmetic base, avoiding a second, unrelated curve library.
+4. **Standardization trajectory**: The IETF CFRG draft gives a reviewed, versioned specification to track, reducing the risk of inventing an ad hoc scheme.
+
+## Consequences
+
+### Positive
+- Engineers disclose the minimum data necessary per verifier, directly reducing data-breach blast radius
+- Verifiers get cryptographic assurance without contacting the issuer or seeing hidden attributes
+- Presentations do not create a new linkable identifier across verifiers
+- Shares pairing primitives with the existing ZK verifier contract, reducing audit surface
+
+### Negative
+- On-chain pairing checks are more compute-expensive than hash checks; contract CPU budgets must be monitored (see `contracts/bbs_plus_v1/src/primitives.rs`)
+- Credential schemas (attribute count/order) must be fixed at issuance time; adding an attribute to an existing credential type requires a new schema version
+- Requires holders to run proof-derivation logic client-side; SDKs must ship this capability (see [BBS+ tutorial](../bbs-plus-tutorial.md))
+
+## Implementation Notes
+
+1. **Signature structure**: `contracts/bbs_plus_v1/src/signature.rs` implements issuer signing over a message vector using the primitives in `primitives.rs` (`Fr`, `G1`, `G2`, `Gt`, `pairing`).
+2. **Presentation/proof derivation**: `contracts/bbs_plus_v1/src/presentation.rs` implements the holder-side derivation of a selective-disclosure proof of knowledge, using `transcript.rs` for Fiat-Shamir challenge generation.
+3. **Revocation**: `contracts/bbs_plus_v1/src/accumulator.rs` provides a cryptographic accumulator so individual credentials can be revoked without breaking unlinkability of unrevoked ones.
+4. **Verification path**: The on-chain contract entry point verifies the proof of knowledge against the issuer's public key and the set of disclosed messages; hidden messages never appear on-chain or in call arguments.
+
+## References
+- [BBS+ Signatures — IETF CFRG Draft](https://datatracker.ietf.org/doc/draft-irtf-cfrg-bbs-signatures/)
+- Au, Susilo, Mu, "Constant-Size Dynamic k-TAA" (origin of the BBS+ construction)
+- [ADR-003: Zero-Knowledge Verification Approach](./adr-003-zk-verification.md)
+- [BBS+ Tutorial and Developer Guide](../bbs-plus-tutorial.md)
+- `contracts/bbs_plus_v1/README.md`

--- a/docs/bbs-plus-tutorial.md
+++ b/docs/bbs-plus-tutorial.md
@@ -1,0 +1,229 @@
+# BBS+ Selective Disclosure Tutorial
+
+## Who this is for
+
+Developers integrating with `contracts/bbs_plus_v1` who need to issue BBS+-signed credentials, or build a holder/verifier flow around selective disclosure, but don't yet have a working mental model of what BBS+ actually does. For the design rationale (why BBS+ over alternatives), see [ADR-007](./adr/adr-007-bbs-plus-selective-disclosure.md). For the raw API surface, read `contracts/bbs_plus_v1/README.md` and the module source directly — this tutorial explains the *flow*, not every parameter.
+
+## 1. Mental Model
+
+A BBS+ signature is over a **vector of messages**, not one blob:
+
+```
+messages = [m1, m2, m3, ..., mL]     // e.g. [name, dob, institution, degree, grad_year]
+signature = Sign(issuer_secret_key, messages)
+```
+
+Three roles:
+- **Issuer** — holds a `SigningKey` (secret scalar) and a corresponding `VerifyingKey`/public key (a G2 point plus circuit metadata such as `message_count`), and signs the full message vector once at credential-issuance time.
+- **Holder** — receives the `Signature` and the messages, and later derives a `PresentationProof` that discloses only a chosen subset of the messages, blinding the rest and re-randomizing the signature so it cannot be linked to prior presentations.
+- **Verifier** — receives the `PresentationProof` plus the disclosed messages, and calls verification against the issuer's `VerifyingKey`. It learns nothing about undisclosed messages beyond what the disclosed ones and the proof imply.
+
+The key property: the holder does not need to go back to the issuer to produce a new presentation. Every presentation is derived locally and is unlinkable to every other presentation of the same underlying signature.
+
+## 2. Signature Creation and Verification
+
+### 2.1 Issuer: key generation
+
+```rust
+use bbs_plus_v1::signature::SigningKey;
+
+let mut rng = rand::thread_rng();
+let signing_key = SigningKey::generate(&mut rng);
+let verifying_key_point = signing_key.public_key(); // G2 point published to holders/verifiers
+```
+
+In production, `SigningKey::generate` should be called inside an HSM or a secure enclave — the raw `Fr` scalar returned by `signing_key.scalar()` is the entire security of every credential this key ever signs. Never log or serialize the signing key scalar outside of a secured issuance service.
+
+### 2.2 Issuer: deriving a verifying key for a credential schema
+
+Each credential type (e.g. "Engineering Degree v1") fixes a message count and a domain-separation context:
+
+```rust
+use bbs_plus_v1::signature::VerifyingKey;
+
+let verifying_key = VerifyingKey::derive(
+    verifying_key_point,
+    b"quorumproof:credential:engineering-degree:v1", // context_id — schema domain separator
+    5,                                                 // message_count: name, dob, institution, degree, grad_year
+)?;
+```
+
+The `context_id` matters: it prevents a signature valid for one credential schema from being reinterpreted as valid for a different schema that happens to share a message count.
+
+### 2.3 Issuer: signing the message vector
+
+```rust
+use bbs_plus_v1::signature::BbsSignature;
+
+let messages: [Fr; 5] = [
+    hash_to_scalar(b"Jane Engineer"),
+    hash_to_scalar(b"1998-04-12"),
+    hash_to_scalar(b"Acme Institute of Technology"),
+    hash_to_scalar(b"BSc Civil Engineering"),
+    hash_to_scalar(b"2021"),
+];
+
+let signature = BbsSignature::sign(&mut rng, &signing_key, &messages)?;
+let signature_bytes: [u8; 112] = signature.to_bytes(); // stored alongside the credential record
+```
+
+Attributes are hashed to `Fr` scalars before signing (BBS+ signs field elements, not raw bytes) — use a fixed, documented hash-to-scalar function per credential schema so issuer and holder never disagree on encoding.
+
+### 2.4 Holder: verifying the raw issuer signature (sanity check)
+
+Before deriving any presentation, the holder should confirm the issuer's signature verifies against the full message vector:
+
+```rust
+let is_valid = BbsSignature::verify(&verifying_key, &signature, &messages)?;
+assert!(is_valid, "issuer signature does not verify — do not accept this credential");
+```
+
+## 3. Disclosure Patterns
+
+### 3.1 Full disclosure (baseline)
+
+Disclosing every message is the degenerate case — equivalent in information content to a plain signature, but still gets unlinkability across presentations for free.
+
+```rust
+use bbs_plus_v1::presentation::BbsPresentation;
+
+let disclosed_indices = [0, 1, 2, 3, 4]; // all five attributes
+let proof = BbsPresentation::create_presentation(
+    &mut rng,
+    &verifying_key,
+    &signature,
+    &messages,
+    &disclosed_indices,
+)?;
+```
+
+### 3.2 Selective disclosure — prove licensure without revealing personal data
+
+The common case: a verifier only needs to know the holder is a licensed civil engineer in a jurisdiction, not their name or date of birth.
+
+```rust
+// Disclose only "degree" (index 3); keep name, dob, institution, grad_year hidden.
+let disclosed_indices = [3];
+let proof = BbsPresentation::create_presentation(
+    &mut rng,
+    &verifying_key,
+    &signature,
+    &messages,
+    &disclosed_indices,
+)?;
+
+// The holder sends `proof.to_bytes()` plus the cleartext value of messages[3]
+// ("BSc Civil Engineering") to the verifier. Nothing else about the credential
+// is transmitted or derivable.
+```
+
+### 3.3 Multi-credential disclosure
+
+A holder can independently derive presentations from *different* credentials for the same verifier interaction (e.g. "degree" from one BBS+-signed credential and "license active" from another) — each presentation is derived and verified independently; there is no built-in cross-credential linking, which is a deliberate anti-correlation property. If a use case genuinely needs to prove two disclosed attributes come from the *same* holder, that requires an explicit binding mechanism (e.g. a shared holder-committed pseudonym) layered on top — it is not automatic.
+
+### 3.4 Predicate disclosure (range/equality proofs)
+
+Beyond revealing a raw attribute value, BBS+ presentations can carry zero-knowledge predicate proofs over hidden messages (e.g. "graduation year is before 2015" without revealing the exact year). This is exposed as an extension of `PresentationProof` — check `contracts/bbs_plus_v1/src/presentation.rs` for the current predicate support surface before relying on a specific predicate type, since this module is still being built out (see the Phase 1 status table in `contracts/bbs_plus_v1/README.md`).
+
+## 4. Verifier: Checking a Presentation
+
+```rust
+use bbs_plus_v1::presentation::BbsPresentation;
+
+let disclosed_messages: &[(usize, Fr)] = &[(3, hash_to_scalar(b"BSc Civil Engineering"))];
+
+let ok = BbsPresentation::verify_presentation(
+    &verifying_key,
+    &proof,
+    disclosed_messages,
+)?;
+
+if !ok {
+    // Reject: either the proof is malformed, was not derived from a valid
+    // issuer signature, or the disclosed message does not match what the
+    // holder committed to inside the proof.
+}
+```
+
+The verifier only ever needs the issuer's `VerifyingKey` and the disclosed messages — it never contacts the issuer and never sees the hidden attributes.
+
+## 5. Privacy Guarantees
+
+| Property | What it means in practice |
+|---|---|
+| **Selective disclosure** | Only attributes the holder explicitly includes in `disclosed_indices` are visible to the verifier, in cleartext or as a predicate proof. Everything else stays computationally hidden inside the proof. |
+| **Unlinkability** | Each call to `create_presentation` re-randomizes the underlying signature commitment. Two presentations derived from the *same* signature and disclosing the *same* attributes are still cryptographically unlinkable to each other — an issuer or verifier colluding across sessions cannot tell they came from the same credential. |
+| **Unforgeability (EUF-CMA)** | No one without the issuer's `SigningKey` can produce a signature (or a presentation that verifies) over a message vector the issuer never signed. |
+| **Honest-verifier zero-knowledge (HVZK)** | The presentation proof reveals nothing about hidden messages beyond what is logically implied by the disclosed ones — a verifier following the protocol learns no extra bits. |
+| **Non-transitive trust** | A verifier's ability to check a presentation does not give it the ability to *forge* new presentations or impersonate the holder to a third party. |
+
+**What BBS+ does *not* protect against:**
+- **Metadata correlation outside the proof** — if the holder always presents from the same network IP, wallet address, or timing pattern, that's a linkability channel BBS+ has no control over.
+- **Issuer collusion at issuance time** — the issuer sees the full message vector when signing; BBS+ protects disclosure to *verifiers*, not from the issuer itself.
+- **Revocation checks leaking information** — naive revocation lookups (e.g. checking a public revocation list by credential ID) can reintroduce linkability. QuorumProof addresses this with the cryptographic accumulator in `contracts/bbs_plus_v1/src/accumulator.rs`, which supports non-membership proofs without revealing which specific credential is being checked.
+
+## 6. Code Samples in Multiple Languages
+
+The Rust examples above use the actual contract crate. The following show the same *conceptual* flow — message vector in, presentation proof out — via a generic client SDK shape. Treat these as illustrative pseudocode until the corresponding JS/Python SDK bindings ship; check `docs/sdk-methods-reference.md` for what is currently available.
+
+### JavaScript / TypeScript (holder-side presentation derivation)
+
+```typescript
+import { BbsPresentation, hashToScalar } from "@quorumproof/bbs-plus-sdk";
+
+const messages = [
+  hashToScalar("Jane Engineer"),
+  hashToScalar("1998-04-12"),
+  hashToScalar("Acme Institute of Technology"),
+  hashToScalar("BSc Civil Engineering"),
+  hashToScalar("2021"),
+];
+
+const proof = await BbsPresentation.createPresentation({
+  verifyingKey,
+  signature,
+  messages,
+  disclosedIndices: [3], // reveal only "degree"
+});
+
+await sendToVerifier({ proofBytes: proof.toBytes(), disclosed: { degree: "BSc Civil Engineering" } });
+```
+
+### Python (verifier-side check)
+
+```python
+from quorumproof_bbs import BbsPresentation, VerifyingKey
+
+verifying_key = VerifyingKey.from_bytes(issuer_vk_bytes)
+proof = BbsPresentation.from_bytes(proof_bytes)
+
+ok = BbsPresentation.verify_presentation(
+    verifying_key,
+    proof,
+    disclosed_messages=[(3, hash_to_scalar("BSc Civil Engineering"))],
+)
+
+if not ok:
+    raise ValueError("presentation failed verification")
+```
+
+### Soroban CLI (invoking the deployed contract directly)
+
+```bash
+soroban contract invoke \
+  --id $BBS_PLUS_CONTRACT_ID \
+  --source verifier-account \
+  --network mainnet \
+  -- \
+  verify_presentation \
+  --verifying_key_hash $VK_HASH \
+  --proof_bytes $PROOF_HEX \
+  --disclosed_messages '[{"index":3,"value":"BSc Civil Engineering"}]'
+```
+
+## References
+- [ADR-007: BBS+ Signatures for Selective Disclosure](./adr/adr-007-bbs-plus-selective-disclosure.md)
+- `contracts/bbs_plus_v1/README.md`
+- `contracts/bbs_plus_v1/src/signature.rs`, `presentation.rs`, `accumulator.rs`
+- [IETF CFRG BBS Signatures draft](https://datatracker.ietf.org/doc/draft-irtf-cfrg-bbs-signatures/)
+- [`docs/privacy-guide.md`](./privacy-guide.md) — broader privacy model this fits into

--- a/docs/mainnet-deployment-runbook.md
+++ b/docs/mainnet-deployment-runbook.md
@@ -1,0 +1,158 @@
+# Mainnet Deployment Runbook
+
+## Purpose and Scope
+
+[`docs/deployment-guide.md`](./deployment-guide.md) and [`docs/deployment-checklist.md`](./deployment-checklist.md) already document *what* the deployment process involves in prose and checklist form. This runbook is the missing **operator-facing, linear script**: the exact sequence an operator follows during an actual mainnet deployment window, start to finish, with explicit go/no-go gates. Follow this document top to bottom during a real deployment; use the other two as reference material when a step needs more explanation.
+
+Two operators minimum are required for any mainnet deployment: one executes commands, one reads them back before submission. Neither operator holds both the deployer key and the admin key.
+
+---
+
+## 0. Pre-Deployment Checklist (Go/No-Go Gate)
+
+Do not proceed past this section unless every item is checked.
+
+- [ ] All tests pass on the exact commit being deployed: `cargo test` (clean, not from memory of a prior run)
+- [ ] `cargo audit` and `cargo deny check` both report zero unresolved advisories (see `deny.toml`)
+- [ ] The commit has been through code review and, for contract changes, the review referenced in [`docs/security-audit-checklist.md`](./security-audit-checklist.md) is complete
+- [ ] WASM artifacts are reproducibly built (see [`docs/deployment-checklist.md`](./deployment-checklist.md) "Artifact Verification") and the build hash is recorded in the deployment ticket
+- [ ] Deployer account and admin account are two **distinct** funded mainnet Stellar accounts (never the same key — see §1)
+- [ ] Admin account is a multisig (see [`docs/deployment-guide.md`](./deployment-guide.md) §4.2) with signers reachable and available during the deployment window
+- [ ] A rollback owner is named and has read §4 of this runbook before deployment starts
+- [ ] Monitoring dashboards (see [`docs/monitoring-guide.md`](./monitoring-guide.md)) are open and confirmed reachable before the first transaction is submitted
+- [ ] A maintenance/deployment window has been communicated to any dependent services (API server, dashboard)
+- [ ] `.env` mainnet values are staged but contract ID fields are still blank (they get filled during §2)
+
+If any box is unchecked, stop. Do not deploy under time pressure with an incomplete checklist — a rushed mainnet deployment is the single most common cause of the incidents in [`docs/disaster-recovery.md`](./disaster-recovery.md).
+
+---
+
+## 1. Funding
+
+Mainnet has no friendbot. Funding must come from a real XLM source.
+
+1. **Acquire XLM** for both the deployer and admin accounts through a licensed exchange or anchor (e.g. an on/off-ramp your organization already has compliance clearance for). Do not use a testnet faucet workflow — it does not exist on mainnet and any tool claiming otherwise is not talking to the real network.
+2. **Fund the deployer account** with enough XLM to cover: 3 contract installs/deploys (~1–2 XLM each), plus a buffer for retries — budget **10 XLM minimum**.
+3. **Fund the admin account(s)** — every signer in the admin multisig needs its own account funded with enough XLM to cover the base reserve (currently 1 XLM per account plus 0.5 XLM per additional signer/entry) and transaction fees for initialization and future admin operations. Under-funding the admin multisig is a common cause of stuck initialization — verify each signer independently:
+   ```bash
+   stellar account show <signer-alias> --network mainnet
+   ```
+4. **Record every funding transaction hash** in the deployment ticket before proceeding — this is your audit trail if a rollback or dispute happens later.
+5. Confirm balances one more time immediately before the deployment window opens (balances can silently drop if a key was reused elsewhere):
+   ```bash
+   stellar account show deployer --network mainnet
+   ```
+
+---
+
+## 2. Deployment Steps
+
+### 2.1 Contract upload (install + deploy)
+
+Follow [`docs/deployment-guide.md`](./deployment-guide.md) §2–3 to build and deploy `quorum_proof`, `sbt_registry`, and `zk_verifier` in that order. Order matters operationally (not technically — the contracts don't yet reference each other's addresses at install time) because `quorum_proof` is the contract every subsequent smoke test depends on, so deploying it first lets you catch build/deploy issues before spending fees on the other two.
+
+After each `stellar contract deploy`, immediately:
+1. Paste the returned contract ID into the deployment ticket
+2. Update the corresponding `.env` field
+3. Confirm the contract exists on-chain before moving to the next one:
+   ```bash
+   stellar contract info --id $CONTRACT_QUORUM_PROOF --network mainnet
+   ```
+
+Do not deploy all three back-to-back without this per-contract confirmation — if `quorum_proof` deployment silently failed (e.g. RPC timeout returning a stale ID), you do not want to discover it after already spending fees on the other two.
+
+### 2.2 Initialization
+
+Follow [`docs/deployment-guide.md`](./deployment-guide.md) §4 to call `initialize(admin)` on each contract. Two operational rules beyond what that section covers:
+
+1. **Initialize in the same order you deployed** (`quorum_proof` → `sbt_registry` → `zk_verifier`). `quorum_proof::initialize` also registers the v1 metadata schema as the active schema as a side effect — verify this schema registration succeeded (§3.2) before initializing the other two contracts, since a failure here is cheaper to fix before other contracts are live.
+2. **Use the admin multisig address, not an individual signer's address**, as the `admin` parameter. Passing an individual signer's address by mistake means that signer alone controls the contract going forward — this cannot be undone without a full redeployment (§4.3).
+
+### 2.3 Cross-contract configuration
+
+If this deployment wires `sbt_registry` or `zk_verifier` to trust `quorum_proof` (e.g. authorizing `quorum_proof` as the only caller allowed to mint SBTs, or registering the verifying key `zk_verifier` will check credential proofs against), perform that wiring now, immediately after all three contracts are initialized and before any real traffic is routed to them. Record every configuration call's transaction hash in the deployment ticket — these are exactly the calls a rollback needs to identify and potentially reverse.
+
+---
+
+## 3. Post-Deployment Verification
+
+Do not announce the deployment as complete until all of these pass.
+
+### 3.1 Basic liveness
+
+```bash
+stellar contract invoke --id $CONTRACT_QUORUM_PROOF --network mainnet -- get_admin
+stellar contract invoke --id $CONTRACT_SBT_REGISTRY --network mainnet -- get_admin
+stellar contract invoke --id $CONTRACT_ZK_VERIFIER --network mainnet -- get_admin
+```
+Confirm each returns the admin multisig address recorded in the deployment ticket — not an individual signer's address (see §2.2).
+
+### 3.2 Schema/state sanity
+
+```bash
+stellar contract invoke --id $CONTRACT_QUORUM_PROOF --network mainnet -- get_active_schema_version
+```
+Confirm this returns `1` (the v1 schema registered during `initialize`).
+
+### 3.3 End-to-end smoke test
+
+Using a disposable, low-value test credential (not a real credential holder's data):
+1. Issue a test credential through `quorum_proof`
+2. Attest it from a test attestor account
+3. Confirm the credential's attestation state reflects the attestation
+4. If `sbt_registry` is wired to `quorum_proof`, confirm the corresponding SBT was minted and that a `transfer()` call on it is rejected with `SoulboundNonTransferable` (see [ADR-002](./adr/adr-002-sbt-non-transferability.md)) — this is a cheap, high-signal check that the non-transferability invariant survived deployment
+5. Revoke the test credential and confirm it is reflected as revoked
+
+Full command sequences for each of these are in [`docs/deployment-guide.md`](./deployment-guide.md) §8.
+
+### 3.4 Monitoring confirmation
+
+Confirm the dashboards from [`docs/monitoring-guide.md`](./monitoring-guide.md) are receiving events from the new contract IDs, not stale data from a previous deployment. Confirm alerting is wired to the new contract IDs specifically — a monitoring config left pointed at old testnet or previous mainnet contract IDs will silently fail to alert on real incidents.
+
+### 3.5 Sign-off
+
+Both operators (executor and reader, from the top of this document) record explicit sign-off in the deployment ticket with timestamp, before the deployment window is considered closed.
+
+---
+
+## 4. Rollback Procedures
+
+Decide which rollback path applies based on severity, then execute it. Full command sequences for each path are in [`docs/deployment-guide.md`](./deployment-guide.md) §6 and [`docs/disaster-recovery.md`](./disaster-recovery.md) — this section is the decision tree, not a duplicate of those commands.
+
+### 4.1 Decide the severity
+
+| Situation | Path |
+|---|---|
+| A non-critical bug found post-deployment, contract state is otherwise healthy | §4.2 Contract upgrade rollback |
+| An active exploit or critical vulnerability is being exploited right now | §4.3 Emergency pause (immediately), then evaluate upgrade vs. redeploy |
+| Admin key compromise, or initialization was performed with the wrong admin address | §4.4 Full redeployment |
+
+### 4.2 Contract upgrade rollback (non-critical regression)
+
+Use when the previous WASM is known-good and on-chain state does not need to change. Follow [`docs/deployment-guide.md`](./deployment-guide.md) §6.1 and [`docs/contract-upgrade-strategy.md`](./contract-upgrade-strategy.md). Requires the admin multisig to approve the upgrade call — budget time for signer coordination; this is not an instant action.
+
+### 4.3 Emergency pause (active exploit)
+
+This is the only rollback action that should happen without waiting for full multisig coordination time if signers are reachable quickly — the goal is to stop damage first, investigate second. Follow [`docs/deployment-guide.md`](./deployment-guide.md) §6.2. After pausing:
+1. Confirm read-only functions still work and write functions are blocked
+2. Investigate root cause before unpausing
+3. Do not unpause until a patched, reviewed, tested contract is ready to deploy — unpausing the vulnerable contract "temporarily" re-exposes the same exploit
+
+### 4.4 Full redeployment (key compromise or bad initialization)
+
+The most expensive path — on-chain state from the compromised contracts is not automatically migrated. Follow [`docs/deployment-guide.md`](./deployment-guide.md) §6.3 and [`docs/disaster-recovery.md`](./disaster-recovery.md) in full. Before starting, notify all issuers and credential holders that re-issuance will be required — this is a coordination-heavy process, not a pure technical one, and the coordination should start in parallel with the technical redeployment, not after it.
+
+### 4.5 Post-rollback verification
+
+Whichever path was taken, re-run §3 (Post-Deployment Verification) in full against the post-rollback state before declaring the incident resolved.
+
+---
+
+## References
+- [`docs/deployment-guide.md`](./deployment-guide.md) — full command reference this runbook sequences
+- [`docs/deployment-checklist.md`](./deployment-checklist.md) — exhaustive pre/post checklist detail
+- [`docs/contract-upgrade-strategy.md`](./contract-upgrade-strategy.md)
+- [`docs/disaster-recovery.md`](./disaster-recovery.md)
+- [`docs/monitoring-guide.md`](./monitoring-guide.md)
+- [`docs/security-audit-checklist.md`](./security-audit-checklist.md)
+- [ADR-001: FBA Trust Model](./adr/adr-001-fba-trust-model.md), [ADR-002: SBT Non-Transferability](./adr/adr-002-sbt-non-transferability.md)

--- a/docs/zk-verification-developer-guide.md
+++ b/docs/zk-verification-developer-guide.md
@@ -1,0 +1,172 @@
+# ZK Verification Developer Guide
+
+## Purpose
+
+Zero-knowledge proof verification is the most cryptographically dense part of QuorumProof, and it is easy to use the `zk_verifier` contract correctly without understanding *why* it is safe. This guide is the missing "how verification actually works" education layer: it walks through the Groth16 proof structure, the PLONK protocol currently implemented on-chain, folding schemes as the likely next step, worked examples with concrete test vectors, and the security implications a developer must keep in mind before shipping changes to this contract.
+
+This guide is deliberately conceptual/educational. For the authoritative byte-level API, see:
+- [`docs/zk-proof-scheme-specification.md`](./zk-proof-scheme-specification.md) — canonical wire formats
+- [`docs/plonk-verification.md`](./plonk-verification.md) — implemented PLONK verifier details
+- [`docs/groth16-migration.md`](./groth16-migration.md) — history of the Groth16 verifier's stub-to-production migration
+- [`docs/zk-api-reference.md`](./zk-api-reference.md) — contract entry points
+- [ADR-003: Zero-Knowledge Verification Approach](./adr/adr-003-zk-verification.md) — why Groth16 and PLONK were chosen at all
+
+## 1. Groth16 Proof Structure and Verification
+
+### 1.1 What a Groth16 proof actually is
+
+Groth16 (Groth, 2016) is a pairing-based zk-SNARK for proving satisfiability of a Rank-1 Constraint System (R1CS) — the arithmetic circuit representation of a claim like "I know a valid credential attestation chain that satisfies this quorum threshold." A Groth16 proof consists of exactly three elliptic curve points:
+
+```
+π = (A, B, C)
+  A ∈ G1   (64 bytes uncompressed on BN254)
+  B ∈ G2   (128 bytes uncompressed on BN254)
+  C ∈ G1   (64 bytes uncompressed on BN254)
+  -----------------------------------------
+  Total: 256 bytes  (see contracts/zk_verifier/src/lib.rs::GROTH16_PROOF_LEN)
+```
+
+This fixed, constant size regardless of circuit complexity is Groth16's headline property — a circuit with a million constraints produces the same 256-byte proof as one with ten.
+
+### 1.2 The verification equation
+
+A verifier holds a verifying key `VK = (α, β, γ, δ, [ICᵢ])` produced once during the circuit-specific trusted setup, plus the public inputs `x = (x₁, ..., xₗ)`. Verification checks a single pairing equation:
+
+```
+e(A, B) = e(α, β) · e(vk_x, γ) · e(C, δ)
+
+where vk_x = IC₀ + Σ xᵢ·ICᵢ
+```
+
+`e(·,·)` is a bilinear pairing over the BN254 curve. Intuitively:
+- `e(α, β)` is a fixed "anchor" baked into the verifying key
+- `vk_x` binds the public inputs into a single G1 point via a linear combination
+- The equation only balances if `A`, `B`, `C` were derived from a satisfying witness for *this* circuit and *these* public inputs
+
+If any public input is wrong, or the proof was generated for a different circuit or different verifying key, the pairing equation fails.
+
+### 1.3 How QuorumProof verifies Groth16 today
+
+Soroban does not currently expose BN254 pairing host functions, so `contracts/zk_verifier` cannot perform the real pairing check above on-chain today. Instead it performs **structural and cryptographic binding validation**:
+1. Proof is exactly 256 bytes and none of `A`, `B`, `C` is the point at infinity (all-zero)
+2. A binding hash ties the proof to a specific `vk_hash` and the claimed `credential_id`/`claim_type`, so a proof cannot be replayed against a different verifying key or claim
+3. Admin-gated `verify_claim` and permissionless `verify_groth16_proof` entry points enforce these checks consistently
+
+This gives a 255/256-bit binding guarantee against proof substitution and replay, but it is **not** equivalent to full pairing-based soundness — see [Security Implications](#4-security-implications) below and [`docs/groth16-migration.md`](./groth16-migration.md) for the full rationale and the path to full pairing verification once/if Soroban exposes BN254 precompiles.
+
+## 2. PLONK and Folding Schemes
+
+### 2.1 PLONK, briefly
+
+Where Groth16 needs a per-circuit trusted setup, PLONK (Gabizon, Williamson, Ciobotaru, 2019) uses a **universal and updatable** structured reference string (SRS) — one SRS (from a KZG commitment scheme) serves any circuit up to a maximum gate count. PLONK represents computation as a sequence of gates connected by a permutation argument, and a proof consists of:
+- Wire commitments (`[a]`, `[b]`, `[c]`)
+- A permutation accumulator commitment (`[z]`)
+- Quotient polynomial commitments split into parts (`[t_lo]`, `[t_mid]`, `[t_hi]`)
+- KZG opening proofs (`[W_zeta]`, `[W_zeta_omega]`)
+- Scalar evaluations at the challenge point (`a_bar`, `b_bar`, `c_bar`, `s1_bar`, `s2_bar`, `zw_bar`)
+
+QuorumProof's PLONK verifier (`contracts/zk_verifier/src/plonk.rs`) performs **genuine BLS12-381 pairing checks** — unlike the Groth16 path above, Soroban does expose the BLS12-381 pairing host functions QuorumProof relies on here. See [`docs/plonk-verification.md`](./plonk-verification.md) for the exact 624-byte proof layout and the r0-direct linearisation variant used.
+
+### 2.2 Folding schemes — the next step beyond one-shot SNARKs
+
+Both Groth16 and PLONK verify *one* proof for *one* circuit execution. When a workflow requires proving a chain of steps (e.g. "this credential was attested, then re-attested three times, then presented"), the naive approach is one proof per step — linear prover cost and linear on-chain verification cost.
+
+**Folding schemes** (Nova — Kothapalli, Setty, Tzialla 2021; and successors like SuperNova, ProtoStar, HyperNova) instead "fold" two instances of the same relation into one, accumulating an arbitrary number of steps into a single running instance with **constant-size folding cost per step**. Only at the very end is a single, small "compression" SNARK (often Groth16 or PLONK itself) applied to the final folded instance to produce a succinct, verifier-friendly proof.
+
+Why this matters for QuorumProof specifically:
+- Credential lifecycles are inherently incremental (issue → attest → re-attest → revoke-check → present), which is exactly the recursive/incremental structure folding schemes target
+- A folded proof lets a holder prove "my full attestation history is valid" in time roughly linear in the *number of new steps since last proof*, not the full history length
+- Folding schemes are not yet implemented in this repository — they are documented here as the evaluated next architectural step, not as shipped functionality. Do not assume any `fold_*` contract entry points exist; grep `contracts/zk_verifier` before relying on this section for implementation details.
+
+If/when folding is adopted, expect it to sit *alongside* Groth16/PLONK rather than replace them: the final compression step of a folding scheme still needs a one-shot SNARK verifier like the ones described above.
+
+## 3. Worked Examples with Test Vectors
+
+These examples show the exact byte layouts a developer will see when debugging proof verification. They are illustrative encodings that match the contract's documented formats — always cross-check against `contracts/zk_verifier/src/lib.rs` and its test modules for the current canonical vectors, since production keys and real curve points are not reproduced here.
+
+### 3.1 Groth16 — minimal proof skeleton (256 bytes)
+
+Byte layout (all-zero point coordinates below are placeholders to show *positions*, not valid curve points):
+
+```
+Offset   Length   Field
+0        64       A  (G1 point, uncompressed: x‖y, 32 bytes each)
+64       128      B  (G2 point, uncompressed: x_c0‖x_c1‖y_c0‖y_c1, 32 bytes each)
+192      64       C  (G1 point, uncompressed: x‖y, 32 bytes each)
+-------------------------------------------------------------
+Total: 256 bytes
+```
+
+Verification-side pseudocode matching `contracts/zk_verifier`'s structural checks:
+
+```rust
+fn verify_groth16_structural(proof: &[u8], vk_hash: [u8; 32], credential_id: u64, claim_type: u8) -> bool {
+    assert_eq!(proof.len(), 256);
+    let a = &proof[0..64];
+    let b = &proof[64..192];
+    let c = &proof[192..256];
+
+    // Reject the point-at-infinity encoding (all-zero) for each component.
+    if a.iter().all(|&b| b == 0) { return false; }
+    if b.iter().all(|&b| b == 0) { return false; }
+    if c.iter().all(|&b| b == 0) { return false; }
+
+    // Binding hash bit: proof must commit to this vk_hash + claim context.
+    let binding = sha256(&[a, b, c, &vk_hash, &credential_id.to_le_bytes(), &[claim_type]].concat());
+    binding_matches_embedded_tag(&binding, proof)
+}
+```
+
+### 3.2 PLONK — proof component test vector (624 bytes)
+
+```
+Offset   Length   Field
+0        48       [a]           wire commitment
+48       48       [b]           wire commitment
+96       48       [c]           wire commitment
+144      48       [z]           permutation accumulator
+192      48       [t_lo]        quotient (low)
+240      48       [t_mid]       quotient (mid)
+288      48       [t_hi]        quotient (high)
+336      48       [W_zeta]      KZG opening at zeta
+384      48       [W_zeta_omega] KZG opening at zeta*omega
+432      32       a_bar         wire a evaluation (Fr, LE)
+464      32       b_bar         wire b evaluation (Fr, LE)
+496      32       c_bar         wire c evaluation (Fr, LE)
+528      32       s1_bar        permutation poly 1 evaluation (Fr, LE)
+560      32       s2_bar        permutation poly 2 evaluation (Fr, LE)
+592      32       zw_bar        accumulator eval at zeta*omega (Fr, LE)
+-------------------------------------------------------------
+Total: 624 bytes
+```
+
+A verifier walks through, in order: (1) recompute the Fiat-Shamir challenges (`beta`, `gamma`, `alpha`, `zeta`, `v`, `u`) by hashing the transcript of commitments in the order they appear above, (2) evaluate the public-input polynomial at `zeta`, (3) compute the linearisation polynomial's constant term directly (the r0-direct variant), and (4) perform the final KZG batched pairing check. See [`docs/plonk-verification.md`](./plonk-verification.md) for the full transcript and pairing equation.
+
+### 3.3 Reading a failed verification
+
+When `verify_claim` or `verify_groth16_proof` return `false`, the two most common root causes during development are:
+1. **Wrong VK hash** — the proof was generated against a different verifying key than the one registered on-chain (check `KeyRotationEntry` history for the credential's issuer — the VK may have rotated)
+2. **Truncated/misordered bytes** — a common bug when hand-assembling proof bytes in a test is concatenating `A`, `B`, `C` in the wrong order, or using compressed instead of uncompressed point encoding
+
+## 4. Security Implications
+
+1. **Groth16's binding check is not full soundness.** Because Soroban lacks BN254 pairing host functions, the on-chain Groth16 path validates proof *shape* and *binding* but cannot verify the pairing equation itself. This means a proof that is well-formed and correctly bound to a `vk_hash` is not cryptographically guaranteed to encode a satisfying witness in the same sense a full pairing check would guarantee. Treat Groth16-verified claims as **binding-checked, not soundness-verified**, and prefer the PLONK path (which performs real BLS12-381 pairing checks) for claims where full on-chain soundness is required. Track `docs/groth16-migration.md` for when/if this changes.
+
+2. **Trusted setup toxic waste (Groth16 only).** Groth16's per-circuit SRS has "toxic waste" (the secret randomness used to generate it) that must be destroyed. If any party retained it, they can forge proofs for that circuit that pass the pairing check. PLONK's universal SRS has the same toxic-waste requirement at generation time, but the SRS is circuit-agnostic and can be reused, reducing (not eliminating) exposure to repeated ceremonies.
+
+3. **Verifying key rotation is a trust boundary.** `KeyRotationEntry` lets an admin rotate the registered verifying key for a circuit. A malicious or compromised admin key could rotate to a VK for which they hold the toxic waste, then forge arbitrary "valid" claims. Key rotation must be multisig-gated in production (see [`docs/deployment-guide.md`](./deployment-guide.md) §4.2) and every rotation is written to an immutable audit trail for exactly this reason.
+
+4. **Public input binding matters as much as the proof.** A pairing check (or the binding-hash equivalent) is only meaningful relative to the specific public inputs it was computed against. Never separate a proof from its public inputs when passing them across a trust boundary (e.g. API → contract call) — a proof valid for public inputs `X` says nothing about public inputs `X'`.
+
+5. **Proof malleability and replay.** Some proof systems permit malleating a valid proof into another valid proof for the same statement (e.g. re-randomizing `A`/`B` in certain Groth16 implementations if the implementation is not malleability-resistant). QuorumProof's binding hash over `(proof, vk_hash, credential_id, claim_type)` is specifically designed to prevent a malleated or replayed proof from being accepted for a different claim context — do not remove this binding when refactoring.
+
+6. **Folding schemes widen the audit surface.** If folding is adopted (see §2.2), the recursive verifier circuit itself becomes part of the trusted computation — a bug in the folding/accumulation logic can silently accept an invalid step anywhere in a long chain, and that error compounds until the final compression proof is checked. Any future folding implementation needs its own dedicated security review; do not assume today's Groth16/PLONK security analysis transfers automatically.
+
+## References
+- [ADR-003: Zero-Knowledge Verification Approach](./adr/adr-003-zk-verification.md)
+- [`docs/zk-proof-scheme-specification.md`](./zk-proof-scheme-specification.md)
+- [`docs/plonk-verification.md`](./plonk-verification.md)
+- [`docs/groth16-migration.md`](./groth16-migration.md)
+- Groth, "On the Size of Pairing-Based Non-interactive Arguments" (2016)
+- Gabizon, Williamson, Ciobotaru, "PLONK: Permutations over Lagrange-bases..." (2019)
+- Kothapalli, Setty, Tzialla, "Nova: Recursive Zero-Knowledge Arguments from Folding Schemes" (2021)


### PR DESCRIPTION
closes #1255 
closes #1256 
closes #1257 
closes #1258 

This PR adds four documentation deliverables closing four open documentation issues. Each is implemented as its own commit on this branch (4 commits total, no code logic changes — docs and doc-comments only).

### 1. Architecture Decision Records (ADRs)
Design decisions were scattered across code comments with no central index. This adds:
- `docs/adr/0000-adr-template.md` — the ADR template that `docs/adr/README.md` already referenced in its "How to Add a New ADR" section but which didn't actually exist in the repo.
- `docs/adr/adr-007-bbs-plus-selective-disclosure.md` — a new ADR documenting why BBS+ was chosen for selective disclosure, evaluated against three alternatives (plain-signature redaction, Merkle-tree credentials, and generic zk-SNARK-wrapped signatures), with rationale, consequences, and implementation notes tied to `contracts/bbs_plus_v1`.
- A reconciled index table in `docs/adr/README.md` — it was missing rows for both pre-existing ADRs that share the number 006 (`adr-006-economic-security-model.md` and `adr-006-quorum-intersection-verification.md`), and now includes ADR-007 with a note that 006/007 are taken and 008 is next.
- Short doc comments linking implementation to rationale: `contracts/sbt_registry/src/lib.rs` → ADR-002 (non-transferability), `contracts/quorum_proof/src/lib.rs` → ADR-001 (FBA quorum-slice trust model), `contracts/bbs_plus_v1/src/lib.rs` → ADR-007 (selective disclosure).

ADRs for FBA (ADR-001) and SBT (ADR-002) already existed in the repo prior to this PR — this work fills the actual gap, which was the missing template, the missing BBS+ ADR, the broken index, and the missing code-to-ADR links.

### 2. ZK verification developer guide
`docs/zk-verification-developer-guide.md` — an education-focused companion to the existing implementation-level docs (`zk-proof-scheme-specification.md`, `plonk-verification.md`, `groth16-migration.md`). Covers:
- Groth16 proof structure (the `A, B, C` triple) and its pairing verification equation, plus why the on-chain verifier currently performs binding/structural checks rather than a full pairing check (Soroban has no BN254 pairing host functions today) — with an explicit note on what that trade-off means for soundness.
- PLONK's universal/updatable SRS versus Groth16's per-circuit trusted setup, and confirmation that QuorumProof's PLONK path performs genuine BLS12-381 pairing verification.
- Folding schemes (Nova and successors) as the evaluated next architectural step for incremental credential-lifecycle proofs — explicitly flagged as not yet implemented, to avoid readers assuming shipped functionality.
- Worked byte-layout examples with test vectors for both the 256-byte Groth16 proof and the 624-byte PLONK proof, plus common failure modes seen during development.
- A security implications section: toxic waste, verifying-key rotation as a trust boundary, public-input binding, proof malleability/replay, and the expanded audit surface folding schemes would introduce.

### 3. BBS+ selective disclosure tutorial
`docs/bbs-plus-tutorial.md` — BBS+ was underdocumented for developers building against `contracts/bbs_plus_v1`. Covers:
- The issuer/holder/verifier mental model for BBS+ multi-message signatures.
- Signature creation and verification walked through against the real crate API (`SigningKey`, `VerifyingKey::derive`, `BbsSignature::sign`/`verify`).
- Disclosure patterns: full disclosure, single-attribute selective disclosure (e.g. proving licensure without revealing name/DOB), multi-credential disclosure, and predicate disclosure (flagged as in-progress in the underlying crate).
- A privacy guarantees table (selective disclosure, unlinkability, EUF-CMA unforgeability, HVZK) with an explicit "what BBS+ does *not* protect against" section (metadata correlation, issuer-side visibility at signing time, revocation-list linkability).
- Code samples in Rust, TypeScript, Python, and the Soroban CLI.

### 4. Mainnet deployment runbook
`docs/mainnet-deployment-runbook.md` — there was no step-by-step, operator-facing script for an actual mainnet deployment window; the existing
`deployment-guide.md`/`deployment-checklist.md` are thorough but prose/checklishan a linear runbook. This adds:
- A go/no-go pre-deployment checklist gate.
- Mainnet-specific funding guidance (no friendbot on mainnet — funding must comding both the deployer key and every admin-multisig signer; recording funding tx hashes for the audit trail).
- Deployment steps in explicit order — contract upload, initialization, cross-cthe operational reasoning for that order (e.g. `quorum_proof::initialize`registers the v1 metadata schema as a side effect, so it should be verified before initializing the other two contracts).
- Post-deployment verification steps, including a smoke test tied to the SBT noADR-002): mint a test SBT and confirm `transfer()` is rejected.
- A rollback decision tree (contract upgrade rollback vs. emergency pause vs. full redeployment) that routes to the existing detailed procedures in `deployment-guide.md` and `disaster-recovery.md` rather than duplicating their command sequences.