### PR TITLE
Docs/integration security troubleshooting backup

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,86 @@
+# .github/workflows/backup.yml — Issue #912: Periodic contract state backup.
+#
+# Runs the daily backup documented in docs/backup-system.md: exports
+# testnet and mainnet contract state via scripts/backup.sh, encrypts it,
+# uploads it to S3, verifies the resulting artifact with
+# scripts/verify_backup.sh, and retains a copy as a GitHub Actions
+# artifact for 90 days. Can also be triggered manually for an on-demand
+# backup ahead of a risky operation (e.g. a contract upgrade).
+
+name: Backup
+
+on:
+  schedule:
+    # Daily at 2 AM UTC
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+    inputs:
+      network:
+        description: "Network to back up (leave blank to back up both testnet and mainnet)"
+        required: false
+        type: choice
+        default: "both"
+        options:
+          - both
+          - testnet
+          - mainnet
+
+jobs:
+  backup:
+    name: Backup ${{ matrix.network }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        network: [testnet, mainnet]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install soroban CLI
+        run: cargo install --locked soroban-cli --version ^21 || true
+
+      - name: Skip network if not selected
+        id: gate
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" \
+                && "${{ github.event.inputs.network }}" != "both" \
+                && "${{ github.event.inputs.network }}" != "${{ matrix.network }}" ]]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run backup
+        if: steps.gate.outputs.run == 'true'
+        env:
+          STELLAR_NETWORK: ${{ matrix.network }}
+          CONTRACT_QUORUM_PROOF: ${{ matrix.network == 'testnet' && secrets.CONTRACT_QUORUM_PROOF_TESTNET || secrets.CONTRACT_QUORUM_PROOF_MAINNET }}
+          BACKUP_ENCRYPTION_KEY: ${{ secrets.BACKUP_ENCRYPTION_KEY }}
+        run: |
+          ./scripts/backup.sh \
+            --network "$STELLAR_NETWORK" \
+            --encrypt \
+            --upload "${{ secrets.BACKUP_S3_BUCKET }}"
+
+      - name: Verify backup integrity
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          latest="$(ls -t backups/daily/*.json 2>/dev/null | head -n1)"
+          if [[ -n "$latest" ]]; then
+            ./scripts/verify_backup.sh "$latest" --dry-run-restore
+          fi
+
+      - name: Upload backup artifact
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: backup-${{ matrix.network }}-${{ github.run_id }}
+          path: backups/daily/
+          retention-days: 90
+
+      - name: Notify on failure
+        if: failure() && steps.gate.outputs.run == 'true'
+        run: |
+          echo "::error::Backup failed for network ${{ matrix.network }}. See docs/backup-system.md and docs/disaster-recovery.md for the manual recovery procedure."

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Follow the step-by-step guide in `demo/demo-script.md`
 - [Threat Model & Security](docs/threat-model.md)
 - [Error Code Reference](docs/error-codes.md)
 - [Integration Patterns Guide](docs/integration-patterns-guide.md)
+- [Issuer Security Checklist](docs/issuer-security-checklist.md)
 - [Roadmap](docs/roadmap.md)
 
 ## 🎓 Smart Contract API

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Follow the step-by-step guide in `demo/demo-script.md`
 - [Integration Patterns Guide](docs/integration-patterns-guide.md)
 - [Issuer Security Checklist](docs/issuer-security-checklist.md)
 - [Troubleshooting Guide](docs/troubleshooting-guide.md)
+- [Backup System](docs/backup-system.md)
 - [Roadmap](docs/roadmap.md)
 
 ## 🎓 Smart Contract API

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Follow the step-by-step guide in `demo/demo-script.md`
 - [Error Code Reference](docs/error-codes.md)
 - [Integration Patterns Guide](docs/integration-patterns-guide.md)
 - [Issuer Security Checklist](docs/issuer-security-checklist.md)
+- [Troubleshooting Guide](docs/troubleshooting-guide.md)
 - [Roadmap](docs/roadmap.md)
 
 ## 🎓 Smart Contract API

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Follow the step-by-step guide in `demo/demo-script.md`
 - [ZK Verification Design](docs/zk-verification.md)
 - [Threat Model & Security](docs/threat-model.md)
 - [Error Code Reference](docs/error-codes.md)
+- [Integration Patterns Guide](docs/integration-patterns-guide.md)
 - [Roadmap](docs/roadmap.md)
 
 ## 🎓 Smart Contract API

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -797,6 +797,8 @@ pub enum ContractError {
     QuorumIntersectionFailed = 84,
     /// Issue #912: Snapshot not found
     SnapshotNotFound = 85,
+    /// Issue #912: Snapshot integrity hash does not match its recorded counts
+    SnapshotCorrupted = 86,
 }
 
 #[contracttype]
@@ -853,6 +855,8 @@ pub enum DataKey {
     SnapshotCount,
     /// Issue #912: List of all snapshot IDs for querying
     AllSnapshots,
+    /// Issue #912: ID of the most recently restored snapshot, for audit purposes
+    LastRestoredSnapshot,
 }
 
 #[contracttype]
@@ -13731,38 +13735,9 @@ impl QuorumProofContract {
             .unwrap_or(1u32);
 
         // Compute hashes (simplified: in production use full Merkle root)
-        let credentials_hash = Bytes::from_slice(&env, &[
-            (credential_count >> 56) as u8,
-            (credential_count >> 48) as u8,
-            (credential_count >> 40) as u8,
-            (credential_count >> 32) as u8,
-            (credential_count >> 24) as u8,
-            (credential_count >> 16) as u8,
-            (credential_count >> 8) as u8,
-            credential_count as u8,
-        ]);
-
-        let slices_hash = Bytes::from_slice(&env, &[
-            (slice_count >> 56) as u8,
-            (slice_count >> 48) as u8,
-            (slice_count >> 40) as u8,
-            (slice_count >> 32) as u8,
-            (slice_count >> 24) as u8,
-            (slice_count >> 16) as u8,
-            (slice_count >> 8) as u8,
-            slice_count as u8,
-        ]);
-
-        let disputes_hash = Bytes::from_slice(&env, &[
-            (dispute_count >> 56) as u8,
-            (dispute_count >> 48) as u8,
-            (dispute_count >> 40) as u8,
-            (dispute_count >> 32) as u8,
-            (dispute_count >> 24) as u8,
-            (dispute_count >> 16) as u8,
-            (dispute_count >> 8) as u8,
-            dispute_count as u8,
-        ]);
+        let credentials_hash = Self::u64_to_hash_bytes(&env, credential_count);
+        let slices_hash = Self::u64_to_hash_bytes(&env, slice_count);
+        let disputes_hash = Self::u64_to_hash_bytes(&env, dispute_count);
 
         // Generate snapshot ID
         let snapshot_id: u64 = env
@@ -13832,14 +13807,40 @@ impl QuorumProofContract {
             .unwrap_or(Vec::new(&env))
     }
 
+    /// Encode a `u64` counter as an 8-byte big-endian hash for snapshot
+    /// integrity checks (simplified stand-in for a full Merkle root).
+    ///
+    /// # Issue #912: State Snapshot and Restore
+    fn u64_to_hash_bytes(env: &Env, value: u64) -> Bytes {
+        Bytes::from_slice(
+            env,
+            &[
+                (value >> 56) as u8,
+                (value >> 48) as u8,
+                (value >> 40) as u8,
+                (value >> 32) as u8,
+                (value >> 24) as u8,
+                (value >> 16) as u8,
+                (value >> 8) as u8,
+                value as u8,
+            ],
+        )
+    }
+
     /// Restore contract state from a snapshot.
-    /// Only the admin can restore. This is a no-op stub — full restoration would require
-    /// iterating through all stored credentials and slices.
-    /// 
-    /// In production, this would:
-    /// 1. Validate the snapshot hash matches current state
-    /// 2. Restore credential metadata, slice definitions, and dispute records
-    /// 3. Verify the restoration against the snapshot hash
+    ///
+    /// Only the admin can restore. The snapshot's stored hashes are
+    /// recomputed from its own recorded counts and compared against the
+    /// hashes captured at snapshot time; a mismatch means the snapshot
+    /// entry was corrupted or tampered with in storage and restoration is
+    /// aborted. On success, the aggregate credential/slice/dispute counters
+    /// are reset to the values captured in the snapshot.
+    ///
+    /// Full per-record restoration (individual credentials, slices, and
+    /// disputes) is out of scope for on-chain execution due to gas limits
+    /// on large state; those are restored off-chain via
+    /// `scripts/restore_from_backup.sh` using the same snapshot data
+    /// exported by `create_state_snapshot`. See `docs/backup-system.md`.
     ///
     /// # Parameters
     /// - `admin`: The admin address; must authorize.
@@ -13848,7 +13849,9 @@ impl QuorumProofContract {
     /// # Panics
     /// - If the contract is paused
     /// - If the admin is not authorized
-    /// - If the snapshot does not exist
+    /// - If the snapshot does not exist (`SnapshotNotFound`)
+    /// - If the snapshot's state version is incompatible with the current schema
+    /// - If the snapshot's recorded hashes do not match its recorded counts (`SnapshotCorrupted`)
     ///
     /// # Issue #912: State Snapshot and Restore
     pub fn restore_from_snapshot(env: Env, admin: Address, snapshot_id: u64) {
@@ -13874,20 +13877,56 @@ impl QuorumProofContract {
             "snapshot state version mismatch"
         );
 
+        // Validate snapshot integrity: recompute hashes from the snapshot's
+        // own recorded counts and compare against what was stored. A
+        // mismatch indicates the snapshot record was corrupted after
+        // creation and must not be used to restore state.
+        let expected_credentials_hash = Self::u64_to_hash_bytes(&env, snapshot.credential_count);
+        let expected_slices_hash = Self::u64_to_hash_bytes(&env, snapshot.slice_count);
+        let expected_disputes_hash = Self::u64_to_hash_bytes(&env, snapshot.dispute_count);
+        if expected_credentials_hash != snapshot.credentials_hash
+            || expected_slices_hash != snapshot.slices_hash
+            || expected_disputes_hash != snapshot.disputes_hash
+        {
+            panic_with_error!(&env, ContractError::SnapshotCorrupted);
+        }
+
+        // Restore the aggregate counters captured in the snapshot. Individual
+        // credential/slice/dispute records are restored off-chain (see
+        // docs/backup-system.md) since iterating and rewriting the full data
+        // set on-chain would exceed transaction resource limits for large
+        // registries.
+        env.storage()
+            .instance()
+            .set(&DataKey::CredentialCount, &snapshot.credential_count);
+        env.storage()
+            .instance()
+            .set(&DataKey::SliceCount, &snapshot.slice_count);
+        env.storage()
+            .instance()
+            .set(&DataKey::DisputeCount, &snapshot.dispute_count);
+
+        // Record which snapshot was last restored, for audit purposes.
+        env.storage()
+            .instance()
+            .set(&DataKey::LastRestoredSnapshot, &snapshot_id);
+        env.storage()
+            .instance()
+            .extend_ttl(EXTENDED_TTL, EXTENDED_TTL);
+
         // Log the restoration event (emit via soroban event system)
         env.events().publish(
             (soroban_sdk::Symbol::short("restore"), snapshot_id),
             soroban_sdk::Symbol::short("restored"),
         );
+    }
 
-        // In a full implementation:
-        // 1. Iterate through all credentials and restore from backup storage
-        // 2. Restore slice definitions
-        // 3. Restore dispute records
-        // 4. Verify hashes match
-
-        // For now, just mark that restoration occurred
-        // (actual data restoration would happen incrementally or via batch operations)
+    /// Return the ID of the most recently restored snapshot, if any restore
+    /// has occurred since deployment.
+    ///
+    /// # Issue #912: State Snapshot and Restore
+    pub fn get_last_restored_snapshot(env: Env) -> Option<u64> {
+        env.storage().instance().get(&DataKey::LastRestoredSnapshot)
     }
 
     // ── Credential Holder Recovery (Issue #290) ──────────────────────────────
@@ -21957,6 +21996,100 @@ mod feature_tests {
         let env2 = Env::from_snapshot_file(snap_path);
         assert_eq!(env.ledger().sequence(), env2.ledger().sequence());
         assert_eq!(env.ledger().timestamp(), env2.ledger().timestamp());
+    }
+
+    // ── State export/restore (Issue #912) ──────────────────────────────────────
+
+    /// `create_state_snapshot` captures the current counters and is
+    /// retrievable via `get_snapshot` and `list_snapshots`.
+    #[test]
+    fn test_create_state_snapshot_captures_counts() {
+        let env = Env::default();
+        let (client, admin) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let metadata = Bytes::from_slice(&env, b"QmBackupHash0000000000000000000000");
+        client.issue_credential(&issuer, &subject, &1u32, &metadata, &None, &0u64);
+
+        let snapshot_id = client.create_state_snapshot(&admin, &String::from_str(&env, "pre-upgrade backup"));
+        assert_eq!(snapshot_id, 1);
+        assert_eq!(client.list_snapshots(), Vec::from_array(&env, [1u64]));
+
+        let snapshot = client.get_snapshot(&snapshot_id).unwrap();
+        assert_eq!(snapshot.credential_count, 1);
+        assert_eq!(snapshot.slice_count, 0);
+    }
+
+    /// `restore_from_snapshot` resets the aggregate counters back to what
+    /// was recorded at snapshot time, even after further state changes.
+    #[test]
+    fn test_restore_from_snapshot_resets_counters() {
+        let env = Env::default();
+        let (client, admin) = setup(&env);
+        let issuer = Address::generate(&env);
+        let subject = Address::generate(&env);
+        let metadata = Bytes::from_slice(&env, b"QmBackupHash0000000000000000000000");
+        client.issue_credential(&issuer, &subject, &1u32, &metadata, &None, &0u64);
+
+        let snapshot_id = client.create_state_snapshot(&admin, &String::from_str(&env, "checkpoint"));
+        assert_eq!(client.get_credential_count(), 1);
+
+        // Simulate further state changes after the snapshot was taken.
+        client.issue_credential(&issuer, &subject, &1u32, &metadata, &None, &0u64);
+        client.issue_credential(&issuer, &subject, &1u32, &metadata, &None, &0u64);
+        assert_eq!(client.get_credential_count(), 3);
+
+        client.restore_from_snapshot(&admin, &snapshot_id);
+
+        assert_eq!(client.get_credential_count(), 1);
+        assert_eq!(client.get_last_restored_snapshot(), Some(snapshot_id));
+    }
+
+    /// Restoring a snapshot ID that was never created fails with `SnapshotNotFound`.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #85)")]
+    fn test_restore_from_snapshot_missing_id_fails() {
+        let env = Env::default();
+        let (client, admin) = setup(&env);
+        client.restore_from_snapshot(&admin, &999u64);
+    }
+
+    /// Restoring is rejected while the contract is paused, matching every
+    /// other admin-gated state mutation.
+    #[test]
+    #[should_panic]
+    fn test_restore_from_snapshot_fails_when_paused() {
+        let env = Env::default();
+        let (client, admin) = setup(&env);
+        let snapshot_id = client.create_state_snapshot(&admin, &String::from_str(&env, "checkpoint"));
+        client.pause(&admin);
+        client.restore_from_snapshot(&admin, &snapshot_id);
+    }
+
+    /// A snapshot record whose stored hash no longer matches its own
+    /// recorded counts (e.g. corrupted or tampered storage) is rejected
+    /// with `SnapshotCorrupted` rather than silently restoring bad data.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #86)")]
+    fn test_restore_from_snapshot_detects_corrupted_hash() {
+        let env = Env::default();
+        let (client, admin) = setup(&env);
+        let snapshot_id = client.create_state_snapshot(&admin, &String::from_str(&env, "checkpoint"));
+
+        env.as_contract(&client.address, || {
+            let mut snapshot: StateSnapshot = env
+                .storage()
+                .instance()
+                .get(&DataKey::StateSnapshot(snapshot_id))
+                .unwrap();
+            // Tamper with the recorded count without updating its hash.
+            snapshot.credential_count = 42;
+            env.storage()
+                .instance()
+                .set(&DataKey::StateSnapshot(snapshot_id), &snapshot);
+        });
+
+        client.restore_from_snapshot(&admin, &snapshot_id);
     }
 
     // ── Property-based fuzz tests ─────────────────────────────────────────────

--- a/docs/backup-system.md
+++ b/docs/backup-system.md
@@ -288,6 +288,77 @@ soroban contract invoke \
 
 ---
 
+## On-Chain State Snapshots
+
+In addition to the off-chain S3 backup pipeline above, the `quorum_proof`
+contract itself supports lightweight on-chain snapshots of its aggregate
+counters (credential, slice, and dispute counts). These act as a fast
+integrity checkpoint and a way to recover the aggregate counters without
+waiting for an off-chain restore, and they are what `create_state_snapshot`
+records get read from by tooling that wants to cross-check an off-chain
+backup against on-chain state at the time it was taken.
+
+### Creating a snapshot
+
+```bash
+soroban contract invoke \
+  --id CAAAAAAA... \
+  --network testnet \
+  -- create_state_snapshot \
+  --admin <ADMIN> \
+  --description "pre-upgrade checkpoint"
+# returns the new snapshot_id, e.g. 7
+```
+
+### Inspecting snapshots
+
+```bash
+# List all snapshot IDs
+soroban contract invoke --id CAAAAAAA... --network testnet -- list_snapshots
+
+# Fetch a specific snapshot's recorded counts and hashes
+soroban contract invoke --id CAAAAAAA... --network testnet \
+  -- get_snapshot --snapshot_id 7
+```
+
+### Restoring from a snapshot
+
+```bash
+soroban contract invoke \
+  --id CAAAAAAA... \
+  --network testnet \
+  -- restore_from_snapshot \
+  --admin <ADMIN> \
+  --snapshot_id 7
+```
+
+Before restoring, the contract:
+
+1. Confirms the snapshot exists (`SnapshotNotFound` if not).
+2. Confirms the snapshot's `state_version` matches the contract's current
+   schema version, refusing to restore snapshots taken under an
+   incompatible schema.
+3. Recomputes the snapshot's hashes from its own recorded counts and
+   compares them against the hashes stored at snapshot time
+   (`SnapshotCorrupted` if they don't match) — this catches a snapshot
+   record that was corrupted or tampered with after creation.
+
+On success, the contract resets `CredentialCount`, `SliceCount`, and
+`DisputeCount` to the values captured in the snapshot, and records the
+restored snapshot ID (queryable via `get_last_restored_snapshot`) for audit
+purposes.
+
+**Scope note:** restoring only resets the aggregate counters, not every
+individual credential/slice/dispute record — rewriting the full data set
+in a single on-chain transaction would exceed Soroban's per-transaction
+resource limits for any registry of meaningful size. Full record-level
+recovery goes through the off-chain [Restore Procedure](#restore-procedure)
+above, which replays individual records from the S3/local JSON backup.
+Use the on-chain snapshot to confirm the counters an off-chain restore
+should converge to.
+
+---
+
 ## Automated Workflow
 
 ### Daily Backup Schedule

--- a/docs/integration-patterns-guide.md
+++ b/docs/integration-patterns-guide.md
@@ -1,0 +1,320 @@
+# Integration Patterns Guide
+
+Third-party developers integrating with QuorumProof generally build one of
+three kinds of application: an **issuer** service that mints credentials, a
+**verifier** service that checks a credential before granting access to
+something, or an **auditor** service that reviews credential and dispute
+history without ever mutating state. This guide documents the recommended
+integration pattern for each role, with runnable code examples, how to
+handle errors and retries, and a troubleshooting section for the failures
+integrators hit most often.
+
+It complements two existing references rather than replacing them:
+- [SDK Methods Reference](sdk-methods-reference.md) — full method signatures
+- [API Client Guide](api-client-guide.md) — auth model and contract addresses
+
+---
+
+## Table of Contents
+
+1. [Issuer Pattern](#1-issuer-pattern)
+2. [Verifier Pattern](#2-verifier-pattern)
+3. [Auditor Pattern](#3-auditor-pattern)
+4. [Error Handling & Retries](#4-error-handling--retries)
+5. [Troubleshooting](#5-troubleshooting)
+
+---
+
+## 1. Issuer Pattern
+
+An issuer integration issues credentials on behalf of an institution
+(university, licensing board, employer). It holds the issuer's signing key
+(or delegates signing to a custody provider) and calls state-mutating
+contract methods.
+
+### Recommended shape
+
+```
+Issuer backend
+  │
+  ├─ Idempotency store (subject, credential_type) → credential_id
+  │     Prevents re-issuing the same credential on retry
+  │
+  ├─ issue_credential() ──> Soroban RPC ──> quorum_proof contract
+  │
+  └─ Event listener (CredentialIssued) ──> update internal system of record
+```
+
+The idempotency store matters because `issue_credential` fails with
+`DuplicateCredential` (`#4`) on a retried duplicate call — that failure
+should be treated as *success* by the caller, not surfaced as an error (see
+[§4](#4-error-handling--retries)).
+
+### Example (TypeScript)
+
+```typescript
+import { Contract, SorobanRpc, TransactionBuilder, Keypair } from "@stellar/stellar-sdk";
+
+async function issueCredential(
+  issuerKeypair: Keypair,
+  subject: string,
+  credentialType: number,
+  metadataHash: Buffer,
+): Promise<bigint> {
+  const server = new SorobanRpc.Server(process.env.SOROBAN_RPC_URL!);
+  const contract = new Contract(process.env.CONTRACT_QUORUM_PROOF!);
+
+  const account = await server.getAccount(issuerKeypair.publicKey());
+  const tx = new TransactionBuilder(account, { fee: "1000000", networkPassphrase: process.env.NETWORK_PASSPHRASE! })
+    .addOperation(
+      contract.call(
+        "issue_credential",
+        issuerKeypair.publicKey(),
+        subject,
+        credentialType,
+        metadataHash,
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  prepared.sign(issuerKeypair);
+
+  const result = await server.sendTransaction(prepared);
+  return await pollForCredentialId(server, result.hash);
+}
+```
+
+### Example (Rust, via soroban-client)
+
+```rust
+let credential_id = client
+    .issue_credential(&issuer, &subject, &credential_type, &metadata_hash, &None, &0u64)
+    .await?;
+```
+
+### Key practices
+
+- Store the returned `credential_id` immediately; it is the only handle for
+  future `revoke_credential` / `suspend_credential` calls.
+- Subscribe to `CredentialIssued` events (see
+  [Audit Log Format](audit-log-format.md)) rather than polling, to keep the
+  system of record in sync with chain state.
+- Never let end users hold or see the issuer's signing key — proxy all
+  calls through the backend. See the
+  [Issuer Security Checklist](issuer-security-checklist.md) for key
+  management requirements.
+
+---
+
+## 2. Verifier Pattern
+
+A verifier integration checks whether a subject holds a valid credential
+before granting access to a resource (a job application portal, a
+regulated service, a physical access system). Verifiers only make
+read-only calls — they never sign transactions on behalf of the subject.
+
+### Recommended shape
+
+```
+Verifier backend
+  │
+  ├─ get_credential(credential_id)         ── fetch the claim
+  ├─ is_attested(credential_id, slice_id)  ── confirm quorum was reached
+  ├─ is_revoked / is_suspended              ── confirm still valid
+  └─ decision: allow / deny
+```
+
+Always check attestation *and* revocation/suspension status — a credential
+can be issued but not yet attested, or attested but later revoked. Checking
+only one leads to false positives.
+
+### Example (TypeScript)
+
+```typescript
+async function verifyCredential(credentialId: bigint, sliceId: bigint): Promise<boolean> {
+  const contract = new Contract(process.env.CONTRACT_QUORUM_PROOF!);
+  const server = new SorobanRpc.Server(process.env.SOROBAN_RPC_URL!);
+
+  const credential = await simulateRead(server, contract, "get_credential", credentialId);
+  if (!credential) return false;
+  if (credential.revoked || credential.suspended) return false;
+
+  const attested = await simulateRead(server, contract, "is_attested", credentialId, sliceId);
+  return Boolean(attested);
+}
+```
+
+### Example (Python)
+
+```python
+def verify_credential(client, credential_id: int, slice_id: int) -> bool:
+    credential = client.get_credential(credential_id)
+    if credential is None or credential["revoked"] or credential["suspended"]:
+        return False
+    return client.is_attested(credential_id, slice_id)
+```
+
+### Key practices
+
+- Read calls are free simulations — there is no reason to cache
+  aggressively, but do cache within a single request lifecycle to avoid
+  redundant RPC round trips (e.g. one `get_credential` call feeding both a
+  revocation check and a display step).
+- Treat `CredentialNotFound` (`#1`) from a read call as "not a valid
+  credential," not as an error to alert on — it is an expected outcome when
+  verifying user-supplied IDs.
+- For ZK-based claims (proving an attribute without revealing the full
+  credential), see [ZK API Reference](zk-api-reference.md) instead of the
+  plain `get_credential` flow above.
+
+---
+
+## 3. Auditor Pattern
+
+An auditor integration reviews the full history of credentials, disputes,
+and attestation events for compliance, reporting, or investigation. It
+never issues, attests, or revokes — it only reads and aggregates.
+
+### Recommended shape
+
+```
+Auditor backend
+  │
+  ├─ Event indexer ── subscribes to all contract events (see audit-log-format.md)
+  │     └─> writes to an append-only local store (Postgres, BigQuery, etc.)
+  │
+  ├─ Reconciliation job ── periodically compares indexed counts against
+  │     get_credential_count() / get_slice_count() on-chain
+  │
+  └─ Reporting layer ── queries the local store, never the chain directly,
+        for anything beyond point lookups
+```
+
+Building a local index is the right pattern for auditors specifically
+because compliance queries ("all credentials issued by issuer X in Q1")
+are not exposed as contract methods and would require scanning every
+credential ID on-chain otherwise.
+
+### Example (TypeScript event indexer)
+
+```typescript
+async function indexEvents(server: SorobanRpc.Server, contractId: string, fromLedger: number) {
+  const events = await server.getEvents({
+    startLedger: fromLedger,
+    filters: [{ type: "contract", contractIds: [contractId] }],
+  });
+
+  for (const event of events.events) {
+    await store.append({
+      ledger: event.ledger,
+      topic: event.topic,
+      value: event.value,
+      txHash: event.txHash,
+    });
+  }
+
+  return events.latestLedger;
+}
+```
+
+### Key practices
+
+- Reconcile your index against `create_state_snapshot` /
+  `get_snapshot` on-chain counters periodically — a mismatch usually means
+  the indexer missed an event, not that the contract is wrong. See
+  [Backup System — On-Chain State Snapshots](backup-system.md#on-chain-state-snapshots).
+- Never expose write credentials to the auditor service; it should hold no
+  signing key at all, only an RPC endpoint.
+- For dispute history specifically, cross-reference
+  [Dispute Resolution Threat Model](threat-model.md#4-dispute-resolution-threat-model).
+
+---
+
+## 4. Error Handling & Retries
+
+All three patterns share the same error-handling contract because they all
+talk to Soroban RPC over the network.
+
+### Classifying failures
+
+| Failure class | Example | Retry? |
+|---|---|---|
+| Network/transient | RPC timeout, `503`, connection reset | Yes, with backoff |
+| Simulation/preflight error | Insufficient resource fee, expired ledger footprint | Yes, rebuild and resubmit |
+| Contract error (`Error(Contract, #N)`) | `DuplicateCredential`, `CredentialNotFound` | Usually no — it's a logic error, not a transient one |
+| Auth error | Missing signature, wrong signer | No — fix the caller, don't retry |
+
+Full per-code recovery guidance lives in
+[Error Code Reference](error-codes.md); this section covers the *retry
+strategy* around those codes, not the codes themselves.
+
+### Retry pattern (exponential backoff with jitter)
+
+```typescript
+async function withRetry<T>(fn: () => Promise<T>, maxAttempts = 5): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (!isRetryable(err) || attempt === maxAttempts - 1) throw err;
+      const delayMs = Math.min(1000 * 2 ** attempt, 15_000) + Math.random() * 250;
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+  throw lastError;
+}
+
+function isRetryable(err: unknown): boolean {
+  const message = String((err as Error)?.message ?? err);
+  // Network-level and preflight failures are retryable; contract panics
+  // (Error(Contract, #N)) and auth failures are not.
+  return !/Error\(Contract, #\d+\)/.test(message) && !/auth/i.test(message);
+}
+```
+
+### Idempotency for issuers
+
+Because `issue_credential` is not naturally idempotent across retries (a
+second call for the same subject+type raises `DuplicateCredential`, `#4`),
+wrap it so a retry after a network failure resolves correctly:
+
+```typescript
+async function issueIdempotent(subject: string, credentialType: number, metadataHash: Buffer) {
+  try {
+    return await withRetry(() => issueCredential(issuerKeypair, subject, credentialType, metadataHash));
+  } catch (err) {
+    if (/Error\(Contract, #4\)/.test(String(err))) {
+      // Already issued by a previous attempt — look up the existing ID instead of failing.
+      return await findExistingCredentialId(subject, credentialType);
+    }
+    throw err;
+  }
+}
+```
+
+---
+
+## 5. Troubleshooting
+
+This section covers integration-specific failures. For end-user-facing
+error diagnosis (decision tree, log interpretation), see the
+[Troubleshooting Guide](troubleshooting-guide.md).
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `issue_credential` succeeds on-chain but the app never sees the ID | Polling for the transaction result stopped too early, or the RPC node served a stale ledger | Poll `getTransaction` until status is `SUCCESS` or `FAILED`, not just `sendTransaction`'s immediate response |
+| Every call fails with an auth error | The keypair used to sign doesn't match the address passed as `issuer`/`admin` | Confirm `require_auth()` target matches the signing key; check for a stale cached keypair |
+| Reads return stale data right after a write | Reading from a different RPC node than the one that processed the write, before it propagated | Read from the same RPC endpoint, or add a short delay / poll `get_credential_count` for the expected increment |
+| `DuplicateCredential` on what looks like a first attempt | A prior request succeeded but the client crashed/timed out before recording the result | Look up by `(subject, credential_type)` before treating this as a real error — see idempotency pattern above |
+| Verifier always returns "not attested" for a credential you know was attested | Checking the wrong `slice_id` — a credential can be associated with multiple slices | Confirm the `slice_id` used at attestation time, not an assumed default |
+| Auditor's local index count drifts from on-chain count | Missed events due to an indexer restart without resuming from the last processed ledger | Persist `latestLedger` after each batch and resume from it, not from "now" |
+| WASM/contract calls fail after a contract upgrade | Client SDK bindings are generated from an older contract spec | Regenerate bindings from the current `.wasm`; see [Contract Upgrade Guide](contract-upgrade-guide.md) |
+
+If none of these match, capture the full `Error(Contract, #N)` code and the
+transaction hash, then check [Error Code Reference](error-codes.md) and
+[Troubleshooting Guide](troubleshooting-guide.md#decision-tree) before
+opening a support request.

--- a/docs/issuer-security-checklist.md
+++ b/docs/issuer-security-checklist.md
@@ -1,0 +1,181 @@
+# Issuer Security Checklist
+
+Issuers hold the highest-value keys in the QuorumProof system: an issuer
+key can mint credentials, revoke them, and initiate holder recovery. A
+compromised issuer key does more damage than almost any other failure mode
+in the protocol (see [Threat Model §2 — Threat Actors](threat-model.md#2-threat-actors)
+and [Risk Assessment Summary](threat-model.md#7-risk-assessment-summary)).
+This checklist gives issuing institutions a concrete set of operational
+security requirements to follow, organized by threat severity, with links
+to the underlying threat model entries that justify each control.
+
+This document is operational guidance for institutions *using* QuorumProof
+as issuers. It is distinct from
+[Security Audit Checklist](security-audit-checklist.md), which is for
+auditors reviewing the contract code itself, and from
+[Security Best Practices](security-best-practices.md), which covers the
+protocol broadly.
+
+---
+
+## How to use this document
+
+Work through each section and check off items before going live on
+mainnet. Re-run the full checklist after any change to signing
+infrastructure, personnel, or credential-issuance volume. Items marked
+**(Critical)** must be resolved before issuing any mainnet credential;
+items marked **(High)** should be resolved within the first issuance
+cycle; **(Medium)** and **(Low)** items are ongoing hardening.
+
+---
+
+## 1. Key Management
+
+- [ ] **(Critical)** Issuer signing keys are generated and stored in an
+      HSM or equivalent hardware-backed key store — never as a plaintext
+      seed phrase in application config, a `.env` file, or source control.
+- [ ] **(Critical)** No single person has unilateral access to the issuer
+      key material. Use a multi-party custody solution (threshold
+      signatures or a hardware approval quorum) for any issuer signing
+      volume above trivial testnet usage.
+- [ ] **(Critical)** Key backup material (seed shares, HSM export) is
+      stored encrypted, offline, and split across at least two physically
+      separate locations.
+- [ ] **(High)** Key rotation procedure is documented and rehearsed. When
+      rotating, revoke the old key's operational access *before*
+      publicizing the new issuer address, to avoid a window where both
+      keys are trusted in downstream systems.
+- [ ] **(High)** Signing keys used for testnet are never reused on
+      mainnet, and vice versa.
+- [ ] **(Medium)** Key usage is rate-limited at the infrastructure layer
+      (e.g. a signing proxy) so a compromised application cannot mint an
+      unbounded number of credentials before detection.
+
+**Relevant threat model entries:** Credential Forgery (Critical impact),
+Admin Collusion (Critical impact) — see
+[Risk Assessment Summary](threat-model.md#7-risk-assessment-summary).
+
+---
+
+## 2. Access Control
+
+- [ ] **(Critical)** The application backend that calls `issue_credential`
+      / `revoke_credential` runs behind authentication and authorization
+      that mirrors the on-chain issuer role — a compromised internal
+      account should not be able to trigger issuance without a second
+      layer of approval.
+- [ ] **(Critical)** Production credentials (RPC API keys, signing service
+      tokens, database credentials) are stored in a secrets manager, not
+      in environment files checked into version control or shared over
+      chat.
+- [ ] **(High)** Staff who can trigger issuance/revocation are limited to
+      a named, reviewed list; access is revoked immediately on role change
+      or offboarding.
+- [ ] **(High)** Recovery initiation (`initiate_recovery`) requires the
+      same approval workflow as issuance, since it can redirect a
+      credential to a new subject address.
+- [ ] **(Medium)** Separate least-privilege service accounts are used for
+      issuance, revocation, and read-only verification integrations — a
+      verifier integration should never hold issuer signing capability.
+- [ ] **(Medium)** Break-glass / emergency-pause access
+      (`pause`/`unpause`) is restricted to a small on-call group distinct
+      from day-to-day issuance staff.
+
+**Relevant threat model entries:** Unauthorized Attestation, Pause/Unpause
+Abuse — see [Attack Vectors & Mitigations](threat-model.md#3-attack-vectors--mitigations).
+
+---
+
+## 3. Audit Logging
+
+- [ ] **(Critical)** Every issuance, revocation, and suspension performed
+      by the issuer's backend is logged with: acting principal, timestamp,
+      credential ID, subject, and the reason/justification supplied.
+      Cross-reference the on-chain event fields in
+      [Audit Log Format](audit-log-format.md) so off-chain and on-chain
+      records can be reconciled.
+- [ ] **(High)** Audit logs are append-only (write-once storage or a
+      hash-chained log) so a compromised backend cannot retroactively
+      hide its own actions.
+- [ ] **(High)** Alerts fire on anomalous issuance patterns — a burst of
+      issuances outside business hours, issuance to a previously unseen
+      batch of subjects, or repeated `DuplicateCredential` (`#4`) errors
+      that could indicate probing.
+- [ ] **(Medium)** Audit logs are retained for at least as long as the
+      credential validity period (see `expires_at` semantics), and
+      exported into the backup pipeline described in
+      [Backup System](backup-system.md) so they survive a backend
+      failure.
+- [ ] **(Low)** Periodic reconciliation jobs compare the issuer's local
+      audit log against on-chain `CredentialIssued`/`CredentialRevoked`
+      events to detect drift or missed writes.
+
+**Relevant threat model entries:** Evidence Tampering, Evidence Forgery —
+see [Attack Vectors & Mitigations](threat-model.md#3-attack-vectors--mitigations).
+
+---
+
+## 4. Security Recommendations by Threat Level
+
+Mapped from [Threat Model — Risk Assessment Summary](threat-model.md#7-risk-assessment-summary):
+
+### Critical impact risks
+*Credential Forgery, SBT Transfer, Cross-Contract Substitution, Admin
+Collusion, Dispute Resolution Collusion.*
+- Treat issuer key compromise as an incident requiring immediate
+  `pause()` and credential-holder communication, not a routine rotation.
+- Require dual control (two-person rule) for any admin-level action,
+  including pause/unpause and recovery approval.
+
+### High impact risks
+*Unauthorized Attestation, Revoked Credential Attestation, ZK Verification
+Bypass, TTL Expiry & Data Loss, Pause/Unpause Abuse, Slice Member Bribery,
+Evidence Tampering, SBT Minting Without Attestation.*
+- Monitor attestation and revocation events in near-real-time (see
+  [Monitoring Guide](monitoring-guide.md)); high-impact risks are the ones
+  where minutes of delay in detection matter most.
+- Do not rely solely on the ZK verifier stub for access decisions until it
+  is out of stub status (`v1.1`) — treat it as advisory, not authoritative,
+  per [Threat Model §5](threat-model.md#5-recent-features-threat-analysis-v10).
+
+### Medium impact risks
+*False Dispute Filing, Metadata Availability Loss, Dispute Spam, SBT
+Metadata Manipulation.*
+- Pin credential metadata (IPFS) with a redundant pinning service; a
+  metadata availability loss degrades verifiability even though the
+  on-chain hash is intact.
+- Rate-limit dispute filing at the application layer in addition to the
+  contract's own protections.
+
+### Low impact risks
+*Double Revocation, Slice Threshold Bypass, Dispute Timeout Abuse, SBT
+Burning & Re-minting.*
+- These are already mitigated at the contract level; issuer-side controls
+  here are limited to standard logging and periodic review rather than
+  dedicated tooling.
+
+---
+
+## 5. Sign-Off
+
+Before issuing on mainnet, confirm:
+
+- [ ] All **Critical** items above are checked off.
+- [ ] All **High** items above are checked off or have a documented
+      remediation timeline.
+- [ ] This checklist has been reviewed against the current
+      [Threat Model](threat-model.md) (re-check after any threat model
+      revision).
+- [ ] The issuer's incident response contact is registered per
+      [SECURITY.md](../SECURITY.md).
+
+---
+
+## Related Documentation
+
+- [Threat Model & Security Analysis](threat-model.md)
+- [Security Best Practices](security-best-practices.md)
+- [Security Audit Checklist](security-audit-checklist.md)
+- [Audit Log Format](audit-log-format.md)
+- [Backup System](backup-system.md)
+- [Monitoring Guide](monitoring-guide.md)

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -1,0 +1,167 @@
+# Troubleshooting Guide
+
+A guide for diagnosing problems encountered while using QuorumProof —
+whether you're an issuer, a verifier, or an end user whose credential
+isn't behaving as expected. It's organized as: common errors and fixes, a
+decision tree to route you to the right fix quickly, and a guide to
+reading the logs you'll be looking at along the way.
+
+For integration-specific failures (SDK/RPC-level issues hit while
+*building* against QuorumProof), see
+[Integration Patterns Guide §5](integration-patterns-guide.md#5-troubleshooting)
+instead — this document is about diagnosing a problem with a specific
+credential, transaction, or deployment.
+
+---
+
+## Table of Contents
+
+1. [Common Errors and Solutions](#1-common-errors-and-solutions)
+2. [Decision Tree](#2-decision-tree)
+3. [Logs Interpretation Guide](#3-logs-interpretation-guide)
+4. [Where to Go Next](#4-where-to-go-next)
+
+---
+
+## 1. Common Errors and Solutions
+
+| Error / Symptom | What it means | Solution |
+|---|---|---|
+| `Error(Contract, #1)` — `CredentialNotFound` | The credential ID doesn't exist on this contract/network | Confirm you're pointed at the right `CONTRACT_QUORUM_PROOF` address and network (testnet vs mainnet); confirm the ID was actually returned by a prior `issue_credential` call |
+| `Error(Contract, #3)` — `ContractPaused` | An admin has paused the contract (usually during an incident or upgrade) | Wait for `unpause`; check the project status page or ask the issuer when service will resume |
+| `Error(Contract, #4)` — `DuplicateCredential` | A credential already exists for this subject + issuer + type | Not necessarily a bug — look up the existing credential instead of re-issuing; see [Integration Patterns Guide](integration-patterns-guide.md#key-practices) for the idempotency pattern |
+| Verification says "not attested" but you were told it was approved | The quorum slice threshold hasn't been met yet, or you're checking against the wrong `slice_id` | Confirm the `slice_id` used at attestation time and check `get_attestation_count` against the slice's threshold |
+| Verification says a credential is invalid, but you have proof it was issued | The credential was revoked or suspended after issuance | Call `get_credential` and check the `revoked` / `suspended` fields, then check `RevocationLog` events for the reason |
+| Transaction submitted but nothing happens | The transaction may still be in flight, or failed simulation silently | Look up the transaction hash via `getTransaction` on the RPC endpoint; a `PENDING` status just needs more time, `FAILED` needs the error inspected |
+| "Insufficient fee" or resource-limit errors | Soroban's resource-based fee model rejected the transaction footprint | Re-simulate the transaction to get an updated resource estimate rather than reusing a stale one |
+| Snapshot restore fails with `Error(Contract, #85)` | The `snapshot_id` passed to `restore_from_snapshot` doesn't exist | Call `list_snapshots()` to see valid IDs |
+| Snapshot restore fails with `Error(Contract, #86)` | The snapshot's stored data no longer matches its own recorded hash — the snapshot record was corrupted | Use a different snapshot, or fall back to the off-chain backup described in [Backup System](backup-system.md) |
+| Metadata (IPFS content) won't resolve | The metadata was never pinned redundantly, or the pinning service expired | Check pin status with your IPFS provider; this is a known partial-mitigation risk, see [Threat Model — Metadata Availability Loss](threat-model.md#7-risk-assessment-summary) |
+
+The full per-code reference, including every error across all three
+contracts, is in [Error Code Reference](error-codes.md) — use the table
+above to triage quickly, then look up the exact code there for the
+authoritative recovery steps.
+
+---
+
+## 2. Decision Tree
+
+Start at the top and follow the first branch that matches your symptom.
+
+```
+Something isn't working. What are you seeing?
+│
+├─ A transaction/call raised "Error(Contract, #N)"
+│   │
+│   ├─ Is N in the 1-10 range (not-found / duplicate / basic validation)?
+│   │     → Look up #N in Error Code Reference — usually a caller-side
+│   │       mistake (wrong ID, wrong network, already-done action).
+│   │
+│   ├─ Is it #3 (ContractPaused)?
+│   │     → Not a bug on your end. Check SECURITY.md / status channel
+│   │       for an active incident, then retry after unpause.
+│   │
+│   ├─ Is it #85 or #86 (snapshot-related)?
+│   │     → See Backup System — On-Chain State Snapshots.
+│   │
+│   └─ Is it something else / unrecognized?
+│         → Capture the full error string + tx hash, check Error Code
+│           Reference for the code's contract of origin, then escalate
+│           (see §4) if still unclear.
+│
+├─ No error was raised, but the result looks wrong
+│   │
+│   ├─ A credential you expect to be valid reads as invalid
+│   │     → Check revoked/suspended flags first (see §1), then check
+│   │       attestation status against the *correct* slice_id.
+│   │
+│   ├─ A count (credential/slice count) looks lower than expected
+│   │     → You may be reading from a stale RPC node, or an indexer
+│   │       (if you built one) missed events. Re-read from the RPC node
+│   │       that processed the write, or reconcile against
+│   │       create_state_snapshot / get_snapshot.
+│   │
+│   └─ Metadata content (off-chain, e.g. IPFS) won't load
+│         → The hash on-chain is still valid; this is an availability
+│           problem with the metadata host, not a contract issue.
+│
+└─ Nothing happens at all (no error, no result)
+    │
+    ├─ Did you call sendTransaction and stop, without polling getTransaction?
+    │     → That's expected — sendTransaction returns immediately with a
+    │       PENDING-style ack; poll getTransaction until SUCCESS/FAILED.
+    │
+    └─ Still nothing after polling for a full ledger close cycle (~5-6s+)?
+          → Check RPC node health / status; see Logs Interpretation below
+            for what to look for in your own service logs.
+```
+
+---
+
+## 3. Logs Interpretation Guide
+
+QuorumProof produces two kinds of logs you'll typically be reading:
+on-chain contract events (the authoritative record) and your own
+application/service logs (network calls, retries, RPC responses).
+
+### On-chain event logs
+
+Every state change emits a Stellar contract event. The canonical field
+reference is [Audit Log Format](audit-log-format.md); the fields you'll
+use most often when troubleshooting:
+
+- `event_type` — tells you *what happened* (`CredentialIssued`,
+  `CredentialRevoked`, `AttestationRecorded`, etc.). Start here to confirm
+  the action you expect actually occurred on-chain.
+- `timestamp` — ledger close time (Unix seconds); compare against your
+  application's local timestamp for the same action to spot clock drift
+  or delayed propagation.
+- `credential_id` / `slice_id` — the handles you'll cross-reference
+  against your own system of record. A mismatch between "the ID my backend
+  has" and "the ID that emitted this event" is one of the most common root
+  causes of "verification says invalid" reports.
+- `reason` (on `CredentialRevoked` and dispute-related events) — the
+  human-readable justification supplied by the issuer or disputant; check
+  this before assuming a revocation was erroneous.
+
+To fetch events for a specific credential or time range, use the RPC
+`getEvents` call filtered by contract ID and ledger range, as shown in
+[Integration Patterns Guide §3 (Auditor Pattern)](integration-patterns-guide.md#3-auditor-pattern).
+
+### Application/service logs
+
+If you operate an issuer, verifier, or auditor backend:
+
+- Log the **transaction hash** on every submitted call — it's the only
+  reliable way to correlate an application-level failure with what
+  actually happened on-chain (or didn't).
+- Log the **raw RPC error body**, not just a summarized message —
+  `Error(Contract, #N)` is easy to grep for across a fleet of logs, and
+  losing the code during summarization is a common cause of "I don't know
+  which error this was" support tickets.
+- Distinguish **simulation failures** (rejected before submission — e.g.
+  bad footprint, insufficient resource fee) from **execution failures**
+  (submitted, included in a ledger, but the contract call itself panicked)
+  — they need different fixes. Simulation failures are usually
+  infrastructure/SDK issues; execution failures are usually the contract
+  error codes covered in §1.
+- If you run the on-chain snapshot/backup tooling from
+  [Backup System](backup-system.md), the scheduled GitHub Actions workflow
+  (`.github/workflows/backup.yml`) logs are the first place to check for a
+  missed or failed backup — `gh run list --workflow backup.yml`.
+
+---
+
+## 4. Where to Go Next
+
+- [Error Code Reference](error-codes.md) — authoritative per-code recovery
+- [Integration Patterns Guide](integration-patterns-guide.md) — patterns and retry logic for developers
+- [Audit Log Format](audit-log-format.md) — full event schema
+- [Threat Model](threat-model.md) — why a given risk is rated the way it is
+- [Backup System](backup-system.md) — recovering from data loss or corruption
+- [Monitoring Guide](monitoring-guide.md) — dashboards and alerts for ongoing operations
+
+If your issue isn't covered above and you believe it's a security
+vulnerability rather than an operational problem, follow the reporting
+process in [SECURITY.md](../SECURITY.md) instead of filing a public issue.


### PR DESCRIPTION
Title: Add integration patterns, issuer security checklist, troubleshooting guide, and on-chain backup/restore

Body:
## Summary

Closes four documentation/reliability gaps:

1. **Integration patterns guide** (`docs/integration-patterns-guide.md`) — documents the issuer, verifier, and auditor integration patterns with TypeScript/Python/Rust code examples, an error classification + exponential-backoff retry strategy, an idempotency pattern for `issue_credential` retries, and an integration-specific troubleshooting table.

2. **Issuer security checklist** (`docs/issuer-security-checklist.md`) — actionable, severity-tagged (Critical/High/Medium/Low) checklist covering key management, access control, and audit logging for issuing institutions, with recommendations mapped to each threat-model risk tier and links into `docs/threat-model.md`.

3. **Troubleshooting guide** (`docs/troubleshooting-guide.md`) — common errors/solutions table, a decision tree for routing a symptom to the right fix, and a logs-interpretation guide covering both on-chain event fields and application-level log fields to capture.

4. **Contract state backup/restore** (`contracts/quorum_proof/src/lib.rs`, `.github/workflows/backup.yml`, `docs/backup-system.md`) — `restore_from_snapshot` was previously a no-op stub; it now validates the snapshot's recorded hashes against its own counts (new `SnapshotCorrupted` error) before actually restoring the credential/slice/dispute counters, and records the restore for audit via a new `get_last_restored_snapshot` query. Added the `.github/workflows/backup.yml` daily-cron scheduler that `docs/backup-system.md` already described but never actually existed, plus tests for snapshot creation, successful restore, missing-snapshot restore, paused-contract restore, and corrupted-snapshot restore — none of which existed before.

Each concern is its own commit on this branch (4 commits total).

closes #1259 
closes #1260
closes #1261 
closes #1262