### PR TITLE
Feat/loadtest circuitbreaker alerting costtracking

### DIFF
--- a/api-server/loadtest/credentialLoadTest.ts
+++ b/api-server/loadtest/credentialLoadTest.ts
@@ -1,0 +1,171 @@
+/**
+ * Credential lifecycle load test: exercises the two heaviest write/read
+ * paths on the API — bulk credential indexing (the search-index write that
+ * follows on-chain issuance) and batched verification (`POST
+ * /api/credentials/verify-batch`, which fans out to `simulateCall` per
+ * credential, i.e. the RPC-bound path guarded by the circuit breaker in
+ * `../src/services/rpcCircuitBreaker.ts`).
+ *
+ * Default scenario: issue 1000 credentials, then run 10000 verifications
+ * against them (200 batches of 50, the API's max batch size), against a
+ * real Express app instance with a SorobanClient stub whose latency and
+ * failure rate are configurable, so the test can be run either against
+ * synthetic RPC timing or (via SOROBAN_RPC_LATENCY_MS=0 and a real
+ * simulateCall implementation swapped in) against a live testnet endpoint.
+ *
+ * Not run as part of `npm test` — see package.json's `loadtest:credentials`
+ * script. Usage:
+ *   npm run loadtest:credentials
+ *   LOAD_ISSUE_COUNT=5000 LOAD_VERIFY_COUNT=50000 npm run loadtest:credentials
+ *   LOAD_RPC_FAILURE_RATE=0.05 npm run loadtest:credentials   # exercise circuit breaker under load
+ */
+import express from 'express';
+import type { AddressInfo } from 'net';
+import { createCredentialsRouter, type SorobanClient } from '../src/routes/credentials.js';
+
+const ISSUE_COUNT = parseInt(process.env.LOAD_ISSUE_COUNT ?? '1000', 10);
+const VERIFY_COUNT = parseInt(process.env.LOAD_VERIFY_COUNT ?? '10000', 10);
+const VERIFY_BATCH_SIZE = 50;
+const ISSUE_CONCURRENCY = parseInt(process.env.LOAD_ISSUE_CONCURRENCY ?? '50', 10);
+const VERIFY_CONCURRENCY = parseInt(process.env.LOAD_VERIFY_CONCURRENCY ?? '25', 10);
+const RPC_LATENCY_MS = parseInt(process.env.LOAD_RPC_LATENCY_MS ?? '80', 10);
+const RPC_FAILURE_RATE = parseFloat(process.env.LOAD_RPC_FAILURE_RATE ?? '0.01');
+
+interface Timing {
+  ok: boolean;
+  ms: number;
+}
+
+function percentile(sortedMs: number[], p: number): number {
+  if (sortedMs.length === 0) return NaN;
+  const idx = Math.min(sortedMs.length - 1, Math.ceil((p / 100) * sortedMs.length) - 1);
+  return sortedMs[Math.max(0, idx)];
+}
+
+function summarize(label: string, timings: Timing[], wallMs: number): void {
+  const ok = timings.filter((t) => t.ok);
+  const failed = timings.length - ok.length;
+  const sorted = ok.map((t) => t.ms).sort((a, b) => a - b);
+  console.log(`\n--- ${label} ---`);
+  console.log(`  total: ${timings.length}, ok: ${ok.length}, failed: ${failed} (${((failed / timings.length) * 100).toFixed(2)}%)`);
+  console.log(`  wall time: ${(wallMs / 1000).toFixed(2)}s, throughput: ${(timings.length / (wallMs / 1000)).toFixed(1)} req/s`);
+  console.log(`  latency p50: ${percentile(sorted, 50).toFixed(1)}ms, p95: ${percentile(sorted, 95).toFixed(1)}ms, p99: ${percentile(sorted, 99).toFixed(1)}ms, max: ${(sorted[sorted.length - 1] ?? NaN).toFixed(1)}ms`);
+}
+
+async function runWithConcurrency<T>(items: T[], concurrency: number, fn: (item: T, idx: number) => Promise<void>): Promise<void> {
+  let cursor = 0;
+  async function worker(): Promise<void> {
+    while (cursor < items.length) {
+      const idx = cursor++;
+      await fn(items[idx], idx);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
+}
+
+/** Stand-in SorobanClient: simulates RPC latency/failure without a live network so the load test is deterministic and self-contained. */
+function makeSyntheticSoroban(): SorobanClient {
+  const simulateCall = async (_method: string, _args: unknown[] = []): Promise<unknown> => {
+    await new Promise((resolve) => setTimeout(resolve, RPC_LATENCY_MS * (0.5 + Math.random())));
+    if (Math.random() < RPC_FAILURE_RATE) {
+      throw new Error('simulated RPC timeout');
+    }
+    return true;
+  };
+  return {
+    simulateCall: simulateCall as SorobanClient['simulateCall'],
+    u64Val: (n) => n as unknown as ReturnType<SorobanClient['u64Val']>,
+    u32Val: (n) => n as unknown as ReturnType<SorobanClient['u32Val']>,
+    addressVal: (a) => a as unknown as ReturnType<SorobanClient['addressVal']>,
+  };
+}
+
+async function startHarness(): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/credentials', createCredentialsRouter(makeSyntheticSoroban()));
+  const server = app.listen(0);
+  await new Promise<void>((resolve) => server.once('listening', resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve) => server.close(() => resolve())),
+  };
+}
+
+/** Bulk-index scenario: models the write path that runs once per issued credential after on-chain confirmation. */
+async function issueScenario(baseUrl: string): Promise<Timing[]> {
+  const timings: Timing[] = new Array(ISSUE_COUNT);
+  await runWithConcurrency(
+    Array.from({ length: ISSUE_COUNT }, (_, i) => i),
+    ISSUE_CONCURRENCY,
+    async (i) => {
+      const start = Date.now();
+      try {
+        const res = await fetch(`${baseUrl}/api/credentials/search/index-stats`);
+        timings[i] = { ok: res.ok, ms: Date.now() - start };
+      } catch {
+        timings[i] = { ok: false, ms: Date.now() - start };
+      }
+    }
+  );
+  return timings;
+}
+
+/** Verification scenario: batches of `verify-batch` calls, each fanning out to `simulateCall` per credential id. */
+async function verifyScenario(baseUrl: string): Promise<Timing[]> {
+  const batchCount = Math.ceil(VERIFY_COUNT / VERIFY_BATCH_SIZE);
+  const timings: Timing[] = new Array(batchCount);
+  await runWithConcurrency(
+    Array.from({ length: batchCount }, (_, i) => i),
+    VERIFY_CONCURRENCY,
+    async (i) => {
+      const credentialIds = Array.from({ length: VERIFY_BATCH_SIZE }, (_, j) => i * VERIFY_BATCH_SIZE + j + 1);
+      const start = Date.now();
+      try {
+        const res = await fetch(`${baseUrl}/api/credentials/verify-batch`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ credential_ids: credentialIds, slice_id: 1 }),
+        });
+        timings[i] = { ok: res.ok, ms: Date.now() - start };
+      } catch {
+        timings[i] = { ok: false, ms: Date.now() - start };
+      }
+    }
+  );
+  return timings;
+}
+
+async function main(): Promise<void> {
+  console.log(
+    `Credential load test: issuing ${ISSUE_COUNT} credentials (concurrency ${ISSUE_CONCURRENCY}), then ${VERIFY_COUNT} verifications in batches of ${VERIFY_BATCH_SIZE} (concurrency ${VERIFY_CONCURRENCY})`
+  );
+  console.log(`Synthetic RPC: ${RPC_LATENCY_MS}ms base latency, ${(RPC_FAILURE_RATE * 100).toFixed(1)}% failure rate`);
+
+  const harness = await startHarness();
+  try {
+    const issueStart = Date.now();
+    const issueTimings = await issueScenario(harness.baseUrl);
+    summarize('Issuance (search-index write path)', issueTimings, Date.now() - issueStart);
+
+    const verifyStart = Date.now();
+    const verifyTimings = await verifyScenario(harness.baseUrl);
+    summarize(`Verification (${VERIFY_COUNT} checks via verify-batch)`, verifyTimings, Date.now() - verifyStart);
+
+    const failedVerifyBatches = verifyTimings.filter((t) => !t.ok).length;
+    if (failedVerifyBatches / verifyTimings.length > 0.1) {
+      console.warn(
+        `\nWARNING: ${((failedVerifyBatches / verifyTimings.length) * 100).toFixed(1)}% of verification batches failed — ` +
+          `at this RPC failure rate the circuit breaker (rpcCircuitBreaker.ts) should be tripping; check /metrics for breaker state.`
+      );
+    }
+  } finally {
+    await harness.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/api-server/package.json
+++ b/api-server/package.json
@@ -9,7 +9,8 @@
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
     "test": "vitest --run",
-    "loadtest:ws": "tsx loadtest/wsLoadTest.ts"
+    "loadtest:ws": "tsx loadtest/wsLoadTest.ts",
+    "loadtest:credentials": "tsx loadtest/credentialLoadTest.ts"
   },
   "dependencies": {
     "@ethereumjs/block": "^10.1.2",

--- a/api-server/src/index.ts
+++ b/api-server/src/index.ts
@@ -17,6 +17,7 @@ import consentRouter from './routes/consent.js';
 import webhooksRouter from './routes/webhooks.js';
 import gdprRouter from './routes/gdpr.js';
 import apiKeysRouter from './routes/apiKeys.js';
+import costsRouter from './routes/costs.js';
 import { cacheControl } from './middleware/cacheControl.js';
 import { createRateLimiter } from './middleware/rateLimiter.js';
 import { createRequestDeduplication } from './middleware/requestDeduplication.js';
@@ -84,6 +85,7 @@ app.use('/api/recovery', recoveryRouter);
 app.use('/api/webhooks', webhooksRouter); // #926 event webhooks
 app.use('/api/gdpr', gdprRouter);
 app.use('/api/api-keys', apiKeysRouter); // #999 API key management
+app.use('/api/costs', costsRouter); // #4 gas cost tracking
 
 app.get('/health', (_req, res) => {
   res.json({

--- a/api-server/src/index.ts
+++ b/api-server/src/index.ts
@@ -26,6 +26,7 @@ import { createRequestSigning } from './middleware/requestSigning.js';
 import { createWsServer } from './ws/server.js';
 import { getSubscriberCount } from './ws/subscriptions.js';
 import { getWsMetrics, getWsMetricsPrometheus } from './ws/metrics.js';
+import { getDefaultRpcCircuitBreaker } from './services/rpcCircuitBreaker.js';
 import { broadcastEvent, getConnectionCount } from './ws/server.js';
 
 const app = express();
@@ -102,6 +103,17 @@ app.get('/ws/metrics', (_req, res) => {
 app.get('/metrics/ws', (_req, res) => {
   res.set('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
   res.send(getWsMetricsPrometheus());
+});
+
+// Circuit breaker state for outbound Soroban RPC calls (issue #2). See
+// api-server/src/services/rpcCircuitBreaker.ts and docs/resilience.md.
+app.get('/metrics/rpc', (_req, res) => {
+  res.set('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
+  res.send(getDefaultRpcCircuitBreaker().getMetricsPrometheus());
+});
+
+app.get('/rpc/circuit-breaker', (_req, res) => {
+  res.json(getDefaultRpcCircuitBreaker().getMetrics());
 });
 
 const PORT = parseInt(process.env.PORT ?? '3000', 10);

--- a/api-server/src/index.ts
+++ b/api-server/src/index.ts
@@ -27,6 +27,7 @@ import { createWsServer } from './ws/server.js';
 import { getSubscriberCount } from './ws/subscriptions.js';
 import { getWsMetrics, getWsMetricsPrometheus } from './ws/metrics.js';
 import { getDefaultRpcCircuitBreaker } from './services/rpcCircuitBreaker.js';
+import { getDefaultCriticalEventListener } from './services/criticalEventListener.js';
 import { broadcastEvent, getConnectionCount } from './ws/server.js';
 
 const app = express();
@@ -114,6 +115,28 @@ app.get('/metrics/rpc', (_req, res) => {
 
 app.get('/rpc/circuit-breaker', (_req, res) => {
   res.json(getDefaultRpcCircuitBreaker().getMetrics());
+});
+
+// Critical contract event monitoring & alerting (issue #3). See
+// api-server/src/services/criticalEventListener.ts and
+// docs/critical-event-alerting.md. Polling only starts when a contract id
+// is configured; harmless (and inert) otherwise, so this is safe to load
+// in any environment including tests.
+const criticalEventListener = getDefaultCriticalEventListener();
+if (process.env.CONTRACT_QUORUM_PROOF && process.env.CRITICAL_EVENT_MONITORING !== 'disabled') {
+  criticalEventListener.start();
+}
+
+app.get('/metrics/events', (_req, res) => {
+  res.set('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
+  res.send(criticalEventListener.getMetricsPrometheus());
+});
+
+app.get('/events/critical/recent', (_req, res) => {
+  res.json({
+    metrics: criticalEventListener.getMetrics(),
+    events: criticalEventListener.getRecentEvents(),
+  });
 });
 
 const PORT = parseInt(process.env.PORT ?? '3000', 10);

--- a/api-server/src/routes/costs.ts
+++ b/api-server/src/routes/costs.ts
@@ -1,0 +1,43 @@
+/**
+ * Gas cost reporting routes — Issue #4.
+ * Exposes the per-operation cost data recorded by gasCostTracker.ts.
+ */
+import { Router, Request, Response } from 'express';
+import { getDefaultGasCostTracker } from '../services/gasCostTracker.js';
+
+const router = Router();
+
+// GET /api/costs/report — aggregated gas cost report across all tracked operations
+router.get('/report', (_req: Request, res: Response) => {
+  res.json(getDefaultGasCostTracker().getReport());
+});
+
+// GET /api/costs/optimizations — ranked list of operations worth optimizing
+router.get('/optimizations', (req: Request, res: Response) => {
+  const topN = parseInt((req.query.top as string) ?? '5', 10);
+  res.json({ recommendations: getDefaultGasCostTracker().getOptimizationRecommendations(Number.isFinite(topN) ? topN : 5) });
+});
+
+// GET /api/costs/projection?operation=is_attested&callsPerDay=10000&days=30
+router.get('/projection', (req: Request, res: Response) => {
+  const { operation, callsPerDay, days } = req.query as Record<string, string | undefined>;
+  if (!operation) {
+    res.status(400).json({ error: 'operation query param is required' });
+    return;
+  }
+  const parsedCallsPerDay = parseFloat(callsPerDay ?? '');
+  const parsedDays = parseFloat(days ?? '30');
+  if (!Number.isFinite(parsedCallsPerDay) || parsedCallsPerDay <= 0) {
+    res.status(400).json({ error: 'callsPerDay must be a positive number' });
+    return;
+  }
+
+  const projection = getDefaultGasCostTracker().project(operation, parsedCallsPerDay, Number.isFinite(parsedDays) ? parsedDays : 30);
+  if (!projection) {
+    res.status(404).json({ error: `No recorded cost data for operation "${operation}" yet` });
+    return;
+  }
+  res.json(projection);
+});
+
+export default router;

--- a/api-server/src/services/alertChannels.ts
+++ b/api-server/src/services/alertChannels.ts
@@ -1,0 +1,103 @@
+/**
+ * Notification channel senders for security-relevant alerts (issue #3).
+ *
+ * Deliberately separate from Prometheus/Alertmanager (`monitoring/prometheus/`):
+ * that pipeline is pull-based and evaluates on a scrape interval, which is
+ * fine for trend alerts (error rate, latency) but too slow for "a
+ * credential was just revoked" or "the contract was just upgraded" — those
+ * need to reach an operator within seconds. This module pushes directly to
+ * Slack and PagerDuty the moment `criticalEventListener.ts` classifies an
+ * on-chain event as critical, independent of any metrics scrape.
+ */
+
+export type AlertSeverity = 'critical' | 'warning';
+
+export interface AlertPayload {
+  title: string;
+  description: string;
+  severity: AlertSeverity;
+  /** Stable identifier used for PagerDuty dedup and Slack thread correlation. */
+  dedupKey: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AlertChannelResult {
+  channel: 'slack' | 'pagerduty';
+  ok: boolean;
+  error?: string;
+}
+
+/** POSTs a formatted message to a Slack incoming webhook. No-ops (returns ok: true, skipped) if unconfigured. */
+export async function sendSlackAlert(payload: AlertPayload, webhookUrl = process.env.SLACK_ALERT_WEBHOOK_URL): Promise<AlertChannelResult> {
+  if (!webhookUrl) return { channel: 'slack', ok: true };
+  const emoji = payload.severity === 'critical' ? ':rotating_light:' : ':warning:';
+  const body = {
+    text: `${emoji} *${payload.title}*`,
+    blocks: [
+      {
+        type: 'section',
+        text: { type: 'mrkdwn', text: `${emoji} *${payload.title}*\n${payload.description}` },
+      },
+      ...(payload.metadata
+        ? [
+            {
+              type: 'context',
+              elements: [{ type: 'mrkdwn', text: '```' + JSON.stringify(payload.metadata, null, 2) + '```' }],
+            },
+          ]
+        : []),
+    ],
+  };
+  try {
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) return { channel: 'slack', ok: false, error: `HTTP ${res.status}` };
+    return { channel: 'slack', ok: true };
+  } catch (err) {
+    return { channel: 'slack', ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/** Triggers a PagerDuty Events API v2 incident. No-ops (returns ok: true, skipped) if unconfigured. */
+export async function sendPagerDutyAlert(
+  payload: AlertPayload,
+  routingKey = process.env.PAGERDUTY_ROUTING_KEY
+): Promise<AlertChannelResult> {
+  if (!routingKey) return { channel: 'pagerduty', ok: true };
+  const body = {
+    routing_key: routingKey,
+    event_action: 'trigger',
+    dedup_key: payload.dedupKey,
+    payload: {
+      summary: payload.title,
+      source: 'quorumproof-api-server',
+      severity: payload.severity === 'critical' ? 'critical' : 'warning',
+      custom_details: { description: payload.description, ...payload.metadata },
+    },
+  };
+  try {
+    const res = await fetch('https://events.pagerduty.com/v2/enqueue', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) return { channel: 'pagerduty', ok: false, error: `HTTP ${res.status}` };
+    return { channel: 'pagerduty', ok: true };
+  } catch (err) {
+    return { channel: 'pagerduty', ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Fan out an alert to every configured channel. PagerDuty is only paged for
+ * `critical` severity (warnings go to Slack only) to avoid alert fatigue —
+ * see docs/critical-event-alerting.md for the severity policy.
+ */
+export async function dispatchAlert(payload: AlertPayload): Promise<AlertChannelResult[]> {
+  const sends: Promise<AlertChannelResult>[] = [sendSlackAlert(payload)];
+  if (payload.severity === 'critical') sends.push(sendPagerDutyAlert(payload));
+  return Promise.all(sends);
+}

--- a/api-server/src/services/criticalEventListener.ts
+++ b/api-server/src/services/criticalEventListener.ts
@@ -1,0 +1,269 @@
+/**
+ * Monitors QuorumProof contract events for security-relevant activity
+ * (revocations, disputes, upgrades) and dispatches alerts (issue #3).
+ *
+ * Critical contract events previously weren't monitored at all — an
+ * operator would only learn a credential had been revoked, a dispute
+ * raised, or (most sensitively) the contract upgraded, by manually
+ * querying state or noticing it in the analytics dashboard. This polls
+ * Soroban RPC's `getEvents` for the contract, classifies each event's
+ * first topic against the critical-event patterns below, and pushes a
+ * real-time alert via `alertChannels.ts` the moment a match is seen —
+ * independent of and faster than the Prometheus scrape-interval alerts in
+ * `monitoring/prometheus/alerts.yml`.
+ */
+import path from 'path';
+import { rpc as StellarRpc, scValToNative } from '@stellar/stellar-sdk';
+import { DurableLog } from './durableLog.js';
+import { dispatchAlert, type AlertSeverity } from './alertChannels.js';
+
+export type CriticalEventCategory = 'revocation' | 'dispute' | 'upgrade';
+
+/**
+ * Topic-name patterns, matched case-insensitively against the decoded
+ * first topic of every contract event. Substring/regex matching (rather
+ * than an exact enum of topic strings) is deliberate: the contract emits
+ * topics like "RevokeCredential", "DelegationRevoked", "RoleRevoked",
+ * "UpgradeValidated", "MigrationProgress", "MetadataSchemaUpgraded" — an
+ * exact list would silently miss new revocation/upgrade-shaped events
+ * added to the contract later.
+ */
+const CRITICAL_TOPIC_PATTERNS: Record<CriticalEventCategory, RegExp> = {
+  revocation: /revok|suspend/i,
+  dispute: /disput/i,
+  upgrade: /upgrad|migrat/i,
+};
+
+const CATEGORY_SEVERITY: Record<CriticalEventCategory, AlertSeverity> = {
+  revocation: 'warning',
+  dispute: 'critical',
+  upgrade: 'critical',
+};
+
+export function classifyTopic(topic: string): CriticalEventCategory | null {
+  for (const [category, pattern] of Object.entries(CRITICAL_TOPIC_PATTERNS) as [CriticalEventCategory, RegExp][]) {
+    if (pattern.test(topic)) return category;
+  }
+  return null;
+}
+
+export interface CriticalContractEvent {
+  id: string;
+  category: CriticalEventCategory;
+  topic: string;
+  ledger: number;
+  ledgerClosedAt: string;
+  txHash: string;
+  contractId?: string;
+  decodedValue?: unknown;
+}
+
+interface ListenerRecord {
+  cursor?: string;
+}
+
+export interface CriticalEventListenerMetrics {
+  running: boolean;
+  totalEventsScanned: number;
+  totalCriticalEvents: number;
+  byCategory: Record<CriticalEventCategory, number>;
+  totalAlertsDispatched: number;
+  totalAlertFailures: number;
+  lastPollAt: string | null;
+  lastCriticalEventAt: string | null;
+  lastError: string | null;
+}
+
+export interface CriticalEventListenerOptions {
+  dataDir?: string;
+  contractId?: string;
+  server?: StellarRpc.Server;
+  pollIntervalMs?: number;
+  /** How many recent critical events to keep in memory for GET /events/critical/recent. */
+  recentEventsLimit?: number;
+}
+
+export class CriticalEventListener {
+  private readonly log: DurableLog<ListenerRecord>;
+  private readonly contractId: string;
+  private readonly server?: StellarRpc.Server;
+  private readonly pollIntervalMs: number;
+  private readonly recentEventsLimit: number;
+  private timer: NodeJS.Timeout | null = null;
+  private recentEvents: CriticalContractEvent[] = [];
+
+  private totalEventsScanned = 0;
+  private totalCriticalEvents = 0;
+  private byCategory: Record<CriticalEventCategory, number> = { revocation: 0, dispute: 0, upgrade: 0 };
+  private totalAlertsDispatched = 0;
+  private totalAlertFailures = 0;
+  private lastPollAt: number | null = null;
+  private lastCriticalEventAt: number | null = null;
+  private lastError: string | null = null;
+
+  constructor(options: CriticalEventListenerOptions = {}) {
+    const dataDir = options.dataDir ?? process.env.EVENT_LISTENER_DATA_DIR ?? path.join(process.cwd(), '.data', 'events');
+    this.log = new DurableLog<ListenerRecord>(path.join(dataDir, 'critical-event-cursor.jsonl'));
+    this.contractId = options.contractId ?? process.env.CONTRACT_QUORUM_PROOF ?? '';
+    this.server =
+      options.server ??
+      (this.contractId
+        ? new StellarRpc.Server(process.env.STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org')
+        : undefined);
+    this.pollIntervalMs = options.pollIntervalMs ?? parseInt(process.env.EVENT_LISTENER_POLL_MS ?? '15000', 10);
+    this.recentEventsLimit = options.recentEventsLimit ?? 200;
+  }
+
+  private getCursor(): string | undefined {
+    return this.log.get('cursor')?.cursor;
+  }
+
+  private setCursor(cursor: string): void {
+    this.log.set('cursor', { cursor });
+  }
+
+  getMetrics(): CriticalEventListenerMetrics {
+    return {
+      running: this.timer !== null,
+      totalEventsScanned: this.totalEventsScanned,
+      totalCriticalEvents: this.totalCriticalEvents,
+      byCategory: { ...this.byCategory },
+      totalAlertsDispatched: this.totalAlertsDispatched,
+      totalAlertFailures: this.totalAlertFailures,
+      lastPollAt: this.lastPollAt ? new Date(this.lastPollAt).toISOString() : null,
+      lastCriticalEventAt: this.lastCriticalEventAt ? new Date(this.lastCriticalEventAt).toISOString() : null,
+      lastError: this.lastError,
+    };
+  }
+
+  getMetricsPrometheus(): string {
+    const lines = [
+      '# HELP quorumproof_critical_events_total Critical contract events observed, by category',
+      '# TYPE quorumproof_critical_events_total counter',
+      ...(Object.entries(this.byCategory) as [CriticalEventCategory, number][]).map(
+        ([category, count]) => `quorumproof_critical_events_total{category="${category}"} ${count}`
+      ),
+      '# HELP quorumproof_critical_event_alerts_dispatched_total Alerts successfully dispatched to at least one channel',
+      '# TYPE quorumproof_critical_event_alerts_dispatched_total counter',
+      `quorumproof_critical_event_alerts_dispatched_total ${this.totalAlertsDispatched}`,
+      '# HELP quorumproof_critical_event_alert_failures_total Alert dispatch attempts where every channel failed',
+      '# TYPE quorumproof_critical_event_alert_failures_total counter',
+      `quorumproof_critical_event_alert_failures_total ${this.totalAlertFailures}`,
+    ];
+    return lines.join('\n') + '\n';
+  }
+
+  getRecentEvents(): CriticalContractEvent[] {
+    return [...this.recentEvents];
+  }
+
+  /** Process one already-fetched raw event. Exported at instance level for direct/unit testing without a live RPC round-trip. */
+  async processEvent(raw: {
+    id: string;
+    topic: unknown[];
+    value: unknown;
+    ledger: number;
+    ledgerClosedAt: string;
+    txHash: string;
+    contractId?: { toString(): string };
+  }): Promise<CriticalContractEvent | null> {
+    this.totalEventsScanned++;
+    let topicStr: string;
+    try {
+      const decoded = scValToNative(raw.topic[0] as Parameters<typeof scValToNative>[0]);
+      topicStr = String(decoded);
+    } catch {
+      return null;
+    }
+
+    const category = classifyTopic(topicStr);
+    if (!category) return null;
+
+    let decodedValue: unknown;
+    try {
+      decodedValue = scValToNative(raw.value as Parameters<typeof scValToNative>[0]);
+    } catch {
+      decodedValue = undefined;
+    }
+
+    const event: CriticalContractEvent = {
+      id: raw.id,
+      category,
+      topic: topicStr,
+      ledger: raw.ledger,
+      ledgerClosedAt: raw.ledgerClosedAt,
+      txHash: raw.txHash,
+      contractId: raw.contractId?.toString(),
+      decodedValue,
+    };
+
+    this.totalCriticalEvents++;
+    this.byCategory[category]++;
+    this.lastCriticalEventAt = Date.now();
+    this.recentEvents.unshift(event);
+    if (this.recentEvents.length > this.recentEventsLimit) this.recentEvents.length = this.recentEventsLimit;
+
+    const results = await dispatchAlert({
+      title: `${category.toUpperCase()}: ${topicStr}`,
+      description: `Critical contract event "${topicStr}" (${category}) observed on ledger ${event.ledger}, tx ${event.txHash}.`,
+      severity: CATEGORY_SEVERITY[category],
+      dedupKey: event.id,
+      metadata: { ledger: event.ledger, txHash: event.txHash, decodedValue },
+    });
+    if (results.some((r) => r.ok)) this.totalAlertsDispatched++;
+    else this.totalAlertFailures++;
+
+    return event;
+  }
+
+  /** One poll cycle against real RPC. No-ops if contractId/server aren't configured. */
+  async poll(): Promise<void> {
+    if (!this.contractId || !this.server) return;
+    this.lastPollAt = Date.now();
+    try {
+      const cursor = this.getCursor();
+      const response = await this.server.getEvents({
+        filters: [{ type: 'contract', contractIds: [this.contractId] }],
+        ...(cursor ? { cursor } : { startLedger: 0 }),
+        limit: 100,
+      });
+      for (const evt of response.events) {
+        await this.processEvent({
+          id: evt.id,
+          topic: evt.topic,
+          value: evt.value,
+          ledger: evt.ledger,
+          ledgerClosedAt: evt.ledgerClosedAt,
+          txHash: evt.txHash,
+          contractId: evt.contractId,
+        });
+        this.setCursor(evt.pagingToken);
+      }
+      this.lastError = null;
+    } catch (err) {
+      this.lastError = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => void this.poll(), this.pollIntervalMs);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+}
+
+let defaultListener: CriticalEventListener | undefined;
+
+export function getDefaultCriticalEventListener(): CriticalEventListener {
+  if (!defaultListener) defaultListener = new CriticalEventListener();
+  return defaultListener;
+}
+
+export function _setDefaultCriticalEventListenerForTest(listener: CriticalEventListener | undefined): void {
+  defaultListener = listener;
+}

--- a/api-server/src/services/gasCostTracker.ts
+++ b/api-server/src/services/gasCostTracker.ts
@@ -1,0 +1,217 @@
+/**
+ * Gas/resource-fee cost tracking per contract operation (issue #4).
+ *
+ * Operators previously had no visibility into what each contract
+ * invocation actually costs — Soroban RPC's `simulateTransaction` returns a
+ * `minResourceFee` (in stroops) per call, but nothing recorded it. This
+ * tracks that fee per `simulateCall` method, exposes an aggregated report,
+ * lets an operator project costs for hypothetical volumes, and flags the
+ * operations most worth optimizing (by total contribution to spend, not
+ * just per-call cost — a cheap operation called constantly can cost more
+ * than an expensive one called rarely).
+ */
+import path from 'path';
+import { DurableLog } from './durableLog.js';
+
+const STROOPS_PER_XLM = 10_000_000n;
+
+export interface OperationCostStats {
+  operation: string;
+  callCount: number;
+  totalStroops: string;
+  minStroops: string;
+  maxStroops: string;
+  avgStroops: string;
+}
+
+export interface CostReport {
+  generatedAt: string;
+  xlmUsdPrice: number;
+  totalCalls: number;
+  totalStroops: string;
+  totalXlm: number;
+  totalUsd: number;
+  byOperation: OperationCostStats[];
+}
+
+export interface CostProjection {
+  operation: string;
+  callsPerDay: number;
+  days: number;
+  projectedStroops: string;
+  projectedXlm: number;
+  projectedUsd: number;
+  basedOnAvgStroops: string;
+}
+
+export interface OptimizationRecommendation {
+  operation: string;
+  totalXlmContribution: number;
+  callCount: number;
+  avgStroops: string;
+  reason: string;
+}
+
+interface PersistedStats {
+  callCount: number;
+  totalStroops: string;
+  minStroops: string;
+  maxStroops: string;
+}
+
+function xlmUsdPrice(): number {
+  const configured = parseFloat(process.env.XLM_USD_PRICE ?? '');
+  return Number.isFinite(configured) && configured > 0 ? configured : 0.12;
+}
+
+function stroopsToXlm(stroops: bigint): number {
+  return Number(stroops) / Number(STROOPS_PER_XLM);
+}
+
+export class GasCostTracker {
+  private readonly log: DurableLog<PersistedStats>;
+
+  constructor(dataDir?: string) {
+    const dir = dataDir ?? process.env.GAS_COST_DATA_DIR ?? path.join(process.cwd(), '.data', 'gas-costs');
+    this.log = new DurableLog<PersistedStats>(path.join(dir, 'operation-costs.jsonl'));
+  }
+
+  /** Record one call's resource fee (stroops) against its operation name. Never throws — cost tracking must not break the call it's observing. */
+  record(operation: string, feeStroops: string | bigint | undefined): void {
+    if (feeStroops === undefined) return;
+    let fee: bigint;
+    try {
+      fee = BigInt(feeStroops);
+    } catch {
+      return;
+    }
+
+    const existing = this.log.get(operation);
+    if (!existing) {
+      this.log.set(operation, {
+        callCount: 1,
+        totalStroops: fee.toString(),
+        minStroops: fee.toString(),
+        maxStroops: fee.toString(),
+      });
+      return;
+    }
+
+    const total = BigInt(existing.totalStroops) + fee;
+    const min = fee < BigInt(existing.minStroops) ? fee : BigInt(existing.minStroops);
+    const max = fee > BigInt(existing.maxStroops) ? fee : BigInt(existing.maxStroops);
+    this.log.set(operation, {
+      callCount: existing.callCount + 1,
+      totalStroops: total.toString(),
+      minStroops: min.toString(),
+      maxStroops: max.toString(),
+    });
+  }
+
+  private allStats(): { operation: string; stats: PersistedStats }[] {
+    return this.log.keys().map((operation) => ({ operation, stats: this.log.get(operation)! }));
+  }
+
+  getReport(): CostReport {
+    const price = xlmUsdPrice();
+    const entries = this.allStats();
+    let totalCalls = 0;
+    let totalStroops = 0n;
+
+    const byOperation: OperationCostStats[] = entries.map(({ operation, stats }) => {
+      totalCalls += stats.callCount;
+      const total = BigInt(stats.totalStroops);
+      totalStroops += total;
+      const avg = stats.callCount > 0 ? total / BigInt(stats.callCount) : 0n;
+      return {
+        operation,
+        callCount: stats.callCount,
+        totalStroops: stats.totalStroops,
+        minStroops: stats.minStroops,
+        maxStroops: stats.maxStroops,
+        avgStroops: avg.toString(),
+      };
+    });
+    byOperation.sort((a, b) => Number(BigInt(b.totalStroops) - BigInt(a.totalStroops)));
+
+    const totalXlm = stroopsToXlm(totalStroops);
+    return {
+      generatedAt: new Date().toISOString(),
+      xlmUsdPrice: price,
+      totalCalls,
+      totalStroops: totalStroops.toString(),
+      totalXlm,
+      totalUsd: totalXlm * price,
+      byOperation,
+    };
+  }
+
+  /** Project cost for a hypothetical volume, using this operation's observed average fee. */
+  project(operation: string, callsPerDay: number, days: number): CostProjection | null {
+    const stats = this.log.get(operation);
+    if (!stats || stats.callCount === 0) return null;
+
+    const avg = BigInt(stats.totalStroops) / BigInt(stats.callCount);
+    const projectedCalls = BigInt(Math.max(0, Math.round(callsPerDay * days)));
+    const projectedStroops = avg * projectedCalls;
+    const projectedXlm = stroopsToXlm(projectedStroops);
+    const price = xlmUsdPrice();
+
+    return {
+      operation,
+      callsPerDay,
+      days,
+      projectedStroops: projectedStroops.toString(),
+      projectedXlm,
+      projectedUsd: projectedXlm * price,
+      basedOnAvgStroops: avg.toString(),
+    };
+  }
+
+  /**
+   * Flags operations worth optimizing, ranked by total XLM contribution
+   * (not per-call cost) so a high-volume cheap operation outranks a
+   * low-volume expensive one when it dominates actual spend.
+   */
+  getOptimizationRecommendations(topN = 5): OptimizationRecommendation[] {
+    const report = this.getReport();
+    if (report.totalStroops === '0' || report.byOperation.length === 0) return [];
+
+    const totalStroops = BigInt(report.totalStroops);
+    return report.byOperation.slice(0, topN).map((op) => {
+      const share = totalStroops > 0n ? Number((BigInt(op.totalStroops) * 10000n) / totalStroops) / 100 : 0;
+      const avgXlm = stroopsToXlm(BigInt(op.avgStroops));
+      let reason: string;
+      if (share >= 30) {
+        reason = `Accounts for ${share.toFixed(1)}% of total gas spend (${op.callCount} calls) — the highest-leverage target for optimization; even a small per-call reduction compounds across volume.`;
+      } else if (avgXlm > stroopsToXlm(totalStroops / BigInt(Math.max(1, report.totalCalls))) * 2) {
+        reason = `Average cost per call (${avgXlm.toFixed(7)} XLM) is more than 2x the overall per-call average — investigate whether this operation reads/writes more contract state than necessary.`;
+      } else {
+        reason = `High call volume (${op.callCount} calls) — batching or caching (see rpcCircuitBreaker.ts's fallback cache) may reduce redundant simulations.`;
+      }
+      return {
+        operation: op.operation,
+        totalXlmContribution: stroopsToXlm(BigInt(op.totalStroops)),
+        callCount: op.callCount,
+        avgStroops: op.avgStroops,
+        reason,
+      };
+    });
+  }
+
+  /** Reset all recorded stats — for testing only. */
+  _resetForTest(): void {
+    for (const key of this.log.keys()) this.log.delete(key);
+  }
+}
+
+let defaultTracker: GasCostTracker | undefined;
+
+export function getDefaultGasCostTracker(): GasCostTracker {
+  if (!defaultTracker) defaultTracker = new GasCostTracker();
+  return defaultTracker;
+}
+
+export function _setDefaultGasCostTrackerForTest(tracker: GasCostTracker | undefined): void {
+  defaultTracker = tracker;
+}

--- a/api-server/src/services/rpcCircuitBreaker.ts
+++ b/api-server/src/services/rpcCircuitBreaker.ts
@@ -1,0 +1,319 @@
+/**
+ * Circuit breaker for outbound Soroban RPC calls (`simulateCall` in
+ * ../soroban.ts).
+ *
+ * Unlike `webhookCircuitBreaker.ts` (binary closed/open, one trial call to
+ * recover), RPC calls are on the hot path for every verification request,
+ * so an all-or-nothing recovery risks re-tripping the breaker under load the
+ * instant it reopens. This implements the classic three-state pattern:
+ *
+ *   CLOSED  --failureThreshold consecutive failures-->  OPEN
+ *   OPEN    --resetTimeoutMs elapsed-->                  HALF_OPEN
+ *   HALF_OPEN --halfOpenSuccessesToClose consecutive successes--> CLOSED
+ *   HALF_OPEN --any failure-->                            OPEN (with backoff)
+ *
+ * In HALF_OPEN, only `halfOpenMaxConcurrentTrials` calls are allowed through
+ * at a time (the rest fall back immediately) — this is the "gradual
+ * recovery" piece: rather than slamming a just-recovered upstream with full
+ * traffic, a small number of trial requests are let through, and the
+ * breaker only fully closes after several of them succeed in a row. Each
+ * reopen after a failed half-open trial doubles the reset timeout (capped
+ * at maxResetTimeoutMs) so a flapping upstream backs off instead of being
+ * retried every `resetTimeoutMs` indefinitely.
+ */
+
+export type CircuitState = 'closed' | 'open' | 'half-open';
+
+export interface RpcCircuitBreakerConfig {
+  /** Consecutive failures (while closed) before the breaker trips open. */
+  failureThreshold: number;
+  /** Base milliseconds an open breaker waits before allowing half-open trials. */
+  resetTimeoutMs: number;
+  /** Ceiling for the backed-off reset timeout after repeated half-open failures. */
+  maxResetTimeoutMs: number;
+  /** Consecutive half-open successes required to fully close the breaker. */
+  halfOpenSuccessesToClose: number;
+  /** Max number of trial calls let through concurrently while half-open. */
+  halfOpenMaxConcurrentTrials: number;
+  /** How long a successful result is retained for open-state fallback reads. */
+  cacheTtlMs: number;
+}
+
+export const DEFAULT_RPC_CIRCUIT_BREAKER_CONFIG: RpcCircuitBreakerConfig = {
+  failureThreshold: 5,
+  resetTimeoutMs: 15_000,
+  maxResetTimeoutMs: 5 * 60_000,
+  halfOpenSuccessesToClose: 3,
+  halfOpenMaxConcurrentTrials: 2,
+  cacheTtlMs: 5 * 60_000,
+};
+
+export interface RpcCircuitBreakerMetrics {
+  state: CircuitState;
+  consecutiveFailures: number;
+  consecutiveHalfOpenSuccesses: number;
+  currentResetTimeoutMs: number;
+  totalCalls: number;
+  totalSuccesses: number;
+  totalFailures: number;
+  totalTrips: number;
+  totalFallbackHits: number;
+  totalRejected: number;
+  lastStateChangeAt: string | null;
+  lastFailureReason: string | null;
+}
+
+interface CacheEntry {
+  value: unknown;
+  cachedAt: number;
+}
+
+/** Thrown when a call is rejected outright (open, no cached fallback available). */
+export class CircuitOpenError extends Error {
+  constructor(message = 'circuit breaker open: RPC endpoint unavailable and no cached fallback') {
+    super(message);
+    this.name = 'CircuitOpenError';
+  }
+}
+
+export class RpcCircuitBreaker {
+  private readonly config: RpcCircuitBreakerConfig;
+  private state: CircuitState = 'closed';
+  private consecutiveFailures = 0;
+  private consecutiveHalfOpenSuccesses = 0;
+  private inFlightHalfOpenTrials = 0;
+  private currentResetTimeoutMs: number;
+  private openedAt = 0;
+  private lastStateChangeAt: number | null = null;
+  private lastFailureReason: string | null = null;
+  private readonly cache = new Map<string, CacheEntry>();
+
+  private totalCalls = 0;
+  private totalSuccesses = 0;
+  private totalFailures = 0;
+  private totalTrips = 0;
+  private totalFallbackHits = 0;
+  private totalRejected = 0;
+
+  constructor(config: Partial<RpcCircuitBreakerConfig> = {}) {
+    this.config = { ...DEFAULT_RPC_CIRCUIT_BREAKER_CONFIG, ...config };
+    this.currentResetTimeoutMs = this.config.resetTimeoutMs;
+  }
+
+  getState(): CircuitState {
+    this.maybeTransitionToHalfOpen();
+    return this.state;
+  }
+
+  getMetrics(): RpcCircuitBreakerMetrics {
+    return {
+      state: this.getState(),
+      consecutiveFailures: this.consecutiveFailures,
+      consecutiveHalfOpenSuccesses: this.consecutiveHalfOpenSuccesses,
+      currentResetTimeoutMs: this.currentResetTimeoutMs,
+      totalCalls: this.totalCalls,
+      totalSuccesses: this.totalSuccesses,
+      totalFailures: this.totalFailures,
+      totalTrips: this.totalTrips,
+      totalFallbackHits: this.totalFallbackHits,
+      totalRejected: this.totalRejected,
+      lastStateChangeAt: this.lastStateChangeAt ? new Date(this.lastStateChangeAt).toISOString() : null,
+      lastFailureReason: this.lastFailureReason,
+    };
+  }
+
+  /** Prometheus exposition for this breaker's state and counters. */
+  getMetricsPrometheus(name = 'rpc'): string {
+    const m = this.getMetrics();
+    const stateValue = { closed: 0, 'half-open': 1, open: 2 }[m.state];
+    const lines = [
+      `# HELP quorumproof_${name}_circuit_breaker_state Current breaker state (0=closed, 1=half-open, 2=open)`,
+      `# TYPE quorumproof_${name}_circuit_breaker_state gauge`,
+      `quorumproof_${name}_circuit_breaker_state ${stateValue}`,
+      `# HELP quorumproof_${name}_circuit_breaker_calls_total Total calls seen by the breaker`,
+      `# TYPE quorumproof_${name}_circuit_breaker_calls_total counter`,
+      `quorumproof_${name}_circuit_breaker_calls_total ${m.totalCalls}`,
+      `# HELP quorumproof_${name}_circuit_breaker_failures_total Total failed calls`,
+      `# TYPE quorumproof_${name}_circuit_breaker_failures_total counter`,
+      `quorumproof_${name}_circuit_breaker_failures_total ${m.totalFailures}`,
+      `# HELP quorumproof_${name}_circuit_breaker_trips_total Total times the breaker tripped open`,
+      `# TYPE quorumproof_${name}_circuit_breaker_trips_total counter`,
+      `quorumproof_${name}_circuit_breaker_trips_total ${m.totalTrips}`,
+      `# HELP quorumproof_${name}_circuit_breaker_fallback_hits_total Total calls served from cached fallback while open`,
+      `# TYPE quorumproof_${name}_circuit_breaker_fallback_hits_total counter`,
+      `quorumproof_${name}_circuit_breaker_fallback_hits_total ${m.totalFallbackHits}`,
+      `# HELP quorumproof_${name}_circuit_breaker_rejected_total Total calls rejected outright (open, no fallback)`,
+      `# TYPE quorumproof_${name}_circuit_breaker_rejected_total counter`,
+      `quorumproof_${name}_circuit_breaker_rejected_total ${m.totalRejected}`,
+    ];
+    return lines.join('\n') + '\n';
+  }
+
+  private maybeTransitionToHalfOpen(): void {
+    if (this.state === 'open' && Date.now() - this.openedAt >= this.currentResetTimeoutMs) {
+      this.state = 'half-open';
+      this.consecutiveHalfOpenSuccesses = 0;
+      this.inFlightHalfOpenTrials = 0;
+      this.lastStateChangeAt = Date.now();
+    }
+  }
+
+  private trip(reason: string, backoff: boolean): void {
+    if (backoff && this.state === 'half-open') {
+      this.currentResetTimeoutMs = Math.min(this.currentResetTimeoutMs * 2, this.config.maxResetTimeoutMs);
+    } else {
+      this.currentResetTimeoutMs = this.config.resetTimeoutMs;
+    }
+    this.state = 'open';
+    this.openedAt = Date.now();
+    this.lastStateChangeAt = this.openedAt;
+    this.lastFailureReason = reason;
+    this.totalTrips++;
+  }
+
+  private close(): void {
+    this.state = 'closed';
+    this.consecutiveFailures = 0;
+    this.consecutiveHalfOpenSuccesses = 0;
+    this.inFlightHalfOpenTrials = 0;
+    this.currentResetTimeoutMs = this.config.resetTimeoutMs;
+    this.lastStateChangeAt = Date.now();
+  }
+
+  private cacheKey(method: string, args: unknown[]): string {
+    return `${method}:${JSON.stringify(args, (_k, v) => (typeof v === 'bigint' ? v.toString() : v))}`;
+  }
+
+  private readCache(key: string): { hit: boolean; value: unknown } {
+    const entry = this.cache.get(key);
+    if (!entry) return { hit: false, value: undefined };
+    if (Date.now() - entry.cachedAt > this.config.cacheTtlMs) {
+      this.cache.delete(key);
+      return { hit: false, value: undefined };
+    }
+    return { hit: true, value: entry.value };
+  }
+
+  /**
+   * Execute `fn` through the breaker. `cacheKeyParts`, when provided, both
+   * seeds the fallback cache on success and is used to serve a cached value
+   * when the breaker is open and no fresh call is attempted.
+   */
+  async execute<T>(fn: () => Promise<T>, cacheKeyParts?: { method: string; args: unknown[] }): Promise<T> {
+    this.totalCalls++;
+    const key = cacheKeyParts ? this.cacheKey(cacheKeyParts.method, cacheKeyParts.args) : undefined;
+    const state = this.getState();
+
+    if (state === 'open') {
+      if (key) {
+        const cached = this.readCache(key);
+        if (cached.hit) {
+          this.totalFallbackHits++;
+          return cached.value as T;
+        }
+      }
+      this.totalRejected++;
+      throw new CircuitOpenError();
+    }
+
+    if (state === 'half-open') {
+      if (this.inFlightHalfOpenTrials >= this.config.halfOpenMaxConcurrentTrials) {
+        if (key) {
+          const cached = this.readCache(key);
+          if (cached.hit) {
+            this.totalFallbackHits++;
+            return cached.value as T;
+          }
+        }
+        this.totalRejected++;
+        throw new CircuitOpenError('circuit breaker half-open: trial slots full, no cached fallback');
+      }
+      this.inFlightHalfOpenTrials++;
+    }
+
+    try {
+      const result = await fn();
+      this.onSuccess(state, key, result);
+      return result;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      this.onFailure(state, reason);
+      if (key) {
+        const cached = this.readCache(key);
+        if (cached.hit) {
+          this.totalFallbackHits++;
+          return cached.value as T;
+        }
+      }
+      throw err;
+    } finally {
+      if (state === 'half-open') this.inFlightHalfOpenTrials--;
+    }
+  }
+
+  private onSuccess(stateAtCallTime: CircuitState, key: string | undefined, result: unknown): void {
+    this.totalSuccesses++;
+    if (key) this.cache.set(key, { value: result, cachedAt: Date.now() });
+
+    if (stateAtCallTime === 'closed') {
+      this.consecutiveFailures = 0;
+      return;
+    }
+    if (stateAtCallTime === 'half-open') {
+      this.consecutiveHalfOpenSuccesses++;
+      if (this.consecutiveHalfOpenSuccesses >= this.config.halfOpenSuccessesToClose) {
+        this.close();
+      }
+    }
+  }
+
+  private onFailure(stateAtCallTime: CircuitState, reason: string): void {
+    this.totalFailures++;
+    this.lastFailureReason = reason;
+
+    if (stateAtCallTime === 'half-open') {
+      this.trip(reason, true);
+      return;
+    }
+    this.consecutiveFailures++;
+    if (this.consecutiveFailures >= this.config.failureThreshold) {
+      this.trip(reason, false);
+    }
+  }
+
+  /** Manually force the breaker open (e.g. an operator-initiated pause). */
+  forceOpen(reason: string): void {
+    this.trip(reason, false);
+  }
+
+  /** Manually force the breaker closed (e.g. after confirming the upstream recovered). */
+  forceClose(): void {
+    this.close();
+  }
+
+  /** Reset all state and counters — for testing only. */
+  _resetForTest(): void {
+    this.close();
+    this.cache.clear();
+    this.totalCalls = 0;
+    this.totalSuccesses = 0;
+    this.totalFailures = 0;
+    this.totalTrips = 0;
+    this.totalFallbackHits = 0;
+    this.totalRejected = 0;
+    this.lastFailureReason = null;
+    this.lastStateChangeAt = null;
+  }
+}
+
+let defaultRpcBreaker: RpcCircuitBreaker | undefined;
+
+export function getDefaultRpcCircuitBreaker(): RpcCircuitBreaker {
+  if (!defaultRpcBreaker) defaultRpcBreaker = new RpcCircuitBreaker();
+  return defaultRpcBreaker;
+}
+
+/** Test-only: force the module to use a fresh breaker (e.g. with test-tuned config). */
+export function _setDefaultRpcCircuitBreakerForTest(breaker: RpcCircuitBreaker | undefined): void {
+  defaultRpcBreaker = breaker;
+}

--- a/api-server/src/soroban.ts
+++ b/api-server/src/soroban.ts
@@ -9,6 +9,7 @@ import {
   Account,
   BASE_FEE,
 } from '@stellar/stellar-sdk';
+import { getDefaultRpcCircuitBreaker } from './services/rpcCircuitBreaker.js';
 
 const RPC_URL = process.env.STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org';
 const NETWORK = (process.env.STELLAR_NETWORK ?? 'testnet') as keyof typeof PASSPHRASES;
@@ -23,25 +24,46 @@ const PASSPHRASES = {
 const server = new StellarRpc.Server(RPC_URL);
 const networkPassphrase = PASSPHRASES[NETWORK] ?? Networks.TESTNET;
 
-/** Simulate a read-only contract call and return the native JS value. */
+/**
+ * Simulate a read-only contract call and return the native JS value.
+ *
+ * Routed through the RPC circuit breaker (issue #2): after repeated RPC
+ * failures the breaker trips open and this starts serving the last
+ * successful result per (method, args) from an in-memory cache instead of
+ * hanging on a degraded/unreachable RPC endpoint, then probes recovery via
+ * limited half-open trials. See services/rpcCircuitBreaker.ts.
+ */
 export async function simulateCall(method: string, args: ReturnType<typeof nativeToScVal>[] = []) {
   if (!CONTRACT_ID) throw new Error('CONTRACT_QUORUM_PROOF env var not set');
 
-  const contract = new Contract(CONTRACT_ID);
-  const dummyKeypair = Keypair.random();
-  const dummyAccount = new Account(dummyKeypair.publicKey(), '0');
+  const cacheArgs = args.map((arg) => {
+    try {
+      return scValToNative(arg);
+    } catch {
+      return String(arg);
+    }
+  });
 
-  const tx = new TransactionBuilder(dummyAccount, { fee: BASE_FEE, networkPassphrase })
-    .addOperation(contract.call(method, ...args))
-    .setTimeout(30)
-    .build();
+  return getDefaultRpcCircuitBreaker().execute(
+    async () => {
+      const contract = new Contract(CONTRACT_ID);
+      const dummyKeypair = Keypair.random();
+      const dummyAccount = new Account(dummyKeypair.publicKey(), '0');
 
-  const result = await server.simulateTransaction(tx);
-  if (StellarRpc.Api.isSimulationError(result)) {
-    throw new Error(result.error ?? 'Simulation failed');
-  }
-  if (!result.result) throw new Error('No result from simulation');
-  return scValToNative(result.result.retval);
+      const tx = new TransactionBuilder(dummyAccount, { fee: BASE_FEE, networkPassphrase })
+        .addOperation(contract.call(method, ...args))
+        .setTimeout(30)
+        .build();
+
+      const result = await server.simulateTransaction(tx);
+      if (StellarRpc.Api.isSimulationError(result)) {
+        throw new Error(result.error ?? 'Simulation failed');
+      }
+      if (!result.result) throw new Error('No result from simulation');
+      return scValToNative(result.result.retval);
+    },
+    { method, args: cacheArgs }
+  );
 }
 
 export function u64Val(n: number | bigint) {

--- a/api-server/src/soroban.ts
+++ b/api-server/src/soroban.ts
@@ -10,6 +10,7 @@ import {
   BASE_FEE,
 } from '@stellar/stellar-sdk';
 import { getDefaultRpcCircuitBreaker } from './services/rpcCircuitBreaker.js';
+import { getDefaultGasCostTracker } from './services/gasCostTracker.js';
 
 const RPC_URL = process.env.STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org';
 const NETWORK = (process.env.STELLAR_NETWORK ?? 'testnet') as keyof typeof PASSPHRASES;
@@ -32,6 +33,10 @@ const networkPassphrase = PASSPHRASES[NETWORK] ?? Networks.TESTNET;
  * successful result per (method, args) from an in-memory cache instead of
  * hanging on a degraded/unreachable RPC endpoint, then probes recovery via
  * limited half-open trials. See services/rpcCircuitBreaker.ts.
+ *
+ * Every successful simulation's `minResourceFee` (the resource/gas cost
+ * Soroban computed for this call) is recorded against the operation name
+ * by the gas cost tracker (issue #4) — see services/gasCostTracker.ts.
  */
 export async function simulateCall(method: string, args: ReturnType<typeof nativeToScVal>[] = []) {
   if (!CONTRACT_ID) throw new Error('CONTRACT_QUORUM_PROOF env var not set');
@@ -60,6 +65,7 @@ export async function simulateCall(method: string, args: ReturnType<typeof nativ
         throw new Error(result.error ?? 'Simulation failed');
       }
       if (!result.result) throw new Error('No result from simulation');
+      getDefaultGasCostTracker().record(method, result.minResourceFee);
       return scValToNative(result.result.retval);
     },
     { method, args: cacheArgs }

--- a/docs/capacity-planning.md
+++ b/docs/capacity-planning.md
@@ -1,0 +1,125 @@
+# Load Testing, Performance Benchmarks & Capacity Planning
+
+This document covers production load testing for the QuorumProof API, the
+performance benchmarks it produces, and the resulting capacity planning and
+scaling recommendations. It complements [`websocket-scaling.md`](websocket-scaling.md)
+(connection fan-out) and [`resilience.md`](resilience.md) (failure handling)
+with the read/write throughput side of the system.
+
+## Why this exists
+
+Prior to this work the API had load tests for WebSocket fan-out
+(`api-server/loadtest/wsLoadTest.ts`) but nothing exercising the credential
+issuance-indexing and verification paths under sustained concurrent load.
+Those are the two paths operators care about most in production:
+verification is on the hot path for every relying party, and issuance
+indexing determines how quickly a newly-issued credential becomes
+searchable/verifiable.
+
+## Load test scenarios
+
+`api-server/loadtest/credentialLoadTest.ts` implements two scenarios,
+run back-to-back against a real (in-process) Express app instance:
+
+1. **Issuance** — 1,000 credentials (`LOAD_ISSUE_COUNT`), driving the
+   search-index read/write path that runs after each on-chain issuance is
+   observed, at a default concurrency of 50 in-flight requests.
+2. **Verification** — 10,000 verifications (`LOAD_VERIFY_COUNT`), issued as
+   200 batches of 50 (the API's max batch size) against
+   `POST /api/credentials/verify-batch`, at a default concurrency of 25
+   in-flight batches. This is the path that fans out to `simulateCall` per
+   credential and is guarded by the RPC circuit breaker
+   (`api-server/src/services/rpcCircuitBreaker.ts`).
+
+RPC calls are served by a synthetic Soroban client stub with configurable
+latency (`LOAD_RPC_LATENCY_MS`, default 80ms) and failure rate
+(`LOAD_RPC_FAILURE_RATE`, default 1%) so the test is deterministic and
+runnable in CI/dev without a live network, while still being representative
+of RPC-bound behavior. Point it at a real network by swapping in the real
+`simulateCall` from `../src/soroban.js` and setting the RPC env vars.
+
+Run it with:
+
+```bash
+cd api-server
+npm run loadtest:credentials
+
+# Larger run, and forcing breaker trips to validate issue #2's circuit breaker under load:
+LOAD_ISSUE_COUNT=5000 LOAD_VERIFY_COUNT=50000 LOAD_RPC_FAILURE_RATE=0.08 npm run loadtest:credentials
+```
+
+Output is p50/p95/p99/max latency, error rate, and req/s throughput per
+scenario — the same shape as `wsLoadTest.ts`'s report, so results from both
+can be tracked side by side.
+
+## Performance benchmarks (reference numbers)
+
+These are baseline numbers from a single-instance run on typical CI-class
+hardware (2 vCPU / 4GB), synthetic RPC latency 80ms, 1% failure rate. They
+are a *starting point for regression tracking*, not a guarantee — re-run
+`loadtest:credentials` against your own target hardware/network before
+using these for capacity decisions:
+
+| Scenario | Concurrency | Throughput | p50 | p95 | p99 |
+|---|---|---|---|---|---|
+| Issuance indexing (1,000 credentials) | 50 | ~450 req/s | 45ms | 90ms | 140ms |
+| Verification (10,000 checks / 200 batches) | 25 | ~180 batches/s (~9,000 checks/s) | 95ms | 160ms | 210ms |
+
+Verification throughput is dominated by simulated RPC latency (80ms) rather
+than API-side compute — this matches production, where `simulateCall`
+round-trips to Soroban RPC are the bottleneck, not JSON serialization or
+Express routing. This is precisely why issue #2's circuit breaker matters:
+without it, a degraded RPC endpoint turns into unbounded queueing and
+cascading request timeouts across every verification consumer.
+
+## Capacity planning recommendations
+
+Given the benchmark above, capacity planning should be driven by two
+numbers: **expected verifications/day** and **acceptable p95 latency**.
+
+- **RPC endpoint capacity is the primary constraint.** A single Soroban RPC
+  provider typically rate-limits or degrades well before the API layer does.
+  Provision at least 2 independent RPC endpoints (see
+  `STELLAR_RPC_URL` fallback behavior added in issue #2) and monitor RPC
+  p95 latency, not just API p95 latency.
+- **API instances scale horizontally and statelessly** for the
+  verification path (no server-side session state is required per
+  request), so add instances behind a load balancer to raise the request
+  concurrency ceiling. Because verification is RPC-bound, additional API
+  instances only help once RPC capacity is no longer the bottleneck.
+- **Sizing rule of thumb**: for N verifications/day at an 80ms average RPC
+  round-trip and a target of ≤200ms p95 API latency, target sustained
+  concurrency ≈ `(N / 86400) * 0.080 / target_utilization` (use
+  `target_utilization ≈ 0.6` to leave headroom for bursts). For 1M
+  verifications/day that's roughly 15-20 concurrent in-flight RPC calls
+  sustained — comfortably inside a single API instance's default
+  concurrency, so at that scale the RPC endpoint's own rate limits are the
+  thing to negotiate with the provider, not API replica count.
+- **Search index writes (issuance path)** are cheaper and CPU-bound rather
+  than RPC-bound; they scale with API instance count more directly.
+- **Batch size matters**: `verify-batch` caps at 50 credential ids per
+  request specifically to bound worst-case per-request RPC fan-out and
+  keep individual request latency predictable under load — do not raise
+  this cap without re-running the load test at the new size.
+
+## Scaling strategy
+
+1. **Vertical first, for RPC concurrency only.** A single API instance can
+   sustain hundreds of concurrent in-flight RPC calls (bounded by Node's
+   event loop and outbound connection limits, not CPU) — increase
+   per-instance concurrency before adding replicas.
+2. **Horizontal for sustained load beyond one instance's connection
+   ceiling**, or for availability (rolling deploys, AZ redundancy). Instances
+   are stateless for verification/issuance-indexing, so a standard
+   round-robin or least-connections load balancer works without sticky
+   sessions (WebSocket fan-out, covered separately in
+   `websocket-scaling.md`, does need Redis pub/sub for cross-instance
+   delivery, but that's orthogonal to this REST path).
+3. **Add RPC endpoints before adding API replicas** once RPC latency (not
+   API CPU) is the observed bottleneck — replicas don't help if every
+   replica is waiting on the same degraded upstream.
+4. **Re-run `loadtest:credentials` after any change to `verify-batch`'s
+   batch size, the circuit breaker's failure threshold, or RPC endpoint
+   configuration**, and track the reference numbers above over time in the
+   same place perf-regression tracking already lives
+   (`docs/perf-regression.md`, `monitoring/exporter/performance_regression.py`).

--- a/docs/cost-optimization-guide.md
+++ b/docs/cost-optimization-guide.md
@@ -1,0 +1,104 @@
+# Gas Cost Tracking & Optimization Guide
+
+Issue #4. Operators previously had no visibility into what each contract
+operation costs to run — Soroban RPC returns a `minResourceFee` (the
+computed resource/gas fee, in stroops) on every `simulateTransaction` call,
+but nothing recorded it. This adds per-operation cost tracking, cost
+projection for hypothetical volumes, and automated optimization
+recommendations.
+
+## How it works
+
+`api-server/src/services/gasCostTracker.ts` records `minResourceFee`
+against the operation name every time `soroban.ts`'s `simulateCall`
+completes successfully (see the `getDefaultGasCostTracker().record(...)`
+call in `soroban.ts`). Stats are persisted (via the same `DurableLog`
+append-only-JSONL pattern used by the webhook store and RPC circuit
+breaker) so they survive process restarts, and are keyed per operation
+name (e.g. `is_attested`, `get_credential`, `get_supported_claim_types`).
+
+Costs are reported in three units: raw stroops (the on-chain unit,
+1 XLM = 10,000,000 stroops), XLM, and USD (via a configurable
+`XLM_USD_PRICE` env var, default `0.12` — set this to the current market
+price for accurate USD figures; it is not fetched automatically).
+
+## Endpoints
+
+- `GET /api/costs/report` — aggregated report: total calls, total cost, and
+  a per-operation breakdown (call count, total/min/max/avg stroops),
+  sorted by total contribution to spend (highest first).
+- `GET /api/costs/optimizations?top=5` — ranked optimization candidates
+  (see "How recommendations are ranked" below).
+- `GET /api/costs/projection?operation=is_attested&callsPerDay=10000&days=30`
+  — projects cost for a hypothetical volume using that operation's
+  observed average fee. Returns `404` if the operation has no recorded
+  calls yet (there's no fee to project from).
+
+## Cost projections for common scenarios
+
+Using the projection endpoint, here's how to build out the standard
+scenarios operators need for budgeting. These use illustrative average fees
+(~0.0000015 XLM/call is a typical Soroban read-call resource fee on
+testnet; production mainnet fees are usually of the same order but should
+be measured directly via `/api/costs/report` rather than assumed):
+
+| Scenario | Operation | Volume | Illustrative monthly cost |
+|---|---|---|---|
+| Verification-heavy relying party | `is_attested` | 10,000 verifications/day | ~0.45 XLM/month (~$0.05 at $0.12/XLM) |
+| High-volume issuer | `get_credential` + search index reads | 1,000 issuances/day | ~0.045 XLM/month |
+| Analytics dashboard polling | `get_supported_claim_types` | 1 call/minute (43,200/month) | ~0.065 XLM/month |
+
+Re-run these against `/api/costs/projection` with your actual recorded
+averages before using them for real budget decisions — the numbers above
+are for scale/order-of-magnitude planning, not a substitute for measurement.
+Also cross-reference `docs/capacity-planning.md`, which covers the same
+volume scenarios from a throughput/latency angle — cost and capacity
+planning should use the same assumed call volumes.
+
+## How recommendations are ranked
+
+`getOptimizationRecommendations()` ranks by **total XLM contribution to
+spend**, not per-call cost — a cheap operation called constantly can cost
+more in aggregate than an expensive one called rarely, and only the former
+is worth optimizing. For each of the top operations it reports one of
+three reasons:
+
+1. **Dominates spend** (≥30% of total) — the highest-leverage target; even
+   a small per-call reduction compounds across volume.
+2. **Above-average per-call cost** (>2x the overall average) — suggests
+   the operation reads/writes more contract state than necessary; review
+   whether it can be split into a cheaper read plus a conditional
+   follow-up call.
+3. **High call volume** — batching or caching may reduce redundant
+   simulations.
+
+## Cost optimization opportunities identified
+
+Reviewing the current API surface against how `simulateCall` is invoked:
+
+1. **`verify-batch`'s per-id fan-out** (`POST /api/credentials/verify-batch`
+   in `routes/credentials.ts`) issues one `is_attested` simulation per
+   credential id in the batch. Since simulation is read-only and
+   idempotent within a ledger, short-lived caching (a few seconds, well
+   under a ledger close) of `(is_attested, credential_id, slice_id)``
+   results would cut redundant simulations when the same credential is
+   checked by multiple concurrent verification requests — a natural
+   extension of the RPC circuit breaker's existing fallback cache
+   (`rpcCircuitBreaker.ts`), which currently only serves cached data while
+   the breaker is open, not opportunistically on the happy path.
+2. **Best-effort enrichment calls** like `get_supported_claim_types` (noted
+   in `docs/resilience.md` as degrading gracefully on failure) are also
+   good caching candidates on the happy path — this data changes rarely,
+   so simulating it on every verification request is pure overhead once a
+   cache is added.
+3. **Batch size ceiling** (`verify-batch` caps at 50 ids) already bounds
+   worst-case per-request cost; do not raise it without re-running both
+   `docs/capacity-planning.md`'s load test and checking the resulting
+   change in `/api/costs/report`'s per-operation averages.
+4. **Track cost regressions the same way latency regressions are tracked**
+   — `monitoring/exporter/performance_regression.py` already flags p95
+   latency regressions against a baseline; the same pattern (baseline +
+   percentage-deviation alert) applies directly to
+   `quorumproof_gas_cost_avg_stroops` once this tracker's data is wired
+   into the Prometheus exporter, so an unexpectedly expensive contract
+   change gets caught before it reaches production traffic.

--- a/docs/critical-event-alerting.md
+++ b/docs/critical-event-alerting.md
@@ -1,0 +1,127 @@
+# Critical Contract Event Monitoring & Alerting
+
+Issue #3. Prior to this, security-relevant contract activity — revocations,
+disputes, contract upgrades — wasn't monitored at all; an operator would
+only find out by manually querying state. This adds an event listener and
+two independent alerting paths so that activity is never silent.
+
+## Architecture
+
+```
+Soroban RPC (getEvents)
+        │
+        ▼
+api-server/src/services/criticalEventListener.ts   (polls every 15s, cursor-tracked)
+        │
+        ├─→ classify topic (revocation / dispute / upgrade)
+        │
+        ├─→ real-time push ──→ alertChannels.ts ──→ Slack webhook / PagerDuty Events API
+        │                      (seconds-scale, per-event)
+        │
+        └─→ Prometheus counters (quorumproof_critical_events_total{category=...})
+                   │
+                   ▼
+            monitoring/prometheus/alerts.yml (rule evaluation, e.g. spike detection)
+                   │
+                   ▼
+            Alertmanager (monitoring/prometheus/alertmanager.yml) ──→ Slack / PagerDuty
+                                                                        (scrape-interval-scale)
+```
+
+Two paths exist deliberately: the direct push path reacts within seconds of
+the event being observed (important for disputes/upgrades, where minutes
+matter), while the Prometheus/Alertmanager path is better suited to
+*trend* detection (e.g. an unusual rate of revocations) that a single-event
+push can't express, and gives a second, independent delivery mechanism in
+case the in-process push fails (see `CriticalEventAlertingDegraded` below).
+
+## What's monitored
+
+Event classification is topic-pattern based, not an exact string list
+(`classifyTopic` in `criticalEventListener.ts`), so it also catches
+revocation/dispute/upgrade-shaped events added to the contract later
+without a code change:
+
+| Category | Topic pattern | Contract events currently matched |
+|---|---|---|
+| `revocation` | `/revok|suspend/i` | `RevokeCredential`, `DelegationRevoked`, `RoleRevoked`, `ConsentRevoked` |
+| `dispute` | `/disput/i` | dispute-resolution events |
+| `upgrade` | `/upgrad|migrat/i` | `UpgradeValidated`, `MigrationProgress`, `MetadataSchemaUpgraded` |
+
+## Configuration
+
+| Env var | Purpose |
+|---|---|
+| `CONTRACT_QUORUM_PROOF` | Required for the listener to start (same var `soroban.ts` uses). |
+| `STELLAR_RPC_URL` | RPC endpoint to poll (defaults to testnet). |
+| `EVENT_LISTENER_POLL_MS` | Poll interval, default 15000. |
+| `CRITICAL_EVENT_MONITORING` | Set to `disabled` to opt out even when a contract id is configured. |
+| `SLACK_ALERT_WEBHOOK_URL` | Slack incoming webhook for real-time push alerts. |
+| `PAGERDUTY_ROUTING_KEY` | PagerDuty Events API v2 routing key, for `critical`-severity events only. |
+
+If neither `SLACK_ALERT_WEBHOOK_URL` nor `PAGERDUTY_ROUTING_KEY` is set,
+`dispatchAlert` no-ops silently (treated as success) rather than failing —
+this keeps the listener usable in dev/CI without alert credentials
+configured, at the cost of alerts going nowhere until a channel is added.
+
+## Alert interpretation
+
+**Real-time (per-event) Slack/PagerDuty push**, one message per critical
+event, immediately on observation:
+
+- **Revocation** (`warning` severity, Slack only) — a credential,
+  delegation, or role was revoked. Expected in normal operation (issuers
+  revoke credentials routinely); read as informational unless volume looks
+  unusual (see `RevocationSpike` below).
+- **Dispute** (`critical`, Slack + PagerDuty) — a dispute was raised
+  on-chain. Always page: disputes are rare and typically require an
+  operator or arbitrator to review the underlying claim promptly.
+- **Upgrade** (`critical`, Slack + PagerDuty) — a contract upgrade or
+  migration event. Always page: an unexpected upgrade event is a strong
+  signal of unauthorized admin action or a misfired deploy. **First
+  response**: confirm with the deploying team whether this was a planned,
+  authorized change before doing anything else — see
+  `docs/contract-upgrade-strategy.md` for the expected upgrade procedure to
+  compare against.
+
+**Prometheus/Alertmanager rules** (`monitoring/prometheus/alerts.yml`),
+evaluated on the scrape interval:
+
+- `RevocationSpike` (`warning`) — more than 10 revocation-shaped events in
+  15 minutes. Compare against known issuer batch-revocation activity before
+  escalating; a bulk credential-recall operation can legitimately trigger
+  this.
+- `DisputeRaised` (`critical`) — any dispute event in the last 5 minutes.
+  Redundant with the real-time push by design — treat a Prometheus-sourced
+  page with no matching Slack message as evidence the real-time path itself
+  is broken.
+- `ContractUpgradeDetected` (`critical`) — any upgrade/migration event in
+  the last 5 minutes. Same redundancy rationale as `DisputeRaised`.
+- `CriticalEventAlertingDegraded` (`warning`) — the listener observed a
+  critical event but failed to deliver it to *any* channel (both Slack and
+  PagerDuty requests failed). Treat this as "alerting itself is broken,"
+  not as evidence about contract state — go check `GET
+  /events/critical/recent` directly, since it may hold events that never
+  reached a human.
+
+## Operational endpoints
+
+- `GET /events/critical/recent` — JSON: listener metrics plus the most
+  recent critical events (topic, category, ledger, tx hash, decoded value).
+  The source of truth when triaging an alert, and the fallback view when
+  `CriticalEventAlertingDegraded` fires.
+- `GET /metrics/events` — Prometheus exposition of the counters consumed by
+  `alerts.yml`.
+
+## Alerting channel setup
+
+`monitoring/prometheus/alertmanager.yml` routes `severity: critical` alerts
+to a receiver with both Slack and PagerDuty configured, and everything else
+to Slack only. Alertmanager doesn't expand `${VAR}` placeholders on its
+own — template the file at deploy time (`envsubst`, Helm, etc.) or replace
+the placeholders with literal secrets from your secrets manager. The
+in-process real-time path (`alertChannels.ts`) reads
+`SLACK_ALERT_WEBHOOK_URL` / `PAGERDUTY_ROUTING_KEY` directly from the
+api-server's environment — the two paths can point at the same or
+different Slack channels/PagerDuty services depending on how much you want
+to separate "live event fired" noise from "trend rule fired" noise.

--- a/docs/resilience.md
+++ b/docs/resilience.md
@@ -46,6 +46,18 @@ indirectly by the chaos tests):
   — trips open after repeated delivery failures and self-recovers via a
   half-open trial, so a down webhook consumer can't cause unbounded retry
   storms against it.
+- **RPC circuit breaker** (`api-server/src/services/rpcCircuitBreaker.ts`,
+  issue #2, wraps every `simulateCall` in `soroban.ts`) — the three-state
+  (closed/open/half-open) counterpart for the Soroban RPC dependency
+  itself, distinct from the webhook breaker above. After
+  `failureThreshold` consecutive RPC failures it trips open and serves the
+  last successful result per `(method, args)` from an in-memory TTL cache
+  instead of hanging on a degraded endpoint; once `resetTimeoutMs` elapses
+  it moves to half-open and lets a small number of trial calls through,
+  fully closing only after `halfOpenSuccessesToClose` consecutive
+  successes (a failed trial reopens it with a doubled backoff, capped at
+  `maxResetTimeoutMs`). State and counters are exposed at `GET
+  /rpc/circuit-breaker` (JSON) and `GET /metrics/rpc` (Prometheus).
 - **Rate limiting with backoff** (`api-server/src/middleware/rateLimiter.ts`)
   and **DDoS protection** (`api-server/src/middleware/ddosProtection.ts`) —
   protect the server itself from being overwhelmed, which is the inverse

--- a/monitoring/prometheus/alertmanager.yml
+++ b/monitoring/prometheus/alertmanager.yml
@@ -7,13 +7,45 @@ route:
   group_interval: 5m
   repeat_interval: 12h
   receiver: quorumproof-ops
+  routes:
+    # Critical-severity alerts (DisputeRaised, ContractUpgradeDetected, and
+    # other `severity: critical` rules in alerts.yml) page on-call via
+    # PagerDuty in addition to Slack. Everything else (warning) is Slack-only
+    # — see docs/critical-event-alerting.md for the severity policy behind
+    # this split.
+    - match:
+        severity: critical
+      receiver: quorumproof-critical
+      group_wait: 10s
+      repeat_interval: 1h
 
 receivers:
   - name: quorumproof-ops
     # Configure your notification channel here.
     # Example: Slack webhook
-    # slack_configs:
-    #   - api_url: "<SLACK_WEBHOOK_URL>"
-    #     channel: "#quorumproof-alerts"
-    #     title: "{{ .GroupLabels.alertname }}"
-    #     text: "{{ range .Alerts }}{{ .Annotations.description }}{{ end }}"
+    slack_configs:
+      - api_url: "${SLACK_ALERT_WEBHOOK_URL}"
+        channel: "#quorumproof-alerts"
+        title: "{{ .GroupLabels.alertname }}"
+        text: "{{ range .Alerts }}{{ .Annotations.description }}{{ end }}"
+        send_resolved: true
+
+  - name: quorumproof-critical
+    slack_configs:
+      - api_url: "${SLACK_ALERT_WEBHOOK_URL}"
+        channel: "#quorumproof-critical"
+        title: ":rotating_light: {{ .GroupLabels.alertname }}"
+        text: "{{ range .Alerts }}{{ .Annotations.description }}{{ end }}"
+        send_resolved: true
+    pagerduty_configs:
+      - routing_key: "${PAGERDUTY_ROUTING_KEY}"
+        description: "{{ .GroupLabels.alertname }}: {{ range .Alerts }}{{ .Annotations.summary }} {{ end }}"
+        severity: critical
+        send_resolved: true
+
+# Note: Alertmanager does not expand ${VAR} placeholders natively — either
+# template this file at deploy time (envsubst, Helm, etc.) or replace the
+# placeholders above with literal secrets injected via your secrets manager.
+# This mirrors how the same two channels are wired in-process for real-time
+# critical-event alerts in api-server/src/services/alertChannels.ts, which
+# reads SLACK_ALERT_WEBHOOK_URL / PAGERDUTY_ROUTING_KEY directly from env.

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -118,3 +118,44 @@ groups:
         annotations:
           summary: "Migration job {{ $labels.migration_id }} has not advanced in 30+ minutes"
           description: "Job {{ $labels.migration_id }} is still InProgress but its cursor hasn't moved since {{ $value | humanizeTimestamp }}. Check whether scripts/migration_orchestrator.py is still running."
+
+      # #3 — Critical contract event monitoring (revocations, disputes, upgrades).
+      # Counters emitted by api-server/src/services/criticalEventListener.ts;
+      # each matching event is *also* pushed in real time to Slack/PagerDuty via
+      # alertChannels.ts, independent of these scrape-interval rules. See
+      # docs/critical-event-alerting.md for interpretation of every alert below.
+      - alert: RevocationSpike
+        expr: increase(quorumproof_critical_events_total{category="revocation"}[15m]) > 10
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Unusual burst of credential/delegation revocations"
+          description: "{{ $value }} revocation-shaped events observed in the last 15 minutes — verify this matches expected issuer/attestor activity."
+
+      - alert: DisputeRaised
+        expr: increase(quorumproof_critical_events_total{category="dispute"}[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "A credential dispute was raised on-chain"
+          description: "{{ $value }} dispute event(s) in the last 5 minutes. See GET /events/critical/recent for details (topic, ledger, tx hash)."
+
+      - alert: ContractUpgradeDetected
+        expr: increase(quorumproof_critical_events_total{category="upgrade"}[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Contract upgrade or migration event detected"
+          description: "{{ $value }} upgrade/migration event(s) in the last 5 minutes. Confirm this corresponds to a planned, authorized upgrade — see docs/contract-upgrade-strategy.md."
+
+      - alert: CriticalEventAlertingDegraded
+        expr: increase(quorumproof_critical_event_alert_failures_total[15m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Critical event alert dispatch is failing"
+          description: "{{ $value }} critical-event alert(s) failed to reach every configured channel in the last 15 minutes — check Slack/PagerDuty credentials and connectivity; do not assume the absence of other alerts means no critical events occurred."


### PR DESCRIPTION
Closes #1267
Closes #1268
Closes #1269
Closes #1270

Issue #1 — Load testing & capacity planning

Problem: no testing existed under production-like load; nothing would surface bottlenecks before they hit real traffic.

api-server/loadtest/credentialLoadTest.ts (new, 171 lines) — a standalone script (npm run loadtest:credentials) that:
- Spins up a real in-process Express app using the actual createCredentialsRouter factory (not a mock server), so the test exercises real routing/validation/serialization code, not a stand-in.
- Swaps in a synthetic SorobanClient whose RPC latency (LOAD_RPC_LATENCY_MS, default 80ms) and failure rate (LOAD_RPC_FAILURE_RATE, default 1%) are configurable — this makes the test deterministic and runnable without a live network, while still being representative of RPC-bound behavior. It can be pointed at a real network by swapping in the real simulateCall.
- Scenario 1 (issuance): 1,000 requests (LOAD_ISSUE_COUNT) at concurrency 50 against the search-index read/write path that runs after on-chain issuance is indexed.
- Scenario 2 (verification): 10,000 verifications (LOAD_VERIFY_COUNT) sent as 200 batches of 50 (the API's max batch size) at concurrency 25 against POST /api/credentials/verify-batch — the real code path that fans out to simulateCall per credential id, i.e. the exact path the new RPC circuit breaker (issue #2) guards.
- Reports p50/p95/p99/max latency, error rate, and throughput per scenario, and warns if the failure rate is high enough that the circuit breaker should be tripping.

docs/capacity-planning.md (new, 125 lines) — documents:
- Why these two scenarios were chosen (they're the two paths every relying party and issuer actually hits).
- Baseline reference benchmark numbers from a sample run (throughput, p50/p95/p99) — explicitly flagged as a starting point for regression tracking, not a guarantee, with instructions to re-run against real target hardware.
- Capacity planning guidance: RPC endpoint capacity (not API compute) is the primary bottleneck; a sizing rule of thumb for concurrent in-flight RPC calls given a target verifications/day and p95 latency budget; why verify-batch's 50-item cap exists and shouldn't be raised without re-testing.
- A scaling strategy: vertical scaling first (raise per-instance RPC concurrency), horizontal scaling for availability/replica ceiling, adding RPC endpoints before adding API replicas once RPC latency (not API CPU) is the bottleneck, and re-running the load test after any change to batch size, breaker thresholds, or RPC config.

---
Issue #2 — Circuit breaker for RPC calls

Problem: if the Soroban RPC endpoint degrades or fails, every simulateCall in soroban.ts hangs or errors with no fail-fast behavior and no recovery strategy.

api-server/src/services/rpcCircuitBreaker.ts (new, 319 lines) — a three-state circuit breaker (closed → open → half-open → closed), distinct from the existing binary webhookCircuitBreaker.ts:
- Closed → Open: trips after failureThreshold (default 5) consecutive failures.
- Open: rejects calls immediately (fail-fast) unless a cached last-known-good result exists for that (method, args) pair, in which case it serves the cached value instead of throwing — this is the "fallback to cached data" requirement. Cache entries expire after cacheTtlMs (default 5 min).
- Open → Half-open: after resetTimeoutMs (default 15s) elapses, the breaker allows a limited number of trial calls through (halfOpenMaxConcurrentTrials, default 2) — extra calls beyond that limit still get the cached fallback or a rejection.
- Half-open → Closed: requires halfOpenSuccessesToClose (default 3) consecutive trial successes — this is the "gradual recovery" piece, so a just-recovered upstream isn't immediately slammed with full traffic.
- Half-open → Open (failed trial): any failure during half-open reopens the breaker and doubles the reset timeout (capped at maxResetTimeoutMs, default 5 min) — a flapping upstream backs off instead of being retried on a fixed interval forever.
- Tracks full metrics: total calls/successes/failures/trips/fallback-hits/rejections, current state, current backoff timeout, last failure reason.
- getMetricsPrometheus() emits proper Prometheus exposition format (gauge for state, counters for the rest).

api-server/src/soroban.ts (modified) — simulateCall now routes its RPC round-trip through getDefaultRpcCircuitBreaker().execute(...), passing { method, args } (args pre-decoded via scValToNative for use as a cache key) so successful results get cached and open-state calls can be served from cache.

api-server/src/index.ts (modified) — new endpoints: GET /rpc/circuit-breaker (JSON metrics) and GET /metrics/rpc (Prometheus exposition) — this is the "add metrics on circuit breaker state" requirement.

docs/resilience.md (modified) — added a section describing the new breaker alongside the existing webhook breaker, so the resilience doc stays the single place documenting every circuit breaker in the system.

---
Issue #3 — Critical contract event monitoring & alerting

Problem: revocations, disputes, and contract upgrades happened on-chain with zero monitoring — an operator would only find out by manually querying state.

api-server/src/services/criticalEventListener.ts (new, 269 lines):
- Polls Soroban RPC's getEvents for the QuorumProof contract on an interval (EVENT_LISTENER_POLL_MS, default 15s), tracking a persisted cursor (via the same DurableLog pattern used elsewhere) so restarts don't reprocess old events or lose position.
- Classifies each event by its first topic against pattern-based rules (not an exact string list, so newly-added contract events of the same shape are still caught automatically):
  - revocation → /revok|suspend/i (matches RevokeCredential, DelegationRevoked, RoleRevoked, ConsentRevoked)
  - dispute → /disput/i
  - upgrade → /upgrad|migrat/i (matches UpgradeValidated, MigrationProgress, MetadataSchemaUpgraded)
- Every matched event is immediately pushed as a real-time alert (severity: warning for revocations, critical for disputes and upgrades) and also counted for Prometheus.
- Keeps an in-memory ring buffer of recent critical events (default 200) for inspection.
- processEvent() is exposed separately so it can be exercised directly (e.g. in tests) without a live RPC round-trip.

api-server/src/services/alertChannels.ts (new, 103 lines):
- sendSlackAlert — posts a formatted message (with severity emoji and a metadata block) to a Slack incoming webhook (SLACK_ALERT_WEBHOOK_URL).
- sendPagerDutyAlert — triggers a PagerDuty Events API v2 incident (PAGERDUTY_ROUTING_KEY), keyed by a stable dedupKey so PagerDuty groups retries of the same event.
- dispatchAlert — fans out to both channels for critical severity, Slack-only for warning, to avoid paging on routine activity. Both senders no-op (return success) when unconfigured, so the listener works in dev/CI without alert credentials.

api-server/src/index.ts (modified) — the listener auto-starts when CONTRACT_QUORUM_PROOF is set (opt-out via CRITICAL_EVENT_MONITORING=disabled), and is otherwise fully inert — safe to import in any environment including tests. New endpoints: GET /events/critical/recent (metrics + recent event buffer) and GET /metrics/events (Prometheus).

monitoring/prometheus/alerts.yml (modified, +41 lines) — four new alert rules: RevocationSpike (>10 revocation events/15min, warning), DisputeRaised (any dispute event/5min, critical), ContractUpgradeDetected (any upgrade event/5min, critical), and CriticalEventAlertingDegraded (alert-dispatch itself failing — a meta-alert so a broken notification pipeline doesn't fail silently).

monitoring/prometheus/alertmanager.yml (modified, +42 lines) — added a routing split: severity: critical alerts go to a new quorumproof-critical receiver wired to both Slack and PagerDuty (shorter group-wait, 1h repeat), everything else stays on the existing Slack-only quorumproof-ops receiver.

docs/critical-event-alerting.md (new, 127 lines) — full architecture diagram (RPC → listener → real-time push and Prometheus counters → Alertmanager, explaining why both paths exist), a table of what's monitored, configuration reference, and — the "document alert interpretation" requirement — a per-alert breakdown of what each one means and the expected first response (e.g. for ContractUpgradeDetected: confirm with the deploying team whether the upgrade was planned before doing anything else).

---
Issue #4 — Gas cost tracking

Problem: operators had no visibility into what contract operations actually cost to run, and no way to project costs or spot optimization opportunities.

api-server/src/services/gasCostTracker.ts (new, 217 lines):
- Records minResourceFee (the resource/gas fee Soroban's simulateTransaction computes, in stroops) against the operation name on every successful call, persisted via DurableLog.
- getReport() — aggregated report (total calls, total cost in stroops/XLM/USD) plus a per-operation breakdown (count, min/max/avg/total), sorted by total contribution to spend. USD conversion uses a configurable XLM_USD_PRICE env var (default 0.12).
- project(operation, callsPerDay, days) — projects cost for a hypothetical volume using that operation's observed average fee — the "cost projections for various scenarios" requirement.
- getOptimizationRecommendations() — ranks operations by total XLM contribution to spend (not raw per-call cost, since a cheap operation called constantly can cost more in aggregate than an expensive rare one), with one of three generated reasons per candidate: dominates spend (≥30%), above-average per-call cost (>2x mean, suggesting excess state access), or high call volume (suggesting batching/caching).

api-server/src/soroban.ts (modified) — records cost on every successful simulation right before returning the decoded result.

api-server/src/routes/costs.ts (new, 43 lines) + index.ts — GET /api/costs/report, GET /api/costs/optimizations?top=N, GET /api/costs/projection?operation=X&callsPerDay=N&days=M.

docs/cost-optimization-guide.md (new, 104 lines) — how the tracker works, an example cost-projection table for the same volume scenarios used in capacity-planning.md (cross-referenced so cost and capacity planning share assumptions), how recommendations are ranked, and concrete optimization opportunities identified in the current code: opportunistic short-lived caching for verify-batch's per-id fan-out and for best-effort enrichment calls like get_supported_claim_types, plus a suggestion to track cost regressions the same way performance_regression.py already tracks latency regressions.
