### PR TITLE
feat: RBAC role inheritance, API key rotation, OAuth2/OIDC, BBS+ key escrow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,17 @@ BRIDGE_HMAC_SECRET=change-me-in-production
 ETH_TOPIC_CREDENTIAL_ISSUED=
 ETH_TOPIC_CREDENTIAL_REVOKED=
 
+# Issue #1296: OAuth2 / OIDC provider credentials
+OAUTH_GOOGLE_CLIENT_ID=
+OAUTH_GOOGLE_CLIENT_SECRET=
+OAUTH_GOOGLE_REDIRECT_URI=
+OAUTH_MICROSOFT_CLIENT_ID=
+OAUTH_MICROSOFT_CLIENT_SECRET=
+OAUTH_MICROSOFT_REDIRECT_URI=
+OAUTH_GITHUB_CLIENT_ID=
+OAUTH_GITHUB_CLIENT_SECRET=
+OAUTH_GITHUB_REDIRECT_URI=
+
 # WebSocket cross-instance delivery (see docs/websocket-scaling.md)
 # Required when running more than one api-server replica; unset falls back
 # to same-process delivery only (fine for local dev, not for production).

--- a/api-server/src/index.ts
+++ b/api-server/src/index.ts
@@ -17,12 +17,14 @@ import consentRouter from './routes/consent.js';
 import webhooksRouter from './routes/webhooks.js';
 import gdprRouter from './routes/gdpr.js';
 import apiKeysRouter from './routes/apiKeys.js';
+import oauth2Router from './routes/oauth2.js';
 import { cacheControl } from './middleware/cacheControl.js';
 import { createRateLimiter } from './middleware/rateLimiter.js';
 import { createRequestDeduplication } from './middleware/requestDeduplication.js';
 import { rbac } from './middleware/rbac.js';
 import { createDDoSProtection } from './middleware/ddosProtection.js';
 import { createRequestSigning } from './middleware/requestSigning.js';
+import { apiKeyRateLimiter } from './middleware/apiKeyRateLimit.js';
 import { createWsServer } from './ws/server.js';
 import { getSubscriberCount } from './ws/subscriptions.js';
 import { getWsMetrics, getWsMetricsPrometheus } from './ws/metrics.js';
@@ -34,6 +36,11 @@ const ddosProtection = createDDoSProtection();
 app.use(ddosProtection);
 
 app.use(express.json({ limit: '100kb' }));
+
+// #1297 per-API-key rate limiting: applies whenever a caller presents
+// x-api-key, independently of the general IP-based limiter below, and
+// no-ops for requests that don't authenticate this way.
+app.use(apiKeyRateLimiter);
 
 const requestSigning = createRequestSigning();
 const requestDeduplication = createRequestDeduplication({ ttlMs: 100, enabled: true });
@@ -82,6 +89,8 @@ app.use('/api/recovery', recoveryRouter);
 app.use('/api/webhooks', webhooksRouter); // #926 event webhooks
 app.use('/api/gdpr', gdprRouter);
 app.use('/api/api-keys', apiKeysRouter); // #999 API key management
+app.use('/auth/api-keys', apiKeysRouter); // #1297 API key management + rotation (spec-mandated path)
+app.use('/auth/oauth2', oauth2Router); // #1296 OAuth2 / OIDC support
 
 app.get('/health', (_req, res) => {
   res.json({

--- a/api-server/src/middleware/apiKeyRateLimit.ts
+++ b/api-server/src/middleware/apiKeyRateLimit.ts
@@ -1,0 +1,52 @@
+import { Request, Response, NextFunction } from 'express';
+import { createRateLimiter, RateLimitConfig } from './rateLimiter.js';
+import { getDefaultApiKeyManager, ApiKeyManager } from '../services/apiKeyManager.js';
+
+const API_KEY_HEADER = 'x-api-key';
+
+const DEFAULT_CONFIG: RateLimitConfig = {
+  windowMs: 60_000,
+  max: 120,
+  name: 'api-key',
+  backoffMultiplier: 2,
+  maxViolations: 5,
+};
+
+/**
+ * Per-API-key rate limiting (#1297). Buckets requests by the presented key
+ * rather than by IP/Stellar address, so a single caller can't burn through
+ * another API key's quota and each key's callers are throttled independently
+ * of the rest of the API's IP-based limiter.
+ *
+ * A request without an `x-api-key` header passes through untouched — this
+ * middleware only governs traffic that is actually authenticating with a
+ * managed key, and defers everything else to the general rate limiter.
+ */
+export function createApiKeyRateLimiter(config: RateLimitConfig = DEFAULT_CONFIG, manager?: ApiKeyManager) {
+  const limiter = createRateLimiter(config, (req: Request) => {
+    const raw = req.headers[API_KEY_HEADER];
+    return typeof raw === 'string' && raw ? `apikey:${raw}` : 'apikey:unknown';
+  });
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const raw = req.headers[API_KEY_HEADER];
+    if (typeof raw !== 'string' || !raw) {
+      next();
+      return;
+    }
+
+    const keyManager = manager ?? getDefaultApiKeyManager();
+    const key = keyManager.verifyKey(raw);
+    if (!key) {
+      res.status(401).json({ error: 'Invalid or expired API key' });
+      return;
+    }
+
+    keyManager.recordUsage(key.id, req.path);
+    (req as Request & { apiKey?: typeof key }).apiKey = key;
+
+    limiter(req, res, next);
+  };
+}
+
+export const apiKeyRateLimiter = createApiKeyRateLimiter();

--- a/api-server/src/routes/apiKeys.ts
+++ b/api-server/src/routes/apiKeys.ts
@@ -125,6 +125,42 @@ router.delete('/:id', (req: Request, res: Response) => {
   }
 });
 
+// POST /api/api-keys/:id/rotate — Rotate a key; old key keeps working for a grace period
+router.post('/:id/rotate', (req: Request, res: Response) => {
+  const issuer = getIssuerFromRequest(req);
+  if (!issuer) {
+    res.status(401).json({ error: 'Missing or invalid authorization' });
+    return;
+  }
+
+  try {
+    const manager = getDefaultApiKeyManager();
+    const key = manager.getKey(req.params.id as string);
+
+    if (!key || key.issuer !== issuer) {
+      res.status(404).json({ error: 'API key not found' });
+      return;
+    }
+
+    const { gracePeriodMs } = req.body as { gracePeriodMs?: unknown };
+    const grace = typeof gracePeriodMs === 'number' && gracePeriodMs > 0 ? gracePeriodMs : undefined;
+
+    const newSecret = manager.rotateKey(req.params.id as string, grace);
+    if (!newSecret) {
+      res.status(409).json({ error: 'Key is already inactive and cannot be rotated' });
+      return;
+    }
+
+    res.status(201).json({
+      ...newSecret,
+      rotatedFrom: req.params.id,
+      warning: 'Store this key securely. It will not be shown again. The old key remains valid until its grace period expires.',
+    });
+  } catch (err: unknown) {
+    res.status(500).json({ error: 'Failed to rotate key' });
+  }
+});
+
 // GET /api/api-keys/:id/usage — Get usage history for a key
 router.get('/:id/usage', (req: Request, res: Response) => {
   const issuer = getIssuerFromRequest(req);

--- a/api-server/src/routes/oauth2.ts
+++ b/api-server/src/routes/oauth2.ts
@@ -1,0 +1,123 @@
+/**
+ * OAuth2 / OIDC routes (#1296).
+ */
+
+import { randomBytes } from 'crypto';
+import { Router, Request, Response } from 'express';
+import { Keypair, StrKey } from '@stellar/stellar-sdk';
+import {
+  isSupportedProvider,
+  buildAuthorizationUrl,
+  exchangeCodeForToken,
+  resolveIdentity,
+} from '../services/oauth2.js';
+import { getDefaultOAuthIdentityStore } from '../services/oauthIdentityStore.js';
+
+const router = Router();
+
+const SIGNATURE_HEX_PATTERN = /^[0-9a-fA-F]{128}$/; // 64-byte ed25519 signature, hex-encoded
+
+/**
+ * Canonical message the Stellar keypair holder signs to authorize linking
+ * their address to an OAuth2 identity. Binding provider + subject + address
+ * prevents a signature collected for one identity from being replayed to
+ * link a different (stolen) OAuth2 account, or the same account to a
+ * different address.
+ */
+function buildLinkMessage(provider: string, subject: string, stellarAddress: string): string {
+  return `QuorumProof OAuth2 Identity Link\nprovider:${provider}\nsubject:${subject}\naddress:${stellarAddress}`;
+}
+
+function verifyLinkSignature(
+  provider: string,
+  subject: string,
+  stellarAddress: string,
+  signatureHex: string,
+): boolean {
+  if (!StrKey.isValidEd25519PublicKey(stellarAddress)) return false;
+  if (typeof signatureHex !== 'string' || !SIGNATURE_HEX_PATTERN.test(signatureHex)) return false;
+
+  const message = Buffer.from(buildLinkMessage(provider, subject, stellarAddress), 'utf8');
+  const signature = Buffer.from(signatureHex, 'hex');
+
+  try {
+    return Keypair.fromPublicKey(stellarAddress).verify(message, signature);
+  } catch {
+    return false;
+  }
+}
+
+// GET /auth/oauth2/:provider/authorize — build the provider's consent screen URL
+router.get('/:provider/authorize', (req: Request, res: Response) => {
+  const provider = req.params.provider;
+  if (!isSupportedProvider(provider)) {
+    res.status(400).json({ error: `Unsupported OAuth2 provider: ${provider}` });
+    return;
+  }
+
+  const state = randomBytes(16).toString('hex');
+  const url = buildAuthorizationUrl(provider, state);
+  res.json({ provider, url, state });
+});
+
+// POST /auth/oauth2/callback — exchange the auth code, verify identity, link to a Stellar address
+router.post('/callback', async (req: Request, res: Response) => {
+  const { provider, code, stellarAddress, signature } = req.body as {
+    provider?: unknown;
+    code?: unknown;
+    stellarAddress?: unknown;
+    signature?: unknown;
+  };
+
+  if (typeof provider !== 'string' || !isSupportedProvider(provider)) {
+    res.status(400).json({ error: 'provider must be one of google, microsoft, github' });
+    return;
+  }
+  if (typeof code !== 'string' || !code) {
+    res.status(400).json({ error: 'code is required' });
+    return;
+  }
+  if (typeof stellarAddress !== 'string' || !stellarAddress) {
+    res.status(400).json({ error: 'stellarAddress is required' });
+    return;
+  }
+  if (typeof signature !== 'string' || !signature) {
+    res.status(400).json({ error: 'signature is required to prove ownership of stellarAddress' });
+    return;
+  }
+
+  let identity;
+  try {
+    const tokens = await exchangeCodeForToken(provider, code);
+    identity = await resolveIdentity(provider, tokens);
+  } catch (err: unknown) {
+    res.status(401).json({ error: 'OAuth2 authentication failed', message: (err as Error).message });
+    return;
+  }
+
+  if (!verifyLinkSignature(provider, identity.subject, stellarAddress, signature)) {
+    res.status(401).json({ error: 'Invalid signature — cannot verify ownership of stellarAddress' });
+    return;
+  }
+
+  const store = getDefaultOAuthIdentityStore();
+  const link = store.link(provider, identity.subject, stellarAddress, identity.email);
+
+  res.status(200).json({
+    provider,
+    subject: identity.subject,
+    email: identity.email,
+    name: identity.name,
+    stellarAddress: link.stellarAddress,
+    linkedAt: link.linkedAt,
+  });
+});
+
+// GET /auth/oauth2/identities/:stellarAddress — list linked identities for an address
+router.get('/identities/:stellarAddress', (req: Request, res: Response) => {
+  const store = getDefaultOAuthIdentityStore();
+  const links = store.getByStellarAddress(req.params.stellarAddress as string);
+  res.json({ data: links });
+});
+
+export default router;

--- a/api-server/src/services/apiKeyManager.ts
+++ b/api-server/src/services/apiKeyManager.ts
@@ -16,6 +16,15 @@ export interface ApiKey {
   lastUsedAt?: string;
   name: string;
   active: boolean;
+  /** Set when this key has been rotated: the id of the key that replaces it. */
+  rotatedTo?: string;
+  /**
+   * Set when this key has been rotated: the key keeps verifying until this
+   * timestamp, after which it is rejected even though `active` stays true.
+   * This is what gives callers a grace window to switch to the new key
+   * instead of every in-flight client breaking the instant rotation happens.
+   */
+  graceExpiresAt?: string;
 }
 
 export interface ApiKeySecret {
@@ -34,6 +43,9 @@ export interface ApiKeyUsageRecord {
 }
 
 const KEY_ID_PATTERN = /^key_([a-zA-Z0-9]{32})$/;
+
+/** Default rotation grace window: 24 hours for the old key to keep working. */
+const DEFAULT_GRACE_PERIOD_MS = 24 * 60 * 60 * 1000;
 
 export interface ApiKeyManagerOptions {
   dataDir?: string;
@@ -114,7 +126,7 @@ export class ApiKeyManager {
   }
 
   /**
-   * Revoke a key by ID.
+   * Revoke a key by ID immediately (no grace period).
    */
   revokeKey(id: string): boolean {
     const key = this.keys.get(id);
@@ -126,32 +138,58 @@ export class ApiKeyManager {
   }
 
   /**
+   * Rotate a key: generates a brand-new key/hash for the same issuer+name,
+   * and lets the old key keep verifying for `gracePeriodMs` longer so
+   * in-flight clients have time to switch over, instead of breaking the
+   * instant rotation happens. Returns the new key's one-time secret, or
+   * undefined if `id` doesn't exist or is already inactive.
+   */
+  rotateKey(id: string, gracePeriodMs: number = DEFAULT_GRACE_PERIOD_MS): ApiKeySecret | undefined {
+    const oldKey = this.keys.get(id);
+    if (!oldKey || !oldKey.active) return undefined;
+
+    const newSecret = this.generateKey(oldKey.issuer, oldKey.name);
+
+    oldKey.rotatedTo = newSecret.id;
+    oldKey.graceExpiresAt = new Date(Date.now() + gracePeriodMs).toISOString();
+    this.keys.set(oldKey.id, oldKey);
+
+    return newSecret;
+  }
+
+  /**
    * Verify an API key and return the key info if valid.
-   * Updates the lastUsedAt timestamp.
+   * Updates the lastUsedAt timestamp. A rotated key still verifies until
+   * its grace period elapses, after which it is rejected even though
+   * `active` remains true.
    */
   verifyKey(rawKey: string): ApiKey | undefined {
     const keyHash = crypto.createHash('sha256').update(rawKey).digest('hex');
 
     for (const key of this.keys.values()) {
-      if (key.active && key.keyHash === keyHash) {
-        // Update last used timestamp
-        key.lastUsedAt = new Date().toISOString();
-        this.keys.set(key.id, key);
+      if (!key.active || key.keyHash !== keyHash) continue;
 
-        // Log usage with unique key
-        const uniqueId = `${key.id}_${Date.now()}_${crypto.randomBytes(4).toString('hex')}`;
-        this.usage.set(
-          uniqueId,
-          {
-            keyId: key.id,
-            issuer: key.issuer,
-            usedAt: key.lastUsedAt,
-            endpoint: 'unspecified',
-          }
-        );
-
-        return key;
+      if (key.graceExpiresAt && Date.now() > new Date(key.graceExpiresAt).getTime()) {
+        continue; // grace period elapsed; this key no longer verifies
       }
+
+      // Update last used timestamp
+      key.lastUsedAt = new Date().toISOString();
+      this.keys.set(key.id, key);
+
+      // Log usage with unique key
+      const uniqueId = `${key.id}_${Date.now()}_${crypto.randomBytes(4).toString('hex')}`;
+      this.usage.set(
+        uniqueId,
+        {
+          keyId: key.id,
+          issuer: key.issuer,
+          usedAt: key.lastUsedAt,
+          endpoint: 'unspecified',
+        }
+      );
+
+      return key;
     }
 
     return undefined;

--- a/api-server/src/services/oauth2.ts
+++ b/api-server/src/services/oauth2.ts
@@ -1,0 +1,295 @@
+/**
+ * OAuth2 / OIDC support (#1296).
+ *
+ * The API previously only supported Stellar keypair auth. This adds
+ * authorization-code exchange against Google, Microsoft, and GitHub, OIDC ID
+ * token validation (RS256, verified against each provider's published JWKS),
+ * and a GitHub-specific fallback since GitHub's OAuth2 implementation has no
+ * ID token -- its identity comes from the authenticated user API instead.
+ *
+ * Deliberately built on Node's built-in `crypto` (RSA-JWK verification) and
+ * global `fetch` rather than a JWT/OIDC library, since no new dependency can
+ * be installed for this change.
+ */
+
+import { createPublicKey, verify as verifyRsaSignature } from 'crypto';
+
+export type OAuthProviderName = 'google' | 'microsoft' | 'github';
+
+export interface OAuthProviderConfig {
+  name: OAuthProviderName;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  /** Absent for GitHub -- it has no OIDC discovery / ID tokens. */
+  jwksUri?: string;
+  /** Expected `iss` claim. Absent for providers with a per-tenant issuer (Microsoft). */
+  issuer?: string;
+  scope: string;
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+}
+
+function env(name: string): string {
+  return process.env[name] ?? '';
+}
+
+export function getProviderConfig(provider: OAuthProviderName): OAuthProviderConfig {
+  switch (provider) {
+    case 'google':
+      return {
+        name: 'google',
+        authorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
+        tokenEndpoint: 'https://oauth2.googleapis.com/token',
+        jwksUri: 'https://www.googleapis.com/oauth2/v3/certs',
+        issuer: 'https://accounts.google.com',
+        scope: 'openid email profile',
+        clientId: env('OAUTH_GOOGLE_CLIENT_ID'),
+        clientSecret: env('OAUTH_GOOGLE_CLIENT_SECRET'),
+        redirectUri: env('OAUTH_GOOGLE_REDIRECT_URI'),
+      };
+    case 'microsoft':
+      return {
+        name: 'microsoft',
+        authorizationEndpoint: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
+        tokenEndpoint: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+        jwksUri: 'https://login.microsoftonline.com/common/discovery/v2.0/keys',
+        scope: 'openid email profile',
+        clientId: env('OAUTH_MICROSOFT_CLIENT_ID'),
+        clientSecret: env('OAUTH_MICROSOFT_CLIENT_SECRET'),
+        redirectUri: env('OAUTH_MICROSOFT_REDIRECT_URI'),
+      };
+    case 'github':
+      return {
+        name: 'github',
+        authorizationEndpoint: 'https://github.com/login/oauth/authorize',
+        tokenEndpoint: 'https://github.com/login/oauth/access_token',
+        scope: 'read:user user:email',
+        clientId: env('OAUTH_GITHUB_CLIENT_ID'),
+        clientSecret: env('OAUTH_GITHUB_CLIENT_SECRET'),
+        redirectUri: env('OAUTH_GITHUB_REDIRECT_URI'),
+      };
+    default: {
+      const exhaustive: never = provider;
+      throw new Error(`Unknown OAuth2 provider: ${exhaustive}`);
+    }
+  }
+}
+
+const SUPPORTED_PROVIDERS: readonly OAuthProviderName[] = ['google', 'microsoft', 'github'];
+
+export function isSupportedProvider(provider: string): provider is OAuthProviderName {
+  return (SUPPORTED_PROVIDERS as readonly string[]).includes(provider);
+}
+
+export function buildAuthorizationUrl(provider: OAuthProviderName, state: string): string {
+  const config = getProviderConfig(provider);
+  const url = new URL(config.authorizationEndpoint);
+  url.searchParams.set('client_id', config.clientId);
+  url.searchParams.set('redirect_uri', config.redirectUri);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('scope', config.scope);
+  url.searchParams.set('state', state);
+  return url.toString();
+}
+
+export interface TokenResponse {
+  access_token?: string;
+  id_token?: string;
+  token_type?: string;
+  scope?: string;
+  expires_in?: number;
+}
+
+export async function exchangeCodeForToken(provider: OAuthProviderName, code: string): Promise<TokenResponse> {
+  const config = getProviderConfig(provider);
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    client_id: config.clientId,
+    client_secret: config.clientSecret,
+    redirect_uri: config.redirectUri,
+  });
+
+  const response = await fetch(config.tokenEndpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    throw new Error(`OAuth2 token exchange failed for ${provider}: ${response.status}`);
+  }
+  return (await response.json()) as TokenResponse;
+}
+
+interface Jwk {
+  kty: string;
+  kid: string;
+  n?: string;
+  e?: string;
+}
+
+interface JwksCacheEntry {
+  keys: Jwk[];
+  fetchedAt: number;
+}
+
+const JWKS_CACHE_TTL_MS = 10 * 60 * 1000;
+const jwksCache = new Map<string, JwksCacheEntry>();
+
+async function fetchJwks(jwksUri: string): Promise<Jwk[]> {
+  const cached = jwksCache.get(jwksUri);
+  if (cached && Date.now() - cached.fetchedAt < JWKS_CACHE_TTL_MS) {
+    return cached.keys;
+  }
+
+  const response = await fetch(jwksUri);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch JWKS from ${jwksUri}: ${response.status}`);
+  }
+  const data = (await response.json()) as { keys: Jwk[] };
+  jwksCache.set(jwksUri, { keys: data.keys, fetchedAt: Date.now() });
+  return data.keys;
+}
+
+function base64UrlDecode(input: string): Buffer {
+  return Buffer.from(input.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+}
+
+export interface IdTokenClaims {
+  iss: string;
+  sub: string;
+  aud: string | string[];
+  exp: number;
+  iat: number;
+  email?: string;
+  name?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Validates an OIDC ID token's RS256 signature against the provider's JWKS,
+ * then checks `iss`/`aud`/`exp` per the OIDC core spec. Only RS256 is
+ * supported -- the algorithm Google and Microsoft's default OIDC
+ * configuration both issue.
+ */
+export async function verifyIdToken(provider: OAuthProviderName, idToken: string): Promise<IdTokenClaims> {
+  const config = getProviderConfig(provider);
+  if (!config.jwksUri) {
+    throw new Error(`Provider ${provider} does not issue OIDC ID tokens`);
+  }
+
+  const parts = idToken.split('.');
+  if (parts.length !== 3) {
+    throw new Error('Malformed ID token');
+  }
+  const [headerB64, payloadB64, signatureB64] = parts;
+
+  const header = JSON.parse(base64UrlDecode(headerB64).toString('utf8')) as { alg: string; kid: string };
+  if (header.alg !== 'RS256') {
+    throw new Error(`Unsupported ID token algorithm: ${header.alg}`);
+  }
+
+  const keys = await fetchJwks(config.jwksUri);
+  const jwk = keys.find((k) => k.kid === header.kid);
+  if (!jwk || !jwk.n || !jwk.e) {
+    throw new Error('No matching JWKS key for ID token kid');
+  }
+
+  const publicKey = createPublicKey({
+    key: { kty: jwk.kty, n: jwk.n, e: jwk.e },
+    format: 'jwk',
+  });
+
+  const signingInput = Buffer.from(`${headerB64}.${payloadB64}`, 'utf8');
+  const signature = base64UrlDecode(signatureB64);
+
+  const valid = verifyRsaSignature('RSA-SHA256', signingInput, publicKey, signature);
+  if (!valid) {
+    throw new Error('ID token signature verification failed');
+  }
+
+  const claims = JSON.parse(base64UrlDecode(payloadB64).toString('utf8')) as IdTokenClaims;
+
+  const now = Math.floor(Date.now() / 1000);
+  if (claims.exp < now) {
+    throw new Error('ID token has expired');
+  }
+  if (config.issuer && claims.iss !== config.issuer) {
+    throw new Error(`Unexpected ID token issuer: ${claims.iss}`);
+  }
+  if (provider === 'microsoft' && !claims.iss.startsWith('https://login.microsoftonline.com/')) {
+    // Microsoft's `iss` is tenant-specific (.../{tenantId}/v2.0), so it is
+    // checked by prefix rather than exact match against a fixed issuer.
+    throw new Error(`Unexpected ID token issuer: ${claims.iss}`);
+  }
+  const audiences = Array.isArray(claims.aud) ? claims.aud : [claims.aud];
+  if (!audiences.includes(config.clientId)) {
+    throw new Error('ID token audience does not match this client');
+  }
+
+  return claims;
+}
+
+export interface OAuthIdentity {
+  provider: OAuthProviderName;
+  subject: string;
+  email?: string;
+  name?: string;
+}
+
+interface GithubUser {
+  id: number;
+  login: string;
+  email: string | null;
+  name: string | null;
+}
+
+async function fetchGithubIdentity(accessToken: string): Promise<OAuthIdentity> {
+  const response = await fetch('https://api.github.com/user', {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'QuorumProof',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub user lookup failed: ${response.status}`);
+  }
+  const user = (await response.json()) as GithubUser;
+  return {
+    provider: 'github',
+    subject: String(user.id),
+    email: user.email ?? undefined,
+    name: user.name ?? user.login,
+  };
+}
+
+/**
+ * Resolves a completed OAuth2 token response into a normalized identity.
+ * Google/Microsoft identities come from their signed OIDC ID token; GitHub
+ * has no ID token, so its identity comes from the authenticated user API.
+ */
+export async function resolveIdentity(provider: OAuthProviderName, tokens: TokenResponse): Promise<OAuthIdentity> {
+  if (provider === 'github') {
+    if (!tokens.access_token) {
+      throw new Error('GitHub token response did not include an access_token');
+    }
+    return fetchGithubIdentity(tokens.access_token);
+  }
+
+  if (!tokens.id_token) {
+    throw new Error(`${provider} token response did not include an id_token`);
+  }
+  const claims = await verifyIdToken(provider, tokens.id_token);
+  return {
+    provider,
+    subject: claims.sub,
+    email: claims.email,
+    name: typeof claims.name === 'string' ? claims.name : undefined,
+  };
+}

--- a/api-server/src/services/oauthIdentityStore.ts
+++ b/api-server/src/services/oauthIdentityStore.ts
@@ -1,0 +1,75 @@
+/**
+ * OAuth2/OIDC identity linking store (#1296).
+ * Maps a (provider, subject) pair -- the stable identifier an IdP issues for
+ * an account -- to the Stellar address the user has proven ownership of, so
+ * an enterprise SSO login can be resolved to an on-chain identity.
+ */
+
+import path from 'path';
+import { DurableLog } from './durableLog.js';
+
+export interface OAuthIdentityLink {
+  provider: string;
+  subject: string;
+  stellarAddress: string;
+  email?: string;
+  linkedAt: string;
+}
+
+function identityKey(provider: string, subject: string): string {
+  return `${provider}:${subject}`;
+}
+
+export class OAuthIdentityStore {
+  readonly dataDir: string;
+  private readonly links: DurableLog<OAuthIdentityLink>;
+
+  constructor(options: { dataDir?: string } = {}) {
+    const dataDir = options.dataDir ?? process.env.OAUTH_IDENTITY_STORE_DATA_DIR ?? path.join(process.cwd(), '.data', 'oauth-identities');
+    this.dataDir = dataDir;
+    this.links = new DurableLog<OAuthIdentityLink>(path.join(dataDir, 'links.jsonl'));
+  }
+
+  link(provider: string, subject: string, stellarAddress: string, email?: string): OAuthIdentityLink {
+    const link: OAuthIdentityLink = {
+      provider,
+      subject,
+      stellarAddress,
+      email,
+      linkedAt: new Date().toISOString(),
+    };
+    this.links.set(identityKey(provider, subject), link);
+    return link;
+  }
+
+  getByIdentity(provider: string, subject: string): OAuthIdentityLink | undefined {
+    return this.links.get(identityKey(provider, subject));
+  }
+
+  getByStellarAddress(stellarAddress: string): OAuthIdentityLink[] {
+    return this.links.values().filter((l) => l.stellarAddress === stellarAddress);
+  }
+
+  unlink(provider: string, subject: string): boolean {
+    const key = identityKey(provider, subject);
+    if (!this.links.has(key)) return false;
+    this.links.delete(key);
+    return true;
+  }
+
+  /** Reset state -- for testing only. */
+  _resetForTest(): void {
+    for (const key of this.links.keys()) this.links.delete(key);
+  }
+}
+
+let defaultStore: OAuthIdentityStore | undefined;
+
+export function getDefaultOAuthIdentityStore(): OAuthIdentityStore {
+  if (!defaultStore) defaultStore = new OAuthIdentityStore();
+  return defaultStore;
+}
+
+export function _setDefaultOAuthIdentityStoreForTest(store: OAuthIdentityStore | undefined): void {
+  defaultStore = store;
+}

--- a/contracts/bbs_plus_v1/src/escrow.rs
+++ b/contracts/bbs_plus_v1/src/escrow.rs
@@ -1,0 +1,186 @@
+//! Threshold (Shamir) secret sharing for BBS+ issuer key escrow/backup.
+//!
+//! # Design
+//!
+//! If an issuer's BBS+ signing key (an `Fr` scalar, see `signature::SigningKey`)
+//! is lost, every signature it ever produced becomes unverifiable-in-spirit --
+//! the issuer can no longer prove continuity of their key material. This
+//! module lets an issuer split that key into `n` shares such that any
+//! `t`-of-`n` ("threshold-of-total") shares reconstruct it, following the
+//! classical Shamir construction over the same scalar field the rest of this
+//! crate already uses for BBS+ arithmetic:
+//!
+//! ```text
+//! f(x) = secret + a_1*x + a_2*x^2 + ... + a_{t-1}*x^{t-1}    (mod r)
+//! share_i = (i, f(i))    for i = 1..=n
+//! ```
+//!
+//! Any `t` shares reconstruct `f(0) = secret` via Lagrange interpolation.
+//! Fewer than `t` shares reveal nothing about the secret (information-
+//! theoretic security), which is the entire point of a *threshold* scheme
+//! over simply handing every guardian a plaintext copy.
+//!
+//! Splitting requires randomness (the polynomial's coefficients), so -- in
+//! keeping with this crate's existing convention that real key/blinding
+//! material is only ever generated off-chain (see the crate-level `rand`
+//! feature note) -- `split_secret` takes the coefficients as an argument
+//! rather than sampling them itself, and is usable in `no_std` contexts.
+//! Reconstruction needs no randomness at all: only field addition,
+//! multiplication, and inversion, all available without `std`.
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+use crate::errors::{BbsError, BbsResult};
+use crate::primitives::Fr;
+
+/// One share of a Shamir-split secret. `index` is the polynomial evaluation
+/// point (always >= 1; index 0 is reserved for the secret itself, `f(0)`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct KeyShare {
+    pub index: u32,
+    pub value: Fr,
+}
+
+impl KeyShare {
+    /// Canonical wire format: big-endian share index followed by the
+    /// share's scalar bytes.
+    pub fn to_bytes(&self) -> [u8; 36] {
+        let mut out = [0u8; 36];
+        out[..4].copy_from_slice(&self.index.to_be_bytes());
+        out[4..].copy_from_slice(&self.value.to_bytes());
+        out
+    }
+
+    pub fn from_bytes(bytes: &[u8; 36]) -> BbsResult<Self> {
+        let mut index_bytes = [0u8; 4];
+        index_bytes.copy_from_slice(&bytes[..4]);
+        let index = u32::from_be_bytes(index_bytes);
+
+        let mut value_bytes = [0u8; 32];
+        value_bytes.copy_from_slice(&bytes[4..]);
+        let value = Fr::from_bytes(&value_bytes)?;
+
+        Ok(KeyShare { index, value })
+    }
+}
+
+/// Splits `secret` into `total_shares` Shamir shares, any
+/// `coefficients.len() + 1` of which reconstruct it.
+///
+/// `coefficients` are the polynomial's degree-1..degree-(t-1) coefficients
+/// (`a_1..a_{t-1}` above), generated off-chain with a CSPRNG -- the caller is
+/// responsible for discarding them securely after splitting, since knowing
+/// them is equivalent to knowing the secret.
+pub fn split_secret(secret: Fr, coefficients: &[Fr], total_shares: u32) -> BbsResult<Vec<KeyShare>> {
+    let threshold = coefficients.len() as u32 + 1;
+    if threshold < 2 || threshold > total_shares {
+        return Err(BbsError::InvalidScalar);
+    }
+
+    let mut shares = Vec::with_capacity(total_shares as usize);
+    for i in 1..=total_shares {
+        let x = Fr::from_u64(i as u64);
+        let mut acc = secret;
+        let mut x_pow = x;
+        for coeff in coefficients {
+            acc = acc.add(&coeff.mul(&x_pow));
+            x_pow = x_pow.mul(&x);
+        }
+        shares.push(KeyShare { index: i, value: acc });
+    }
+    Ok(shares)
+}
+
+/// Reconstructs the secret from `shares` (must contain at least the
+/// original threshold's worth, though this function has no way to know that
+/// threshold itself -- callers must not invoke it with fewer than `t`
+/// shares, since it will silently return the wrong scalar rather than fail).
+///
+/// Uses Lagrange interpolation evaluated at `x = 0`:
+/// `secret = sum_i( y_i * prod_{j != i}( x_j / (x_j - x_i) ) )`.
+pub fn reconstruct_secret(shares: &[KeyShare]) -> BbsResult<Fr> {
+    if shares.len() < 2 {
+        return Err(BbsError::InvalidScalar);
+    }
+
+    for i in 0..shares.len() {
+        for j in (i + 1)..shares.len() {
+            if shares[i].index == shares[j].index {
+                // Duplicate share index: the Lagrange basis below would
+                // divide by zero, and a duplicate carries no additional
+                // information anyway.
+                return Err(BbsError::InvalidScalar);
+            }
+        }
+    }
+
+    let mut secret = Fr::zero();
+    for i in 0..shares.len() {
+        let xi = Fr::from_u64(shares[i].index as u64);
+        let mut numerator = Fr::one();
+        let mut denominator = Fr::one();
+        for j in 0..shares.len() {
+            if i == j {
+                continue;
+            }
+            let xj = Fr::from_u64(shares[j].index as u64);
+            numerator = numerator.mul(&xj);
+            denominator = denominator.mul(&xj.sub(&xi));
+        }
+        let lagrange_coefficient = numerator.mul(&denominator.invert()?);
+        secret = secret.add(&shares[i].value.mul(&lagrange_coefficient));
+    }
+    Ok(secret)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_and_reconstruct_exact_threshold() {
+        let secret = Fr::from_u64(424242);
+        let coefficients = [Fr::from_u64(7), Fr::from_u64(19)]; // threshold = 3
+        let shares = split_secret(secret, &coefficients, 5).unwrap();
+        assert_eq!(shares.len(), 5);
+
+        let subset = [shares[0], shares[2], shares[4]];
+        let recovered = reconstruct_secret(&subset).unwrap();
+        assert_eq!(recovered, secret);
+    }
+
+    #[test]
+    fn test_reconstruct_with_different_subset_matches() {
+        let secret = Fr::from_u64(99);
+        let coefficients = [Fr::from_u64(3)]; // threshold = 2
+        let shares = split_secret(secret, &coefficients, 5).unwrap();
+
+        let subset_a = [shares[0], shares[1]];
+        let subset_b = [shares[2], shares[4]];
+        assert_eq!(reconstruct_secret(&subset_a).unwrap(), secret);
+        assert_eq!(reconstruct_secret(&subset_b).unwrap(), secret);
+    }
+
+    #[test]
+    fn test_split_rejects_invalid_threshold() {
+        let secret = Fr::from_u64(1);
+        // threshold (coefficients.len() + 1 = 6) exceeds total_shares (5)
+        let coefficients = [Fr::from_u64(1); 5];
+        assert!(split_secret(secret, &coefficients, 5).is_err());
+    }
+
+    #[test]
+    fn test_reconstruct_rejects_duplicate_indices() {
+        let share = KeyShare { index: 1, value: Fr::from_u64(1) };
+        assert!(reconstruct_secret(&[share, share]).is_err());
+    }
+
+    #[test]
+    fn test_key_share_byte_round_trip() {
+        let share = KeyShare { index: 3, value: Fr::from_u64(555) };
+        let bytes = share.to_bytes();
+        let decoded = KeyShare::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded, share);
+    }
+}

--- a/contracts/bbs_plus_v1/src/lib.rs
+++ b/contracts/bbs_plus_v1/src/lib.rs
@@ -9,6 +9,7 @@ pub mod transcript;
 pub mod signature;
 pub mod presentation;
 pub mod accumulator;
+pub mod escrow;
 
 pub use errors::{BbsError, BbsResult};
 pub use primitives::{Fr, G1, G2, Gt, pairing, linear_combination_g1, msm_g1};
@@ -16,6 +17,7 @@ pub use transcript::Transcript;
 pub use signature::{SigningKey, VerifyingKey, Signature, BbsSignature};
 pub use presentation::{PresentationProof, BbsPresentation};
 pub use accumulator::{AccumulatorKey, AccumulatorEpoch, Witness, NonRevocationProof};
+pub use escrow::{KeyShare, split_secret, reconstruct_secret};
 
 /// Library version information
 pub const VERSION: &str = "0.1.0";

--- a/contracts/quorum_proof/src/key_escrow.rs
+++ b/contracts/quorum_proof/src/key_escrow.rs
@@ -1,0 +1,212 @@
+//! BBS+ issuer key escrow/backup (#1295).
+//!
+//! The actual Shamir splitting/reconstruction math (`bbs_plus_v1::escrow`)
+//! runs off-chain: an issuer with no on-chain entropy source splits their
+//! BBS+ signing key into `threshold`-of-`guardians.len()` shares themselves,
+//! then deposits one opaque share per guardian here. This module only
+//! tracks *who holds which share* and *whether enough guardians have
+//! consented to a recovery* -- it never sees the underlying secret, only
+//! the 32-byte share blobs guardians will later feed back into
+//! `bbs_plus_v1::escrow::reconstruct_secret` off-chain.
+use crate::{ContractError, DataKeyEscrow, EXTENDED_TTL, STANDARD_TTL};
+use soroban_sdk::{contracttype, panic_with_error, Address, BytesN, Env, String, Vec};
+
+#[contracttype]
+#[derive(Clone)]
+pub struct GuardianShare {
+    pub guardian: Address,
+    pub share_index: u32,
+    pub encrypted_share: BytesN<32>,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct KeyEscrow {
+    pub issuer: Address,
+    pub threshold: u32,
+    pub total_shares: u32,
+    pub guardians: Vec<Address>,
+    pub created_at: u64,
+    pub recovered: bool,
+}
+
+fn find_guardian(guardians: &Vec<Address>, guardian: &Address) -> bool {
+    for i in 0..guardians.len() {
+        if guardians.get(i).unwrap() == *guardian {
+            return true;
+        }
+    }
+    false
+}
+
+/// Deposits a threshold key escrow for `issuer`. Issuer-only: the caller
+/// must already be authenticated and role-checked as `Role::Issuer` by the
+/// contract entry point before this is invoked.
+pub fn deposit_key_escrow(
+    env: &Env,
+    issuer: &Address,
+    guardians: Vec<Address>,
+    shares: Vec<BytesN<32>>,
+    threshold: u32,
+) -> KeyEscrow {
+    if guardians.len() != shares.len() {
+        panic_with_error!(env, ContractError::InvalidEscrowConfig);
+    }
+    let total_shares = guardians.len();
+    if threshold < 2 || threshold > total_shares {
+        panic_with_error!(env, ContractError::InvalidEscrowConfig);
+    }
+    if env
+        .storage()
+        .instance()
+        .has(&DataKeyEscrow::Escrow(issuer.clone()))
+    {
+        panic_with_error!(env, ContractError::EscrowAlreadyExists);
+    }
+
+    let now = env.ledger().timestamp();
+    for i in 0..guardians.len() {
+        let guardian = guardians.get(i).unwrap();
+        let share = shares.get(i).unwrap();
+        env.storage().instance().set(
+            &DataKeyEscrow::GuardianShare(issuer.clone(), guardian.clone()),
+            &GuardianShare {
+                guardian: guardian.clone(),
+                share_index: i + 1,
+                encrypted_share: share,
+            },
+        );
+    }
+
+    let escrow = KeyEscrow {
+        issuer: issuer.clone(),
+        threshold,
+        total_shares,
+        guardians: guardians.clone(),
+        created_at: now,
+        recovered: false,
+    };
+    env.storage()
+        .instance()
+        .set(&DataKeyEscrow::Escrow(issuer.clone()), &escrow);
+    env.storage()
+        .instance()
+        .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+
+    let topic = String::from_str(env, crate::TOPIC_KEY_ESCROW_DEPOSITED);
+    let mut topics: Vec<soroban_sdk::String> = Vec::new(env);
+    topics.push_back(topic);
+    env.events().publish(
+        topics,
+        (crate::TOPIC_KEY_ESCROW_DEPOSITED, issuer.clone(), total_shares),
+    );
+
+    escrow
+}
+
+/// A guardian confirms participation in a recovery for `issuer`'s escrow.
+/// Returns the number of guardians who have submitted so far.
+pub fn submit_recovery_share(env: &Env, guardian: &Address, issuer: &Address) -> u32 {
+    let escrow: KeyEscrow = env
+        .storage()
+        .instance()
+        .get(&DataKeyEscrow::Escrow(issuer.clone()))
+        .unwrap_or_else(|| panic_with_error!(env, ContractError::EscrowNotFound));
+
+    if escrow.recovered {
+        panic_with_error!(env, ContractError::EscrowAlreadyRecovered);
+    }
+    if !find_guardian(&escrow.guardians, guardian) {
+        panic_with_error!(env, ContractError::PermissionDenied);
+    }
+
+    let mut submissions: Vec<Address> = env
+        .storage()
+        .instance()
+        .get(&DataKeyEscrow::RecoverySubmissions(issuer.clone()))
+        .unwrap_or(Vec::new(env));
+
+    if find_guardian(&submissions, guardian) {
+        panic_with_error!(env, ContractError::DuplicateShareSubmission);
+    }
+
+    submissions.push_back(guardian.clone());
+    let count = submissions.len();
+    env.storage()
+        .instance()
+        .set(&DataKeyEscrow::RecoverySubmissions(issuer.clone()), &submissions);
+    env.storage()
+        .instance()
+        .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+
+    count
+}
+
+/// Once `threshold` guardians have submitted, the issuer (or contract
+/// admin) retrieves the stored share blobs for off-chain reconstruction via
+/// `bbs_plus_v1::escrow::reconstruct_secret`. Marks the escrow as recovered
+/// so it cannot be replayed.
+pub fn recover_key(env: &Env, caller: &Address, issuer: &Address) -> Vec<GuardianShare> {
+    let mut escrow: KeyEscrow = env
+        .storage()
+        .instance()
+        .get(&DataKeyEscrow::Escrow(issuer.clone()))
+        .unwrap_or_else(|| panic_with_error!(env, ContractError::EscrowNotFound));
+
+    if escrow.recovered {
+        panic_with_error!(env, ContractError::EscrowAlreadyRecovered);
+    }
+
+    let stored_admin: Address = env
+        .storage()
+        .instance()
+        .get(&crate::DataKey::Admin)
+        .expect("not initialized");
+    if *caller != escrow.issuer && *caller != stored_admin {
+        panic_with_error!(env, ContractError::PermissionDenied);
+    }
+
+    let submissions: Vec<Address> = env
+        .storage()
+        .instance()
+        .get(&DataKeyEscrow::RecoverySubmissions(issuer.clone()))
+        .unwrap_or(Vec::new(env));
+
+    if submissions.len() < escrow.threshold {
+        panic_with_error!(env, ContractError::InsufficientShares);
+    }
+
+    let mut shares: Vec<GuardianShare> = Vec::new(env);
+    for i in 0..submissions.len() {
+        let guardian = submissions.get(i).unwrap();
+        if let Some(share) = env
+            .storage()
+            .instance()
+            .get::<_, GuardianShare>(&DataKeyEscrow::GuardianShare(issuer.clone(), guardian.clone()))
+        {
+            shares.push_back(share);
+        }
+    }
+
+    escrow.recovered = true;
+    env.storage()
+        .instance()
+        .set(&DataKeyEscrow::Escrow(issuer.clone()), &escrow);
+    env.storage()
+        .instance()
+        .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+
+    let topic = String::from_str(env, crate::TOPIC_KEY_ESCROW_RECOVERED);
+    let mut topics: Vec<soroban_sdk::String> = Vec::new(env);
+    topics.push_back(topic);
+    env.events()
+        .publish(topics, (crate::TOPIC_KEY_ESCROW_RECOVERED, issuer.clone()));
+
+    shares
+}
+
+pub fn get_key_escrow(env: &Env, issuer: &Address) -> Option<KeyEscrow> {
+    env.storage()
+        .instance()
+        .get(&DataKeyEscrow::Escrow(issuer.clone()))
+}

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -5,11 +5,12 @@ extern crate std;
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
-    Bytes, Env, IntoVal, Map, String, Symbol, Vec,
+    Bytes, BytesN, Env, IntoVal, Map, String, Symbol, Vec,
 };
 use soroban_sdk::xdr::ToXdr;
 
 mod rbac;
+mod key_escrow;
 mod slice_enhancements;
 #[cfg(test)]
 mod simulation_agent_based;
@@ -41,6 +42,8 @@ const TOPIC_MIGRATION_PROGRESS: &str = "MigrationProgress";
 const TOPIC_TEMPLATE_CREATED: &str = "TemplateCreated";
 const TOPIC_TEMPLATE_UPDATED: &str = "TemplateUpdated";
 const TOPIC_ATTESTOR_REPLACEMENT: &str = "AttestorReplaced";
+const TOPIC_KEY_ESCROW_DEPOSITED: &str = "KeyEscrowDeposited";
+const TOPIC_KEY_ESCROW_RECOVERED: &str = "KeyEscrowRecovered";
 /// `migration::MigrationJob.kind` tag for credential-metadata-schema migrations.
 const MIGRATION_KIND_METADATA_SCHEMA: u32 = 1;
 const STANDARD_TTL: u32 = 16_384;
@@ -797,6 +800,18 @@ pub enum ContractError {
     QuorumIntersectionFailed = 84,
     /// Issue #912: Snapshot not found
     SnapshotNotFound = 85,
+    /// Issue #1295: BBS+ key escrow config invalid (threshold/shares mismatch)
+    InvalidEscrowConfig = 86,
+    /// Issue #1295: Key escrow already exists for this issuer
+    EscrowAlreadyExists = 87,
+    /// Issue #1295: Key escrow not found for this issuer
+    EscrowNotFound = 88,
+    /// Issue #1295: Not enough guardian shares submitted to meet threshold
+    InsufficientShares = 89,
+    /// Issue #1295: Guardian already submitted a recovery share
+    DuplicateShareSubmission = 90,
+    /// Issue #1295: Key escrow has already been recovered
+    EscrowAlreadyRecovered = 91,
 }
 
 #[contracttype]
@@ -1138,6 +1153,18 @@ pub enum DataKey6 {
     RoleAssignment(Address),
     RoleDelegation(Address),
     RoleAuditLog,
+}
+
+/// Storage keys for BBS+ issuer key escrow (#1295).
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKeyEscrow {
+    /// Escrow configuration/status, keyed by issuer.
+    Escrow(Address),
+    /// A single guardian's opaque share blob, keyed by (issuer, guardian).
+    GuardianShare(Address, Address),
+    /// Guardians who have submitted for an in-progress recovery, keyed by issuer.
+    RecoverySubmissions(Address),
 }
 
 /// Storage keys for W3C Decentralized Identifier (DID) support.
@@ -16176,6 +16203,7 @@ impl QuorumProofContract {
             2 => rbac::Role::Issuer,
             3 => rbac::Role::Verifier,
             4 => rbac::Role::RevocationAgent,
+            5 => rbac::Role::Auditor,
             _ => panic_with_error!(&env, ContractError::InvalidEnumValue),
         };
         crate::rbac::assign_role(&env, &admin, &target, rbac_role, expires_at);
@@ -16203,6 +16231,7 @@ impl QuorumProofContract {
             2 => rbac::Role::Issuer,
             3 => rbac::Role::Verifier,
             4 => rbac::Role::RevocationAgent,
+            5 => rbac::Role::Auditor,
             _ => panic_with_error!(&env, ContractError::InvalidEnumValue),
         };
         crate::rbac::delegate_role(&env, &delegator, &delegatee, rbac_role, expires_at);
@@ -16222,6 +16251,7 @@ impl QuorumProofContract {
             2 => rbac::Role::Issuer,
             3 => rbac::Role::Verifier,
             4 => rbac::Role::RevocationAgent,
+            5 => rbac::Role::Auditor,
             _ => return false,
         };
         crate::rbac::has_role(&env, &address, rbac_role)
@@ -16240,6 +16270,49 @@ impl QuorumProofContract {
     /// Get the full RBAC audit log.
     pub fn get_role_audit_log(env: Env) -> Vec<rbac::RoleAuditEntry> {
         crate::rbac::get_audit_log(&env)
+    }
+
+    // ── BBS+ Key Escrow (#1295) ─────────────────────────────────────────
+
+    /// Deposits a threshold (`threshold`-of-`guardians.len()`) Shamir-split
+    /// backup of the issuer's BBS+ signing key. Splitting happens off-chain
+    /// (see `bbs_plus_v1::escrow`); this only stores each guardian's opaque
+    /// share so it can be recovered on threshold-approved request.
+    /// Issuer-only.
+    pub fn deposit_key_escrow(
+        env: Env,
+        issuer: Address,
+        guardians: Vec<Address>,
+        shares: Vec<BytesN<32>>,
+        threshold: u32,
+    ) -> key_escrow::KeyEscrow {
+        issuer.require_auth();
+        Self::require_not_paused(&env);
+        crate::rbac::require_role(&env, &issuer, rbac::Role::Issuer);
+        crate::key_escrow::deposit_key_escrow(&env, &issuer, guardians, shares, threshold)
+    }
+
+    /// A guardian confirms it holds its share and consents to a recovery
+    /// for `issuer`'s escrow. Returns the number of guardians who have
+    /// submitted so far.
+    pub fn submit_recovery_share(env: Env, guardian: Address, issuer: Address) -> u32 {
+        guardian.require_auth();
+        Self::require_not_paused(&env);
+        crate::key_escrow::submit_recovery_share(&env, &guardian, &issuer)
+    }
+
+    /// Once `threshold` guardians have submitted, the issuer (or contract
+    /// admin) retrieves the stored share blobs for off-chain Shamir
+    /// reconstruction.
+    pub fn recover_key(env: Env, caller: Address, issuer: Address) -> Vec<key_escrow::GuardianShare> {
+        caller.require_auth();
+        Self::require_not_paused(&env);
+        crate::key_escrow::recover_key(&env, &caller, &issuer)
+    }
+
+    /// Gets the escrow configuration/status for an issuer, if any.
+    pub fn get_key_escrow(env: Env, issuer: Address) -> Option<key_escrow::KeyEscrow> {
+        crate::key_escrow::get_key_escrow(&env, &issuer)
     }
 
     // ── Attestation Queue Management (#843) ────────────────────────────

--- a/contracts/quorum_proof/src/rbac.rs
+++ b/contracts/quorum_proof/src/rbac.rs
@@ -9,6 +9,7 @@ pub enum Role {
     Issuer = 2,
     Verifier = 3,
     RevocationAgent = 4,
+    Auditor = 5,
 }
 
 #[contracttype]
@@ -49,7 +50,21 @@ pub enum RoleAction {
     Expired = 5,
 }
 
+/// Checks whether `address` holds `role`, either directly or through role
+/// inheritance: the Admin role sits at the top of the hierarchy and
+/// implicitly holds every other role's permissions, so an address with an
+/// unexpired Admin assignment/delegation satisfies `has_role` for any role.
 pub fn has_role(env: &Env, address: &Address, role: Role) -> bool {
+    if has_exact_role(env, address, role) {
+        return true;
+    }
+    if role != Role::Admin && has_exact_role(env, address, Role::Admin) {
+        return true;
+    }
+    false
+}
+
+fn has_exact_role(env: &Env, address: &Address, role: Role) -> bool {
     if let Some(assignment) = env
         .storage()
         .instance()


### PR DESCRIPTION
Closes #1295, #1296, #1297, #1298.
- #1298: add Auditor role and Admin role inheritance to the existing on-chain RBAC (assign_role/delegate_role/audit log were already in place).
- #1297: mount API key routes at /auth/api-keys per spec, add key rotation with a grace period, and add per-API-key rate limiting middleware.
- #1296: add OAuth2/OIDC support for Google, Microsoft, and GitHub — authorization-code exchange, RS256 ID token verification against each provider's JWKS, and signature-proven linking of the identity to a Stellar address.
- #1295: add Shamir secret sharing (split/reconstruct) to bbs_plus_v1 and a Soroban-side threshold key escrow workflow (deposit/guardian submission/ recovery) in quorum_proof so issuers can back up their BBS+ signing key.
Closes #1295 
Closes #1296 
Closes #1297 
Closes #1298 