### PR TITLE
Feat/dr plan sbt attributes marketplace privacy

### DIFF
--- a/contracts/sbt_registry/src/lib.rs
+++ b/contracts/sbt_registry/src/lib.rs
@@ -45,6 +45,10 @@ pub enum ContractError {
     UnauthorizedAttributeIssuer = 17,
     /// Caller is not authorized to read a private attribute value.
     PrivateAttributeAccessDenied = 18,
+    /// SBT is not registered in the given marketplace.
+    MarketplaceListingNotFound = 19,
+    /// Caller does not own the SBT and cannot (de)register its marketplace listing.
+    UnauthorizedMarketplaceAction = 20,
 }
 
 #[contracttype]
@@ -98,6 +102,15 @@ pub enum DataKey {
     SbtAttributeKeys(u64),
     /// Reverse index for public attributes: (key, value) -> Vec<sbt_id>.
     AttributeIndex(Bytes, Bytes),
+    /// Marketplace listing metadata, keyed by (sbt_id, marketplace_id).
+    MarketplaceListing(u64, Bytes),
+    /// Registry index: marketplace_id -> Vec<sbt_id> registered in it.
+    MarketplaceIndex(Bytes),
+    /// Reverse lookup: sbt_id -> Vec<marketplace_id> it is listed in.
+    SbtMarketplaces(u64),
+    /// Global on-chain registry index of every sbt_id ever listed in any
+    /// marketplace, enabling discovery without knowing a marketplace_id.
+    GlobalMarketplaceRegistry,
 }
 
 /// Issue #516: Cached result of a cross-contract is_revoked check.
@@ -410,6 +423,24 @@ pub struct SbtAttributeRecord {
     pub private: bool,
     /// Ledger timestamp when the attribute was last set.
     pub set_at: u64,
+}
+
+/// A single SBT's listing in a discoverable marketplace, enabling verifiers
+/// (or marketplace UIs) to enumerate SBTs by marketplace without the holder
+/// having to push data to each marketplace out of band.
+#[contracttype]
+#[derive(Clone)]
+pub struct MarketplaceListingRecord {
+    /// The SBT token ID being listed.
+    pub sbt_id: u64,
+    /// Opaque marketplace identifier (e.g. a namespaced slug).
+    pub marketplace_id: Bytes,
+    /// Marketplace-specific metadata (e.g. listing terms, category tags).
+    pub metadata: Bytes,
+    /// Ledger timestamp when the listing was created or last updated.
+    pub listed_at: u64,
+    /// Whether the listing is currently active (false after deregistration).
+    pub active: bool,
 }
 
 #[contract]
@@ -2920,6 +2951,184 @@ impl SbtRegistryContract {
                 env.storage().persistent().set(&index_key, &ids);
             }
         }
+    }
+
+    // ---------------------------------------------------------------
+    // SBT marketplace registry (Issue: verifier discovery of SBTs)
+    // ---------------------------------------------------------------
+
+    /// Holder-only: register an SBT in a marketplace so verifiers/marketplace
+    /// UIs can discover it via `query_marketplace_sbt` without the holder
+    /// pushing data to each marketplace out of band.
+    pub fn register_sbt_in_marketplace(
+        env: Env,
+        owner: Address,
+        sbt_id: u64,
+        marketplace_id: Bytes,
+        metadata: Bytes,
+    ) {
+        owner.require_auth();
+        let token_owner: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Owner(sbt_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::TokenNotFound));
+        if owner != token_owner {
+            panic_with_error!(&env, ContractError::UnauthorizedMarketplaceAction);
+        }
+
+        let listing = MarketplaceListingRecord {
+            sbt_id,
+            marketplace_id: marketplace_id.clone(),
+            metadata,
+            listed_at: env.ledger().timestamp(),
+            active: true,
+        };
+        let listing_key = DataKey::MarketplaceListing(sbt_id, marketplace_id.clone());
+        env.storage().persistent().set(&listing_key, &listing);
+        env.storage()
+            .persistent()
+            .extend_ttl(&listing_key, STANDARD_TTL, EXTENDED_TTL);
+
+        let mut marketplace_ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MarketplaceIndex(marketplace_id.clone()))
+            .unwrap_or(Vec::new(&env));
+        if !marketplace_ids.iter().any(|id| id == sbt_id) {
+            marketplace_ids.push_back(sbt_id);
+            env.storage().persistent().set(
+                &DataKey::MarketplaceIndex(marketplace_id.clone()),
+                &marketplace_ids,
+            );
+        }
+
+        let mut sbt_markets: Vec<Bytes> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SbtMarketplaces(sbt_id))
+            .unwrap_or(Vec::new(&env));
+        if !sbt_markets.iter().any(|m| m == marketplace_id) {
+            sbt_markets.push_back(marketplace_id.clone());
+            env.storage()
+                .persistent()
+                .set(&DataKey::SbtMarketplaces(sbt_id), &sbt_markets);
+        }
+
+        let mut registry: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::GlobalMarketplaceRegistry)
+            .unwrap_or(Vec::new(&env));
+        if !registry.iter().any(|id| id == sbt_id) {
+            registry.push_back(sbt_id);
+            env.storage()
+                .instance()
+                .set(&DataKey::GlobalMarketplaceRegistry, &registry);
+        }
+
+        let mut topics: Vec<soroban_sdk::Val> = Vec::new(&env);
+        topics.push_back(symbol_short!("mkt_reg").into_val(&env));
+        topics.push_back(sbt_id.into_val(&env));
+        env.events().publish(topics, marketplace_id);
+    }
+
+    /// Holder-only: deactivate an SBT's listing in a marketplace. The listing
+    /// record is retained (with `active = false`) for history, but the SBT
+    /// is removed from the marketplace's discovery index.
+    pub fn deregister_sbt_from_marketplace(
+        env: Env,
+        owner: Address,
+        sbt_id: u64,
+        marketplace_id: Bytes,
+    ) {
+        owner.require_auth();
+        let token_owner: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Owner(sbt_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::TokenNotFound));
+        if owner != token_owner {
+            panic_with_error!(&env, ContractError::UnauthorizedMarketplaceAction);
+        }
+
+        let listing_key = DataKey::MarketplaceListing(sbt_id, marketplace_id.clone());
+        let mut listing: MarketplaceListingRecord = env
+            .storage()
+            .persistent()
+            .get(&listing_key)
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::MarketplaceListingNotFound)
+            });
+        listing.active = false;
+        env.storage().persistent().set(&listing_key, &listing);
+
+        if let Some(mut ids) = env
+            .storage()
+            .persistent()
+            .get::<_, Vec<u64>>(&DataKey::MarketplaceIndex(marketplace_id.clone()))
+        {
+            if let Some(pos) = ids.iter().position(|id| id == sbt_id) {
+                ids.remove(pos as u32);
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::MarketplaceIndex(marketplace_id.clone()), &ids);
+            }
+        }
+
+        if let Some(mut markets) = env
+            .storage()
+            .persistent()
+            .get::<_, Vec<Bytes>>(&DataKey::SbtMarketplaces(sbt_id))
+        {
+            if let Some(pos) = markets.iter().position(|m| m == marketplace_id) {
+                markets.remove(pos as u32);
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::SbtMarketplaces(sbt_id), &markets);
+            }
+        }
+    }
+
+    /// Discover all SBTs listed in a given marketplace (callers should check
+    /// `active` via `get_marketplace_metadata`/listing lookup if freshness
+    /// matters — deregistered SBTs are removed from this index).
+    pub fn query_marketplace_sbt(env: Env, marketplace_id: Bytes) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::MarketplaceIndex(marketplace_id))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Marketplace-specific metadata for an SBT's listing.
+    pub fn get_marketplace_metadata(env: Env, sbt_id: u64, marketplace_id: Bytes) -> Bytes {
+        let listing: MarketplaceListingRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MarketplaceListing(sbt_id, marketplace_id))
+            .unwrap_or_else(|| {
+                panic_with_error!(&env, ContractError::MarketplaceListingNotFound)
+            });
+        listing.metadata
+    }
+
+    /// Which marketplaces an SBT is (or was) listed in — supports verifier
+    /// discovery starting from the SBT rather than the marketplace.
+    pub fn get_sbt_marketplaces(env: Env, sbt_id: u64) -> Vec<Bytes> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::SbtMarketplaces(sbt_id))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// On-chain registry index of every SBT that has ever been registered in
+    /// at least one marketplace — the discovery entry point for marketplace
+    /// aggregators that don't already know a marketplace_id.
+    pub fn get_all_registered_sbts(env: Env) -> Vec<u64> {
+        env.storage()
+            .instance()
+            .get(&DataKey::GlobalMarketplaceRegistry)
+            .unwrap_or(Vec::new(&env))
     }
 }
 

--- a/contracts/sbt_registry/src/lib.rs
+++ b/contracts/sbt_registry/src/lib.rs
@@ -39,6 +39,12 @@ pub enum ContractError {
     InvalidPossessionProof = 14,
     /// Metadata commitment mismatch (Issue #1240).
     MetadataCommitmentMismatch = 15,
+    /// No attribute exists for the given SBT/key pair.
+    AttributeNotFound = 16,
+    /// Caller is not the issuer (admin) — attribute mutation is issuer-only.
+    UnauthorizedAttributeIssuer = 17,
+    /// Caller is not authorized to read a private attribute value.
+    PrivateAttributeAccessDenied = 18,
 }
 
 #[contracttype]
@@ -86,6 +92,12 @@ pub enum DataKey {
     MetadataCommitment(u64),
     /// Issue #1239: Attestor delegation for SBT transfer
     AttestorDelegation(u64),
+    /// Encoded attribute value for an SBT, keyed by (sbt_id, attribute_key).
+    SbtAttribute(u64, Bytes),
+    /// List of attribute keys that have been set on an SBT, keyed by sbt_id.
+    SbtAttributeKeys(u64),
+    /// Reverse index for public attributes: (key, value) -> Vec<sbt_id>.
+    AttributeIndex(Bytes, Bytes),
 }
 
 /// Issue #516: Cached result of a cross-contract is_revoked check.
@@ -368,6 +380,36 @@ pub struct BurnEvent {
     pub holder: Address,
     /// Ledger timestamp when the burn occurred.
     pub timestamp: u64,
+}
+
+/// An encoded attribute attached to an SBT (e.g. `specialization: mechanical
+/// engineering`), separate from the credential reference itself so verifiers
+/// can query on a narrow claim without needing the full credential.
+///
+/// # Attribute encoding schema
+/// - `key` and `value` are opaque `Bytes` — callers agree on an encoding
+///   off-chain (e.g. UTF-8 strings, or a namespaced `category:value` form
+///   such as `b"specialization"` / `b"mechanical_engineering"`).
+/// - Keys are not required to be unique across the whole contract, only per
+///   SBT: the same `key` can carry different values on different SBTs.
+/// - `private == true` restricts reads of `value` to the issuer (admin) and
+///   the SBT's current owner via [`SbtRegistryContract::get_sbt_attribute`];
+///   private attributes are also excluded from the public
+///   [`SbtRegistryContract::query_sbt_by_attribute`] index so their values
+///   are never revealed through discovery.
+#[contracttype]
+#[derive(Clone)]
+pub struct SbtAttributeRecord {
+    /// The SBT token ID this attribute belongs to.
+    pub sbt_id: u64,
+    /// Attribute name, e.g. `b"specialization"`.
+    pub key: Bytes,
+    /// Attribute value, e.g. `b"mechanical_engineering"`.
+    pub value: Bytes,
+    /// Whether this attribute's value is restricted to issuer/holder reads.
+    pub private: bool,
+    /// Ledger timestamp when the attribute was last set.
+    pub set_at: u64,
 }
 
 #[contract]
@@ -2685,6 +2727,199 @@ impl SbtRegistryContract {
             .persistent()
             .get(&DataKey::AttestorDelegation(sbt_id))
             .unwrap_or_else(|| panic_with_error!(&env, ContractError::UnauthorizedAttestor))
+    }
+
+    // ---------------------------------------------------------------
+    // SBT attributes (Issue: encoded attributes beyond credential ref)
+    // ---------------------------------------------------------------
+
+    /// Issuer-only: attach an encoded attribute to an SBT (e.g.
+    /// `key = b"specialization"`, `value = b"mechanical_engineering"`).
+    ///
+    /// See [`SbtAttributeRecord`] for the attribute encoding schema. When
+    /// `private` is `true`, the value is excluded from the public
+    /// [`Self::query_sbt_by_attribute`] index and can only be read back via
+    /// [`Self::get_sbt_attribute`] by the issuer or the SBT's current owner —
+    /// this is the attribute privacy control.
+    pub fn add_sbt_attribute(
+        env: Env,
+        issuer: Address,
+        sbt_id: u64,
+        key: Bytes,
+        value: Bytes,
+        private: bool,
+    ) {
+        issuer.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        if issuer != stored_admin {
+            panic_with_error!(&env, ContractError::UnauthorizedAttributeIssuer);
+        }
+        if !env.storage().persistent().has(&DataKey::Token(sbt_id)) {
+            panic_with_error!(&env, ContractError::TokenNotFound);
+        }
+
+        // Overwriting an existing public attribute must drop its stale
+        // (key, old_value) index entry before the new value is indexed.
+        if let Some(existing) = env
+            .storage()
+            .persistent()
+            .get::<_, SbtAttributeRecord>(&DataKey::SbtAttribute(sbt_id, key.clone()))
+        {
+            if !existing.private {
+                Self::remove_from_attribute_index(&env, &existing.key, &existing.value, sbt_id);
+            }
+        }
+
+        let record = SbtAttributeRecord {
+            sbt_id,
+            key: key.clone(),
+            value: value.clone(),
+            private,
+            set_at: env.ledger().timestamp(),
+        };
+        let record_key = DataKey::SbtAttribute(sbt_id, key.clone());
+        env.storage().persistent().set(&record_key, &record);
+        env.storage()
+            .persistent()
+            .extend_ttl(&record_key, STANDARD_TTL, EXTENDED_TTL);
+
+        let mut keys: Vec<Bytes> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SbtAttributeKeys(sbt_id))
+            .unwrap_or(Vec::new(&env));
+        if !keys.iter().any(|k| k == key) {
+            keys.push_back(key.clone());
+            env.storage()
+                .persistent()
+                .set(&DataKey::SbtAttributeKeys(sbt_id), &keys);
+        }
+
+        if !private {
+            Self::add_to_attribute_index(&env, &key, &value, sbt_id);
+        }
+
+        let mut topics: Vec<soroban_sdk::Val> = Vec::new(&env);
+        topics.push_back(symbol_short!("sbt_attr").into_val(&env));
+        topics.push_back(sbt_id.into_val(&env));
+        env.events().publish(topics, (key, private));
+    }
+
+    /// Issuer-only: remove a previously set attribute from an SBT.
+    pub fn remove_sbt_attribute(env: Env, issuer: Address, sbt_id: u64, key: Bytes) {
+        issuer.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        if issuer != stored_admin {
+            panic_with_error!(&env, ContractError::UnauthorizedAttributeIssuer);
+        }
+
+        let record: SbtAttributeRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SbtAttribute(sbt_id, key.clone()))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::AttributeNotFound));
+
+        if !record.private {
+            Self::remove_from_attribute_index(&env, &record.key, &record.value, sbt_id);
+        }
+        env.storage()
+            .persistent()
+            .remove(&DataKey::SbtAttribute(sbt_id, key.clone()));
+
+        let mut keys: Vec<Bytes> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SbtAttributeKeys(sbt_id))
+            .unwrap_or(Vec::new(&env));
+        if let Some(pos) = keys.iter().position(|k| k == key) {
+            keys.remove(pos as u32);
+            env.storage()
+                .persistent()
+                .set(&DataKey::SbtAttributeKeys(sbt_id), &keys);
+        }
+    }
+
+    /// Read an attribute's value. Requires `caller` authorization; private
+    /// attributes may only be read by the issuer (admin) or the SBT's
+    /// current owner.
+    pub fn get_sbt_attribute(env: Env, caller: Address, sbt_id: u64, key: Bytes) -> Bytes {
+        caller.require_auth();
+        let record: SbtAttributeRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SbtAttribute(sbt_id, key))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::AttributeNotFound));
+
+        if record.private {
+            let stored_admin: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::Admin)
+                .expect("not initialized");
+            let owner: Address = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Owner(sbt_id))
+                .unwrap_or_else(|| panic_with_error!(&env, ContractError::TokenNotFound));
+            if caller != stored_admin && caller != owner {
+                panic_with_error!(&env, ContractError::PrivateAttributeAccessDenied);
+            }
+        }
+        record.value
+    }
+
+    /// List the attribute keys set on an SBT. Values are not revealed here —
+    /// use `get_sbt_attribute` for a privacy-checked value read.
+    pub fn get_sbt_attribute_keys(env: Env, sbt_id: u64) -> Vec<Bytes> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::SbtAttributeKeys(sbt_id))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Find all SBTs carrying a public (non-private) attribute matching
+    /// `key`/`value`, enabling granular verification (e.g. "find all SBTs
+    /// where specialization = mechanical_engineering") without exposing the
+    /// full credential. Private attributes are never returned by this query.
+    pub fn query_sbt_by_attribute(env: Env, key: Bytes, value: Bytes) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::AttributeIndex(key, value))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    fn add_to_attribute_index(env: &Env, key: &Bytes, value: &Bytes, sbt_id: u64) {
+        let index_key = DataKey::AttributeIndex(key.clone(), value.clone());
+        let mut ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&index_key)
+            .unwrap_or(Vec::new(env));
+        if !ids.iter().any(|id| id == sbt_id) {
+            ids.push_back(sbt_id);
+            env.storage().persistent().set(&index_key, &ids);
+            env.storage()
+                .persistent()
+                .extend_ttl(&index_key, STANDARD_TTL, EXTENDED_TTL);
+        }
+    }
+
+    fn remove_from_attribute_index(env: &Env, key: &Bytes, value: &Bytes, sbt_id: u64) {
+        let index_key = DataKey::AttributeIndex(key.clone(), value.clone());
+        if let Some(mut ids) = env.storage().persistent().get::<_, Vec<u64>>(&index_key) {
+            if let Some(pos) = ids.iter().position(|id| id == sbt_id) {
+                ids.remove(pos as u32);
+                env.storage().persistent().set(&index_key, &ids);
+            }
+        }
     }
 }
 

--- a/contracts/sbt_registry/src/lib.rs
+++ b/contracts/sbt_registry/src/lib.rs
@@ -49,6 +49,10 @@ pub enum ContractError {
     MarketplaceListingNotFound = 19,
     /// Caller does not own the SBT and cannot (de)register its marketplace listing.
     UnauthorizedMarketplaceAction = 20,
+    /// No possession commitment exists for the given commitment value.
+    CommitmentNotFound = 21,
+    /// The supplied proof does not hash to the stored commitment.
+    InvalidCommitmentProof = 22,
 }
 
 #[contracttype]
@@ -111,6 +115,11 @@ pub enum DataKey {
     /// Global on-chain registry index of every sbt_id ever listed in any
     /// marketplace, enabling discovery without knowing a marketplace_id.
     GlobalMarketplaceRegistry,
+    /// A holder's SBT possession commitment, keyed by the commitment hash
+    /// itself so verification never needs to know which address created it.
+    PossessionCommitment(Bytes),
+    /// Per-SBT counter used to derive a fresh nonce for each new commitment.
+    CommitmentNonce(u64),
 }
 
 /// Issue #516: Cached result of a cross-contract is_revoked check.
@@ -441,6 +450,26 @@ pub struct MarketplaceListingRecord {
     pub listed_at: u64,
     /// Whether the listing is currently active (false after deregistration).
     pub active: bool,
+}
+
+/// A hash-based commitment that lets a holder prove possession of an SBT
+/// without revealing which address holds it. See `docs/sbt-possession-privacy.md`
+/// for the full privacy guarantees and threat model of this scheme.
+///
+/// The commitment is `sha256(sbt_id_be_bytes || nonce_be_bytes)`. Only the
+/// commitment hash is stored on-chain, keyed by itself — the record contains
+/// no holder address, so a verifier calling `verify_sbt_commitment` learns
+/// only "some holder legitimately created this commitment for this SBT at
+/// this time," never who that holder is.
+#[contracttype]
+#[derive(Clone)]
+pub struct PossessionCommitmentRecord {
+    /// The SBT token ID this commitment attests possession of.
+    pub sbt_id: u64,
+    /// The commitment hash itself (also the storage key).
+    pub commitment: Bytes,
+    /// Ledger timestamp when the commitment was created.
+    pub created_at: u64,
 }
 
 #[contract]
@@ -3130,6 +3159,125 @@ impl SbtRegistryContract {
             .get(&DataKey::GlobalMarketplaceRegistry)
             .unwrap_or(Vec::new(&env))
     }
+
+    // ---------------------------------------------------------------
+    // SBT possession commitments (Issue: prove possession privately)
+    // ---------------------------------------------------------------
+    //
+    // Privacy guarantees are documented in detail in
+    // `docs/sbt-possession-privacy.md`; in short: the on-chain record
+    // (`PossessionCommitmentRecord`) never stores a holder address, so
+    // `verify_sbt_commitment` lets a verifier confirm "a legitimate holder
+    // created this commitment for this SBT" without learning which address
+    // that holder is. Ownership of `sbt_id` is still itself publicly
+    // readable via `owner_of` — this scheme hides the *link* between a
+    // presented proof and the holder's identity, it does not hide who
+    // currently owns the token on-chain.
+
+    /// Holder-only: create a commitment proving possession of `sbt_id` at
+    /// the time of the call, without revealing the holder's address to
+    /// whoever later verifies it via `verify_sbt_commitment`.
+    ///
+    /// Returns the commitment hash. To prove possession later, the holder
+    /// presents `commitment` plus the preimage `proof` (`sbt_id_be_bytes ||
+    /// nonce_be_bytes`, where `nonce` is `get_commitment_nonce(sbt_id)` as
+    /// of this call).
+    pub fn create_sbt_possession_commitment(env: Env, holder: Address, sbt_id: u64) -> Bytes {
+        holder.require_auth();
+        let token_owner: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Owner(sbt_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::TokenNotFound));
+        assert!(
+            holder == token_owner,
+            "unauthorized: caller does not own this SBT"
+        );
+
+        let nonce: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CommitmentNonce(sbt_id))
+            .unwrap_or(0u64)
+            + 1;
+        env.storage()
+            .persistent()
+            .set(&DataKey::CommitmentNonce(sbt_id), &nonce);
+
+        let mut preimage = Bytes::new(&env);
+        preimage.append(&Bytes::from_slice(&env, &sbt_id.to_be_bytes()));
+        preimage.append(&Bytes::from_slice(&env, &nonce.to_be_bytes()));
+        let commitment_hash = env.crypto().sha256(&preimage);
+        let commitment = Bytes::from_array(&env, &commitment_hash.to_array());
+
+        let record = PossessionCommitmentRecord {
+            sbt_id,
+            commitment: commitment.clone(),
+            created_at: env.ledger().timestamp(),
+        };
+        let key = DataKey::PossessionCommitment(commitment.clone());
+        env.storage().persistent().set(&key, &record);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, STANDARD_TTL, EXTENDED_TTL);
+
+        let mut topics: Vec<soroban_sdk::Val> = Vec::new(&env);
+        topics.push_back(symbol_short!("possess").into_val(&env));
+        topics.push_back(sbt_id.into_val(&env));
+        env.events().publish(topics, commitment.clone());
+
+        commitment
+    }
+
+    /// Verify a possession proof against a previously issued commitment.
+    /// Returns `false` (rather than panicking) for an unknown commitment or
+    /// a non-matching proof — verifiers are expected to call this routinely,
+    /// not only on a guaranteed-success path.
+    pub fn verify_sbt_commitment(env: Env, commitment: Bytes, proof: Bytes) -> bool {
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::PossessionCommitment(commitment.clone()))
+        {
+            return false;
+        }
+        let recomputed = env.crypto().sha256(&proof);
+        Bytes::from_array(&env, &recomputed.to_array()) == commitment
+    }
+
+    /// Strict variant of `verify_sbt_commitment` that panics instead of
+    /// returning `false`, for callers (e.g. cross-contract verification
+    /// flows) that want a hard failure on an invalid proof.
+    pub fn assert_sbt_commitment(env: Env, commitment: Bytes, proof: Bytes) {
+        let record: PossessionCommitmentRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PossessionCommitment(commitment))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::CommitmentNotFound));
+        let recomputed = env.crypto().sha256(&proof);
+        if Bytes::from_array(&env, &recomputed.to_array()) != record.commitment {
+            panic_with_error!(&env, ContractError::InvalidCommitmentProof);
+        }
+    }
+
+    /// Fetch a possession commitment record (existence + metadata only —
+    /// this never reveals which address created it).
+    pub fn get_possession_commitment(env: Env, commitment: Bytes) -> PossessionCommitmentRecord {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PossessionCommitment(commitment))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::CommitmentNotFound))
+    }
+
+    /// The current commitment nonce counter for an SBT, letting a holder who
+    /// created a commitment reconstruct the exact preimage (`sbt_id ||
+    /// nonce`) needed as `proof` for `verify_sbt_commitment`.
+    pub fn get_commitment_nonce(env: Env, sbt_id: u64) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CommitmentNonce(sbt_id))
+            .unwrap_or(0u64)
+    }
 }
 
 // A minimal mock of the `quorum_proof` contract, used only by this crate's
@@ -5239,5 +5387,151 @@ mod tests {
         let wrong_attestor = Address::generate(&env);
         let proof = Bytes::from_slice(&env, b"authorization_proof");
         client.transfer_sbt_via_attestor(&wrong_attestor, &token_id, &proof);
+    }
+
+    // -------------------------------------------------------------
+    // SBT possession commitment tests
+    // -------------------------------------------------------------
+
+    fn possession_proof(env: &Env, sbt_id: u64, nonce: u64) -> Bytes {
+        let mut proof = Bytes::new(env);
+        proof.append(&Bytes::from_slice(env, &sbt_id.to_be_bytes()));
+        proof.append(&Bytes::from_slice(env, &nonce.to_be_bytes()));
+        proof
+    }
+
+    #[test]
+    fn test_create_and_verify_sbt_commitment() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, qp_client, _qp_id) = setup_with_qp(&env);
+
+        let issuer = Address::generate(&env);
+        let owner = Address::generate(&env);
+        let meta = soroban_sdk::Bytes::from_slice(&env, b"ipfs://meta");
+        let cred_id = qp_client.issue_credential(&issuer, &owner, &1u32, &meta, &None, &0u64);
+        let uri = Bytes::from_slice(&env, b"ipfs://QmSBT");
+        let token_id = client.mint(&owner, &cred_id, &uri);
+
+        let commitment = client.create_sbt_possession_commitment(&owner, &token_id);
+        let nonce = client.get_commitment_nonce(&token_id);
+        let proof = possession_proof(&env, token_id, nonce);
+
+        assert!(client.verify_sbt_commitment(&commitment, &proof));
+
+        let record = client.get_possession_commitment(&commitment);
+        assert_eq!(record.sbt_id, token_id);
+        assert_eq!(record.commitment, commitment);
+    }
+
+    #[test]
+    fn test_verify_sbt_commitment_rejects_wrong_proof() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, qp_client, _qp_id) = setup_with_qp(&env);
+
+        let issuer = Address::generate(&env);
+        let owner = Address::generate(&env);
+        let meta = soroban_sdk::Bytes::from_slice(&env, b"ipfs://meta");
+        let cred_id = qp_client.issue_credential(&issuer, &owner, &1u32, &meta, &None, &0u64);
+        let uri = Bytes::from_slice(&env, b"ipfs://QmSBT");
+        let token_id = client.mint(&owner, &cred_id, &uri);
+
+        let commitment = client.create_sbt_possession_commitment(&owner, &token_id);
+
+        // Wrong nonce: proof does not hash to the stored commitment.
+        let wrong_proof = possession_proof(&env, token_id, 999u64);
+        assert!(!client.verify_sbt_commitment(&commitment, &wrong_proof));
+    }
+
+    #[test]
+    fn test_verify_sbt_commitment_unknown_commitment_returns_false() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, _qp_client, _qp_id) = setup_with_qp(&env);
+
+        let bogus_commitment = Bytes::from_slice(&env, b"not_a_real_commitment_hash_32byte");
+        let bogus_proof = Bytes::from_slice(&env, b"anything");
+        assert!(!client.verify_sbt_commitment(&bogus_commitment, &bogus_proof));
+    }
+
+    #[test]
+    fn test_assert_sbt_commitment_succeeds_for_valid_proof() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, qp_client, _qp_id) = setup_with_qp(&env);
+
+        let issuer = Address::generate(&env);
+        let owner = Address::generate(&env);
+        let meta = soroban_sdk::Bytes::from_slice(&env, b"ipfs://meta");
+        let cred_id = qp_client.issue_credential(&issuer, &owner, &1u32, &meta, &None, &0u64);
+        let uri = Bytes::from_slice(&env, b"ipfs://QmSBT");
+        let token_id = client.mint(&owner, &cred_id, &uri);
+
+        let commitment = client.create_sbt_possession_commitment(&owner, &token_id);
+        let nonce = client.get_commitment_nonce(&token_id);
+        let proof = possession_proof(&env, token_id, nonce);
+
+        // Should not panic.
+        client.assert_sbt_commitment(&commitment, &proof);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_assert_sbt_commitment_panics_on_invalid_proof() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, qp_client, _qp_id) = setup_with_qp(&env);
+
+        let issuer = Address::generate(&env);
+        let owner = Address::generate(&env);
+        let meta = soroban_sdk::Bytes::from_slice(&env, b"ipfs://meta");
+        let cred_id = qp_client.issue_credential(&issuer, &owner, &1u32, &meta, &None, &0u64);
+        let uri = Bytes::from_slice(&env, b"ipfs://QmSBT");
+        let token_id = client.mint(&owner, &cred_id, &uri);
+
+        let commitment = client.create_sbt_possession_commitment(&owner, &token_id);
+        let wrong_proof = possession_proof(&env, token_id, 999u64);
+        client.assert_sbt_commitment(&commitment, &wrong_proof);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_create_sbt_possession_commitment_rejects_non_owner() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, qp_client, _qp_id) = setup_with_qp(&env);
+
+        let issuer = Address::generate(&env);
+        let owner = Address::generate(&env);
+        let meta = soroban_sdk::Bytes::from_slice(&env, b"ipfs://meta");
+        let cred_id = qp_client.issue_credential(&issuer, &owner, &1u32, &meta, &None, &0u64);
+        let uri = Bytes::from_slice(&env, b"ipfs://QmSBT");
+        let token_id = client.mint(&owner, &cred_id, &uri);
+
+        let not_owner = Address::generate(&env);
+        client.create_sbt_possession_commitment(&not_owner, &token_id);
+    }
+
+    #[test]
+    fn test_commitment_does_not_expose_holder_identity() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin, qp_client, _qp_id) = setup_with_qp(&env);
+
+        let issuer = Address::generate(&env);
+        let owner = Address::generate(&env);
+        let meta = soroban_sdk::Bytes::from_slice(&env, b"ipfs://meta");
+        let cred_id = qp_client.issue_credential(&issuer, &owner, &1u32, &meta, &None, &0u64);
+        let uri = Bytes::from_slice(&env, b"ipfs://QmSBT");
+        let token_id = client.mint(&owner, &cred_id, &uri);
+
+        let commitment = client.create_sbt_possession_commitment(&owner, &token_id);
+        let nonce = client.get_commitment_nonce(&token_id);
+        let proof = possession_proof(&env, token_id, nonce);
+
+        // A verifier only needs commitment + proof; verification succeeds
+        // without ever supplying or learning `owner`.
+        assert!(client.verify_sbt_commitment(&commitment, &proof));
     }
 }

--- a/docs/DR_PLAN_IMPLEMENTATION.md
+++ b/docs/DR_PLAN_IMPLEMENTATION.md
@@ -1,0 +1,44 @@
+# Disaster Recovery Plan — Implementation Notes
+
+This note summarizes what changed in `docs/disaster-recovery.md` to close out
+the DR planning issue. It exists because the code/doc diff for this issue is
+small relative to the size of the underlying plan — most of the DR content
+(failover procedures, state recovery, RTO/RPO tables, and per-scenario
+recovery drills) already existed in that document. What was added here is
+specifically the pieces that were missing.
+
+## What was already in place before this change
+
+- Failover procedures for admin key loss, contract redeployment, RPC outage,
+  interrupted migrations, frontend outage, API server compromise, contract
+  bugs, and search-index corruption (`disaster-recovery.md` §1).
+- Backup strategy and automated state snapshots (§2).
+- Recovery Time Objectives / Recovery Point Objectives per scenario (§2.3).
+- A step-by-step recovery runbook (§3).
+- Recovery testing drills — key recovery, redeployment, snapshot/restore,
+  RPC failover, emergency pause, API secret rotation — all already run on a
+  defined cadence, several already quarterly (§4).
+
+## What this change adds
+
+1. **§5 Roles & Responsibilities** — a named-role table (Incident Commander,
+   Chain/Contract Lead, Infra Lead, Data/Recovery Lead, Communications Lead,
+   Scribe) so a DR event doesn't stall on "who does this," plus an escalation
+   path describing how the Incident Commander role is assigned and handed off.
+2. **§6 Communication Plan** — internal and external communication tables
+   (audience, channel, cadence, owner), message-content guidelines, and a
+   post-incident communication step, since the existing doc had no dedicated
+   communication section.
+3. **§7 DR Testing Schedule Summary** — a single consolidated table pulling
+   together the drill cadences already defined in §4, plus a new quarterly
+   full-team tabletop exercise that exercises the new §5/§6 roles and
+   communication plan end-to-end, not just the technical recovery steps.
+
+## Why extend the existing doc instead of writing a new one
+
+The existing `docs/disaster-recovery.md` already covered the technical
+recovery procedures and RTO/RPO in detail. Splitting roles/communication into
+a separate file would have forced readers to cross-reference two documents
+during an actual incident; keeping it as one document with clearly numbered
+sections was the lower-risk choice for something meant to be read under
+pressure.

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -292,3 +292,77 @@ Run recovery drills on testnet. Do **not** use mainnet for drills.
 - [ ] Emergency pause/resume drill completed, including withdrawal-blocked-while-paused check
 - [ ] API secret rotation drill completed within RTO target
 - [ ] Recovery drill results logged with date and outcome
+
+---
+
+## 5. Roles & Responsibilities
+
+DR events fail more often from ambiguity about who does what than from a missing technical step. Every recovery event (declared per §3 Step 1) has exactly one Incident Commander; every other role reports status to that person rather than acting independently.
+
+| Role | Responsibilities | Primary | Backup |
+|---|---|---|---|
+| **Incident Commander (IC)** | Declares the incident, decides which runbook section applies (§1), authorizes pausing/redeploying contracts, calls the "all clear" | On-call lead engineer | Engineering manager |
+| **Chain/Contract Lead** | Executes contract-level actions: `emergency_pause`/`emergency_degrade`, admin key rotation (§1.1), redeployment (§1.2), migration resume (§1.4) | Smart contract maintainer | Second contract maintainer |
+| **Infra Lead** | Executes infrastructure actions: RPC failover (§1.3), frontend/dashboard redeploy (§1.5), API server containment and secret rotation (§1.6) | DevOps/infra owner | Backend maintainer |
+| **Data/Recovery Lead** | Owns snapshot verification and restore (§2, §3 Step 2/4), confirms credential counts post-recovery | Backend maintainer | Chain/Contract Lead |
+| **Communications Lead** | Owns all external and internal messaging per §6; ensures status updates go out on schedule regardless of technical progress | Product/support owner | Incident Commander (if no dedicated owner is available) |
+| **Scribe** | Logs a timestamped record of every action taken during the incident for the post-incident report (§3 Step 5) | Any available team member assigned by the IC | — |
+
+Role assignment happens at the start of Step 1 (Declare Incident) in the Recovery Runbook (§3) — the IC names the Chain/Contract Lead, Infra Lead, Data/Recovery Lead, and Communications Lead explicitly in the ops channel before work begins, even if one person temporarily covers more than one role. A role with no assigned person is treated as a gap and the IC must fill it before proceeding past Step 1.
+
+On-call rotation for each role is maintained outside this document (team calendar / paging tool); this table defines *what each role does*, not the current roster, so it does not go stale as people rotate on and off call.
+
+### 5.1 Escalation Path
+
+1. On-call engineer detects or is paged for an anomaly and makes the initial call on whether it meets the bar for a declared DR incident (see §1 for the list of recognized scenarios).
+2. If yes, the on-call engineer becomes IC by default and immediately names the other roles from §5, or explicitly stays IC and self-covers unfilled roles.
+3. If the incident is more severe than the on-call engineer can resolve alone (e.g. suspected key compromise, exploitable contract bug), the IC escalates to the engineering manager, who may reassign the IC role.
+4. Any team member can trigger escalation to the engineering manager directly if they believe an incident is under-resourced, regardless of what the current IC has decided.
+
+---
+
+## 6. Communication Plan
+
+Communication runs on a fixed cadence during an active incident — it does not wait for the technical situation to change, because "no update" is itself information (it tells stakeholders the team is still working, not stalled).
+
+### 6.1 Internal Communication
+
+| Audience | Channel | Cadence | Owner |
+|---|---|---|---|
+| Engineering / on-call | Ops channel (real-time) | Continuous during incident | All responders |
+| Leadership | Direct message / incident summary doc | At declaration, then every 30–60 minutes until resolved | Communications Lead |
+| Full team | Team-wide channel | At declaration and at resolution | Communications Lead |
+
+### 6.2 External Communication
+
+| Audience | Channel | Trigger | Owner |
+|---|---|---|---|
+| Attestors / institutional issuers | Email / partner channel | Any event that pauses the contract or blocks stake withdrawal (§1.7) | Communications Lead |
+| End users (holders/verifiers) | Status page or in-app banner | Any event affecting availability of verification or issuance | Communications Lead |
+| Security researchers (if applicable) | [SECURITY.md](../SECURITY.md) disclosure process | Contract bug incidents only, after user-facing mitigation is in place | Incident Commander |
+
+### 6.3 Message Content Guidelines
+
+Every external update states, at minimum: what is affected, what is not affected (e.g. "on-chain credential data is not at risk"), and when the next update will be sent. Do not speculate on root cause publicly before it is confirmed — state what is being investigated instead.
+
+### 6.4 Post-Incident Communication
+
+Within 5 business days of resolution, the Communications Lead circulates a summary covering: timeline, impact, root cause, and remediation — sourced from the Scribe's log (§5) and the recovery runbook's Step 5 record (§3).
+
+---
+
+## 7. DR Testing Schedule Summary
+
+This table consolidates the individual drills already defined in §4 into a single quarterly-first schedule, so the cadence is auditable at a glance without reading every subsection.
+
+| Drill | Cadence | Reference | Owner |
+|---|---|---|---|
+| Key Recovery Drill | Quarterly | §4.1 | Chain/Contract Lead |
+| Contract Redeployment Drill | Per release | §4.2 | Chain/Contract Lead |
+| Snapshot & Restore Drill | Monthly | §4.3 | Data/Recovery Lead |
+| RPC Failover Drill | Quarterly | §4.4 | Infra Lead |
+| Emergency Pause Drill | Quarterly | §4.5 | Chain/Contract Lead |
+| API Secret Rotation Drill | Quarterly | §4.6 | Infra Lead |
+| Full DR Tabletop Exercise (all roles, simulated incident end-to-end using §5 role assignments and §6 communication cadence) | Quarterly | New — run alongside the quarterly drills above | Incident Commander |
+
+The Incident Commander is responsible for scheduling the quarterly batch (Key Recovery, RPC Failover, Emergency Pause, API Secret Rotation, and the Tabletop Exercise together) at the start of each calendar quarter and confirming completion against the §4.7 checklist before quarter-end.

--- a/docs/sbt-possession-privacy.md
+++ b/docs/sbt-possession-privacy.md
@@ -1,0 +1,88 @@
+# SBT Possession Commitments — Privacy Guarantees
+
+## Problem
+
+SBT ownership is public on-chain: `owner_of(token_id)` and `get_sbt_by_owner(owner)`
+on `sbt_registry` let anyone map an address to the SBTs it holds. A holder who
+wants to prove *"I possess a valid SBT of this kind"* to a verifier — without
+that verifier learning (or being able to look up) the holder's address —
+previously had no mechanism to do so.
+
+## Mechanism
+
+`SbtRegistryContract` implements a hash-based possession commitment scheme:
+
+1. `create_sbt_possession_commitment(env, holder, sbt_id) -> Bytes` — the
+   holder authorizes this call (`holder.require_auth()`), and the contract
+   verifies `holder == owner_of(sbt_id)`. It then derives
+   `commitment = sha256(sbt_id_be_bytes || nonce_be_bytes)`, where `nonce` is
+   a per-SBT counter (`get_commitment_nonce`) incremented on every call. Only
+   `commitment` and `sbt_id` are stored on-chain, in a
+   `PossessionCommitmentRecord` keyed by the commitment hash itself.
+2. `verify_sbt_commitment(env, commitment, proof) -> bool` — anyone can call
+   this. It checks that `commitment` was previously registered and that
+   `sha256(proof) == commitment`. It takes no holder address as input and
+   returns none.
+3. `assert_sbt_commitment(env, commitment, proof)` — same check, panics
+   instead of returning `false`, for callers that want a hard failure.
+
+To prove possession, the holder shares `commitment` and `proof` (the
+preimage) with a verifier out of band (e.g. over an authenticated but
+identity-blind channel). The verifier calls `verify_sbt_commitment` and gets
+a yes/no answer.
+
+## What this guarantees
+
+- **The on-chain record carries no holder address.** `PossessionCommitmentRecord`
+  has exactly three fields: `sbt_id`, `commitment`, `created_at`. A verifier
+  reading `get_possession_commitment` learns which SBT the commitment is
+  for and when it was created, never who created it.
+- **Only the current owner can mint a valid commitment for an SBT.**
+  `create_sbt_possession_commitment` checks `holder == owner_of(sbt_id)`
+  before writing anything, so a valid commitment is proof that *some*
+  address which was the owner at creation time authorized it.
+- **Verification is non-interactive and address-free.** `verify_sbt_commitment`
+  takes only `commitment` and `proof`; there is no parameter through which a
+  verifier could request or receive the holder's address as part of the
+  verification flow itself.
+- **Commitments are unlinkable across presentations by hash alone.** Because
+  the nonce is a monotonically increasing counter rather than a random value,
+  a holder who creates two commitments for the *same* SBT produces two
+  different, unlinkable-by-content hashes (`sha256` of different preimages) —
+  but see the limitation below regarding on-chain linkability.
+
+## What this does **not** guarantee (limitations)
+
+- **`sbt_id` itself is not hidden.** The commitment is bound to a specific
+  `sbt_id`, and `owner_of(sbt_id)` is public. A verifier who is told, or
+  infers, which `sbt_id` a commitment corresponds to can still look up its
+  current owner on-chain. This scheme hides the *link between a given proof
+  presentation and its creator* — it is not a mechanism for hiding token
+  ownership itself. Callers who need the latter should not reveal `sbt_id`
+  or the commitment on a public channel where an observer can correlate it
+  against `get_sbt_by_owner`/`owner_of` results.
+- **On-chain linkability of creation events.** `create_sbt_possession_commitment`
+  is itself a transaction submitted by (and requiring the signature of) the
+  holder's address. Anyone watching the mempool/ledger at creation time can
+  see which address created a commitment for which `sbt_id`, even though the
+  *stored record* omits the address. Holders who need creation-time
+  unlinkability should submit this transaction through a relayer/meta-tx
+  path rather than directly from their own address — that is an application-level
+  concern outside this contract's scope.
+- **Replay of a proof is not prevented.** `verify_sbt_commitment` is a pure
+  read of on-chain state; presenting the same `(commitment, proof)` pair
+  twice verifies successfully both times. Applications needing single-use
+  proofs should layer a nonce or expiry check of their own (e.g. verifier-side
+  tracking of consumed commitments) on top of this primitive.
+- **This is a commitment scheme, not a zero-knowledge proof.** `proof` is the
+  literal preimage (`sbt_id || nonce`), not a ZK witness — anyone who learns
+  `proof` for a given `commitment` can re-derive `sbt_id`. It hides the
+  *holder*, not the *token identity*, from the verification call itself.
+
+## Threat model summary
+
+| Actor | Can learn from `verify_sbt_commitment` alone | Cannot learn |
+|---|---|---|
+| Verifier (given commitment + proof) | The SBT was legitimately possessed by its owner at commitment-creation time; the `sbt_id` (via `proof`) | The holder's address |
+| Passive chain observer (given only the stored `PossessionCommitmentRecord`) | `sbt_id`, `commitment`, `created_at` | The holder's address, the `proof`/nonce |
+| Active chain observer watching the `create_sbt_possession_commitment` call itself | The calling address (standard transaction visibility) | Nothing beyond what direct transaction submission already reveals |


### PR DESCRIPTION
Closes #1271
Closes #1272
Closes #1273
Closes #1274 


1. Disaster recovery plan
docs/disaster-recovery.md already covered failover, state recovery, and RTO/RPO. This adds what was missing:
- Named role assignments (Incident Commander, Chain/Contract Lead, Infra Lead, Data/Recovery Lead, Communications Lead, Scribe) and an escalation path
- Internal/external communication plan with cadence, channel, and message-content guidelines
- A consolidated quarterly DR testing schedule, including a new full-team tabletop exercise
- See docs/DR_PLAN_IMPLEMENTATION.md for a summary of what was pre-existing vs. added

2. SBT attributes
Encoded key/value attributes on top of the credential reference for granular verification:
- add_sbt_attribute / remove_sbt_attribute — issuer (admin)-only
- get_sbt_attribute / get_sbt_attribute_keys
- query_sbt_by_attribute(key, value) -> Vec<u64> via an on-chain reverse index
- Privacy control: attributes can be marked private, excluding them from the public index and restricting reads to the issuer or current owner

3. SBT marketplace registry
On-chain discovery mechanism so verifiers/marketplaces can find SBTs from holders:
- register_sbt_in_marketplace / deregister_sbt_from_marketplace — holder-only
- query_marketplace_sbt(marketplace_id) -> Vec<u64>
- get_marketplace_metadata, get_sbt_marketplaces
- get_all_registered_sbts — global on-chain registry index

4. SBT possession commitments (privacy)
Lets a holder prove possession without revealing identity:
- create_sbt_possession_commitment(holder, sbt_id) -> Bytes — hash-based commitment (sha256(sbt_id || nonce)), stores no holder address
- verify_sbt_commitment(commitment, proof) -> bool and a panicking assert_sbt_commitment variant
- Six new tests covering success, invalid proof, unknown commitment, and non-owner rejection
- docs/sbt-possession-privacy.md documents guarantees and explicit limitations (token identity/ownership remain public; this hides the holder-to-proof link, not the SBT itself)
