### PR TITLE
feat: add MFA (#1299) and session management with expiry (#1300)

### DIFF
--- a/api-server/src/index.ts
+++ b/api-server/src/index.ts
@@ -17,12 +17,14 @@ import consentRouter from './routes/consent.js';
 import webhooksRouter from './routes/webhooks.js';
 import gdprRouter from './routes/gdpr.js';
 import apiKeysRouter from './routes/apiKeys.js';
+import authRouter from './routes/auth.js';         // #1299 MFA / #1300 session management
 import { cacheControl } from './middleware/cacheControl.js';
 import { createRateLimiter } from './middleware/rateLimiter.js';
 import { createRequestDeduplication } from './middleware/requestDeduplication.js';
 import { rbac } from './middleware/rbac.js';
 import { createDDoSProtection } from './middleware/ddosProtection.js';
 import { createRequestSigning } from './middleware/requestSigning.js';
+import { requireMfa } from './middleware/auth.js';    // #1299 MFA gate for admin endpoints
 import { createWsServer } from './ws/server.js';
 import { getSubscriberCount } from './ws/subscriptions.js';
 import { getWsMetrics, getWsMetricsPrometheus } from './ws/metrics.js';
@@ -82,6 +84,12 @@ app.use('/api/recovery', recoveryRouter);
 app.use('/api/webhooks', webhooksRouter); // #926 event webhooks
 app.use('/api/gdpr', gdprRouter);
 app.use('/api/api-keys', apiKeysRouter); // #999 API key management
+// #1299 MFA auth endpoints / #1300 session management
+app.use('/api/auth', authRouter);
+// #1299 — Admin-only endpoints require a fully MFA-verified session in addition to RBAC.
+// The requireMfa middleware checks mfaVerified=true in the Bearer token so that
+// even a valid (non-MFA) session cannot access admin bridge operations.
+app.use('/api/bridge', requireMfa);
 
 app.get('/health', (_req, res) => {
   res.json({

--- a/api-server/src/middleware/auth.ts
+++ b/api-server/src/middleware/auth.ts
@@ -1,0 +1,125 @@
+/**
+ * Auth Middleware — Issues #1299 / #1300
+ *
+ * Provides two Express middleware functions:
+ *
+ *  requireAuth    — validates the Bearer access token; attaches the JWT payload
+ *                   to req.auth for downstream handlers.
+ *
+ *  requireMfa     — extends requireAuth by additionally checking that the
+ *                   mfaVerified flag is set in the token. Use this for admin
+ *                   endpoints that require MFA.
+ *
+ * The authenticated user is available as:
+ *   req.auth.sub          → userId
+ *   req.auth.role         → role
+ *   req.auth.mfaVerified  → boolean
+ *   req.auth.jti          → sessionId
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { getDefaultSessionManager, type JwtPayload } from '../services/sessionManager.js';
+
+// ---------------------------------------------------------------------------
+// Augment Express Request type
+// ---------------------------------------------------------------------------
+declare global {
+  namespace Express {
+    interface Request {
+      auth?: JwtPayload;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Token extraction helper
+// ---------------------------------------------------------------------------
+function extractBearerToken(req: Request): string | null {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
+  const token = authHeader.slice(7).trim();
+  return token.length > 0 ? token : null;
+}
+
+// ---------------------------------------------------------------------------
+// requireAuth middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates the Bearer JWT in the Authorization header.
+ * Sets req.auth with the decoded payload on success.
+ * Returns 401 if the token is missing, invalid, expired, or revoked.
+ */
+export function requireAuth(req: Request, res: Response, next: NextFunction): void {
+  const token = extractBearerToken(req);
+  if (!token) {
+    res.status(401).json({ error: 'Authentication required', message: 'Missing Bearer token' });
+    return;
+  }
+
+  const sessionManager = getDefaultSessionManager();
+  const payload = sessionManager.validateAccessToken(token);
+  if (!payload) {
+    res.status(401).json({ error: 'Authentication failed', message: 'Invalid, expired, or revoked token' });
+    return;
+  }
+
+  req.auth = payload;
+  next();
+}
+
+// ---------------------------------------------------------------------------
+// requireMfa middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Requires a valid access token AND that MFA was verified during login.
+ * Use this to protect admin-only endpoints.
+ *
+ * Returns 401 if the token is missing/invalid.
+ * Returns 403 if the token is valid but MFA was not completed.
+ */
+export function requireMfa(req: Request, res: Response, next: NextFunction): void {
+  const token = extractBearerToken(req);
+  if (!token) {
+    res.status(401).json({ error: 'Authentication required', message: 'Missing Bearer token' });
+    return;
+  }
+
+  const sessionManager = getDefaultSessionManager();
+  const payload = sessionManager.validateAccessToken(token);
+  if (!payload) {
+    res.status(401).json({ error: 'Authentication failed', message: 'Invalid, expired, or revoked token' });
+    return;
+  }
+
+  if (!payload.mfaVerified) {
+    res.status(403).json({
+      error: 'MFA required',
+      message: 'This endpoint requires multi-factor authentication. Complete MFA via POST /auth/mfa/verify.',
+    });
+    return;
+  }
+
+  req.auth = payload;
+  next();
+}
+
+// ---------------------------------------------------------------------------
+// optionalAuth middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempts to validate the Bearer token but does NOT reject the request on
+ * failure. Use this for endpoints that behave differently for authenticated
+ * vs anonymous callers.
+ */
+export function optionalAuth(req: Request, _res: Response, next: NextFunction): void {
+  const token = extractBearerToken(req);
+  if (token) {
+    const sessionManager = getDefaultSessionManager();
+    const payload = sessionManager.validateAccessToken(token);
+    if (payload) req.auth = payload;
+  }
+  next();
+}

--- a/api-server/src/routes/auth.ts
+++ b/api-server/src/routes/auth.ts
@@ -1,0 +1,337 @@
+/**
+ * Auth Routes — Issues #1299 / #1300
+ *
+ * POST /auth/login               — Authenticate with userId + password stub; returns token pair
+ * POST /auth/mfa/enable          — Begin TOTP MFA setup for the authenticated user
+ * POST /auth/mfa/verify          — Verify TOTP code and elevate session to mfaVerified
+ * POST /auth/refresh             — Refresh an expired access token via a refresh token
+ * GET  /auth/sessions            — List all sessions for the authenticated user
+ * DELETE /auth/sessions/:id      — Revoke a specific session
+ * DELETE /auth/sessions          — Revoke all sessions for the authenticated user (logout everywhere)
+ * POST /auth/logout              — Revoke the current session
+ */
+
+import { Router, Request, Response } from 'express';
+import { getDefaultMfaService } from '../services/mfa.js';
+import { getDefaultSessionManager } from '../services/sessionManager.js';
+import { requireAuth } from '../middleware/auth.js';
+
+const router = Router();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal credential store stub.
+ *
+ * In production this would be backed by a real user database with bcrypt
+ * hashed passwords. For this implementation we provide a functional stub
+ * that demonstrates the auth flow end-to-end.
+ *
+ * Credentials are loaded from USER_CREDENTIALS env var as JSON:
+ *   USER_CREDENTIALS='[{"userId":"alice","passwordHash":"<sha256-hex>","role":"admin"}]'
+ *
+ * If the env var is absent we fall back to a single hard-coded test account
+ * that should NEVER be used in production (guarded by NODE_ENV check below).
+ */
+interface UserCredential {
+  userId: string;
+  passwordHash: string;
+  role: string;
+}
+
+function loadUserCredentials(): UserCredential[] {
+  const raw = process.env.USER_CREDENTIALS;
+  if (raw) {
+    try {
+      return JSON.parse(raw) as UserCredential[];
+    } catch {
+      console.warn('[auth] Failed to parse USER_CREDENTIALS — ignoring');
+    }
+  }
+  // Stub only: password is "changeme" (SHA256)
+  if (process.env.NODE_ENV === 'production') {
+    console.error('[auth] No USER_CREDENTIALS configured in production!');
+    return [];
+  }
+  return [
+    {
+      userId: 'admin',
+      passwordHash: '3a7bd3e2360a3d29eea436fcfb7e44c735d117c42d1c1835420b6b9942dd4f1b', // sha256("changeme")
+      role: 'admin',
+    },
+    {
+      userId: 'user1',
+      passwordHash: '3a7bd3e2360a3d29eea436fcfb7e44c735d117c42d1c1835420b6b9942dd4f1b',
+      role: 'user',
+    },
+  ];
+}
+
+import crypto from 'crypto';
+
+function hashPassword(password: string): string {
+  return crypto.createHash('sha256').update(password).digest('hex');
+}
+
+function findUser(userId: string, passwordHash: string): UserCredential | undefined {
+  return loadUserCredentials().find(
+    (u) => u.userId === userId && u.passwordHash === passwordHash
+  );
+}
+
+// ---------------------------------------------------------------------------
+// POST /auth/login
+// ---------------------------------------------------------------------------
+
+/**
+ * Primary authentication endpoint.
+ *
+ * If the user has MFA enabled, the response includes `mfaRequired: true` and a
+ * pre-MFA access token with `mfaVerified: false`. The client must then call
+ * POST /auth/mfa/verify with the TOTP code to upgrade to a fully verified session.
+ *
+ * If the user does NOT have MFA enabled, a fully authenticated session is returned
+ * immediately.
+ *
+ * Body: { userId: string, password: string }
+ */
+router.post('/login', (req: Request, res: Response) => {
+  const { userId, password } = req.body as { userId?: unknown; password?: unknown };
+
+  if (typeof userId !== 'string' || !userId.trim()) {
+    res.status(400).json({ error: 'userId is required' });
+    return;
+  }
+  if (typeof password !== 'string' || !password) {
+    res.status(400).json({ error: 'password is required' });
+    return;
+  }
+
+  const user = findUser(userId.trim(), hashPassword(password));
+  if (!user) {
+    // Use a consistent error to avoid username enumeration
+    res.status(401).json({ error: 'Invalid credentials' });
+    return;
+  }
+
+  const mfaService = getDefaultMfaService();
+  const sessionManager = getDefaultSessionManager();
+  const mfaEnabled = mfaService.isMfaEnabled(user.userId);
+
+  // Create session — mfaVerified=false if MFA is enabled (requires second factor)
+  const tokens = sessionManager.createSession(user.userId, {
+    mfaVerified: !mfaEnabled,
+    role: user.role,
+  });
+
+  res.status(200).json({
+    ...tokens,
+    mfaRequired: mfaEnabled,
+    userId: user.userId,
+    role: user.role,
+    message: mfaEnabled
+      ? 'MFA required. Submit TOTP code via POST /auth/mfa/verify.'
+      : 'Login successful.',
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /auth/mfa/enable — begin MFA setup (requires auth)
+// ---------------------------------------------------------------------------
+
+/**
+ * Initiates TOTP MFA setup for the authenticated user.
+ * Returns the base32 secret and an otpauth:// URL for QR code scanning.
+ * Backup codes are returned once and should be stored by the user.
+ *
+ * MFA is not active until the user calls POST /auth/mfa/verify with a valid code.
+ */
+router.post('/mfa/enable', requireAuth, (req: Request, res: Response) => {
+  const userId = req.auth!.sub;
+  const mfaService = getDefaultMfaService();
+
+  if (mfaService.isMfaEnabled(userId)) {
+    res.status(409).json({
+      error: 'MFA already enabled',
+      message: 'Disable existing MFA before re-enrolling.',
+    });
+    return;
+  }
+
+  const setup = mfaService.setupMfa(userId, 'QuorumProof');
+
+  res.status(200).json({
+    secret: setup.secret,
+    otpAuthUrl: setup.otpAuthUrl,
+    backupCodes: setup.backupCodes,
+    message: 'Scan the QR code in your authenticator app, then call POST /auth/mfa/verify with a valid code to activate MFA.',
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /auth/mfa/verify — verify TOTP code (requires auth)
+// ---------------------------------------------------------------------------
+
+/**
+ * Two use cases:
+ *   1. MFA SETUP confirmation: If MFA is pending (enabled=false in the service),
+ *      this call activates it and upgrades the current session to mfaVerified=true.
+ *   2. MFA LOGIN: If the session has mfaVerified=false (post-login, MFA enabled),
+ *      a valid code upgrades the session by issuing a new mfaVerified token pair.
+ *
+ * Body: { code: string }
+ */
+router.post('/mfa/verify', requireAuth, (req: Request, res: Response) => {
+  const userId = req.auth!.sub;
+  const { code } = req.body as { code?: unknown };
+
+  if (typeof code !== 'string' || !/^\d{6}$/.test(code)) {
+    res.status(400).json({ error: 'code must be a 6-digit string' });
+    return;
+  }
+
+  const mfaService = getDefaultMfaService();
+  const sessionManager = getDefaultSessionManager();
+
+  // Case 1: MFA setup confirmation — the user has a pending (enabled=false) record
+  const status = mfaService.getMfaStatus(userId);
+  if (status && !status.enabled) {
+    const confirmed = mfaService.verifySetup(userId, code);
+    if (!confirmed) {
+      res.status(401).json({ error: 'Invalid TOTP code', message: 'Code verification failed during setup.' });
+      return;
+    }
+
+    // Revoke the current session and issue a new one with mfaVerified=true
+    sessionManager.revokeSession(req.auth!.jti);
+    const tokens = sessionManager.createSession(userId, {
+      mfaVerified: true,
+      role: req.auth!.role,
+    });
+
+    res.status(200).json({
+      ...tokens,
+      mfaEnabled: true,
+      message: 'MFA activated successfully. Your session has been upgraded.',
+    });
+    return;
+  }
+
+  // Case 2: MFA login — verify and upgrade the session
+  const valid = mfaService.verifyCode(userId, code);
+  if (!valid) {
+    res.status(401).json({ error: 'Invalid TOTP code', message: 'Code verification failed.' });
+    return;
+  }
+
+  // Revoke current (pre-MFA) session and issue a verified one
+  sessionManager.revokeSession(req.auth!.jti);
+  const tokens = sessionManager.createSession(userId, {
+    mfaVerified: true,
+    role: req.auth!.role,
+  });
+
+  res.status(200).json({
+    ...tokens,
+    mfaVerified: true,
+    message: 'MFA verified. Session upgraded to full access.',
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /auth/refresh — refresh token rotation
+// ---------------------------------------------------------------------------
+
+/**
+ * Exchange a valid refresh token for a new access + refresh token pair.
+ * The old refresh token is invalidated on use (token rotation).
+ *
+ * Body: { refreshToken: string }
+ */
+router.post('/refresh', (req: Request, res: Response) => {
+  const { refreshToken } = req.body as { refreshToken?: unknown };
+
+  if (typeof refreshToken !== 'string' || !refreshToken.trim()) {
+    res.status(400).json({ error: 'refreshToken is required' });
+    return;
+  }
+
+  const sessionManager = getDefaultSessionManager();
+  const tokens = sessionManager.refreshSession(refreshToken.trim());
+
+  if (!tokens) {
+    res.status(401).json({
+      error: 'Invalid or expired refresh token',
+      message: 'Please log in again.',
+    });
+    return;
+  }
+
+  res.status(200).json({
+    ...tokens,
+    message: 'Token refreshed successfully.',
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /auth/sessions — list all sessions for the authenticated user
+// ---------------------------------------------------------------------------
+
+router.get('/sessions', requireAuth, (req: Request, res: Response) => {
+  const userId = req.auth!.sub;
+  const sessionManager = getDefaultSessionManager();
+  const sessions = sessionManager.listSessions(userId);
+  res.status(200).json({ data: sessions, total: sessions.length });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /auth/sessions — revoke ALL sessions (logout everywhere)
+// ---------------------------------------------------------------------------
+
+router.delete('/sessions', requireAuth, (req: Request, res: Response) => {
+  const userId = req.auth!.sub;
+  const sessionManager = getDefaultSessionManager();
+  const count = sessionManager.revokeAllSessions(userId);
+  res.status(200).json({ message: `Revoked ${count} session(s).`, count });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /auth/sessions/:id — revoke a specific session
+// ---------------------------------------------------------------------------
+
+router.delete('/sessions/:id', requireAuth, (req: Request, res: Response) => {
+  const userId = req.auth!.sub;
+  const sessionId = req.params.id as string;
+  const sessionManager = getDefaultSessionManager();
+
+  // Verify the session belongs to the requesting user
+  const sessions = sessionManager.listSessions(userId);
+  const owned = sessions.find((s) => s.sessionId === sessionId);
+  if (!owned) {
+    res.status(404).json({ error: 'Session not found or not owned by you' });
+    return;
+  }
+
+  const revoked = sessionManager.revokeSession(sessionId);
+  if (!revoked) {
+    res.status(404).json({ error: 'Session not found' });
+    return;
+  }
+
+  res.status(200).json({ message: 'Session revoked successfully.' });
+});
+
+// ---------------------------------------------------------------------------
+// POST /auth/logout — revoke the current session
+// ---------------------------------------------------------------------------
+
+router.post('/logout', requireAuth, (req: Request, res: Response) => {
+  const sessionId = req.auth!.jti;
+  const sessionManager = getDefaultSessionManager();
+  sessionManager.revokeSession(sessionId);
+  res.status(200).json({ message: 'Logged out successfully.' });
+});
+
+export default router;

--- a/api-server/src/services/mfa.ts
+++ b/api-server/src/services/mfa.ts
@@ -1,0 +1,265 @@
+/**
+ * MFA Service — Issue #1299
+ *
+ * Implements TOTP-based Multi-Factor Authentication using the RFC 6238 standard.
+ * Uses @noble/hashes for HMAC-SHA1 (TOTP standard) without requiring extra deps.
+ *
+ * Each user can have one active TOTP secret. Pending secrets are stored until
+ * the user verifies their first code, at which point MFA is fully enabled.
+ */
+
+import crypto from 'crypto';
+
+export interface MfaRecord {
+  userId: string;
+  secret: string;          // base32-encoded TOTP secret
+  enabled: boolean;        // true once the user has verified a code
+  enabledAt?: string;      // ISO timestamp when MFA was confirmed
+  backupCodes: string[];   // hashed single-use backup codes
+}
+
+export interface MfaSetupResult {
+  secret: string;          // base32 secret for authenticator app
+  otpAuthUrl: string;      // otpauth:// URI for QR code generation
+  backupCodes: string[];   // plain-text codes (shown once)
+}
+
+// ---------------------------------------------------------------------------
+// Base32 helpers (RFC 4648 — subset used by TOTP)
+// ---------------------------------------------------------------------------
+const BASE32_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+function base32Encode(bytes: Buffer): string {
+  let bits = 0;
+  let value = 0;
+  let output = '';
+  for (const byte of bytes) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      output += BASE32_CHARS[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) {
+    output += BASE32_CHARS[(value << (5 - bits)) & 31];
+  }
+  return output;
+}
+
+function base32Decode(encoded: string): Buffer {
+  const clean = encoded.toUpperCase().replace(/=+$/, '');
+  let bits = 0;
+  let value = 0;
+  const output: number[] = [];
+  for (const char of clean) {
+    const idx = BASE32_CHARS.indexOf(char);
+    if (idx === -1) throw new Error(`Invalid base32 character: ${char}`);
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      output.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+  return Buffer.from(output);
+}
+
+// ---------------------------------------------------------------------------
+// HOTP / TOTP core (RFC 4226 / RFC 6238)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute HOTP value for a given secret and counter.
+ */
+function hotp(secret: Buffer, counter: bigint, digits = 6): string {
+  // Encode counter as 8-byte big-endian buffer
+  const counterBuf = Buffer.alloc(8);
+  counterBuf.writeBigUInt64BE(counter);
+
+  const hmac = crypto.createHmac('sha1', secret).update(counterBuf).digest();
+
+  // Dynamic truncation
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const code =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff);
+
+  const otp = code % Math.pow(10, digits);
+  return String(otp).padStart(digits, '0');
+}
+
+/**
+ * Compute TOTP value for the current (or provided) timestamp.
+ * step = 30 seconds, digits = 6.
+ */
+export function totp(secret: string, timestampMs = Date.now(), step = 30, digits = 6): string {
+  const keyBytes = base32Decode(secret);
+  const counter = BigInt(Math.floor(timestampMs / 1000 / step));
+  return hotp(keyBytes, counter, digits);
+}
+
+/**
+ * Verify a TOTP code with a ±1 step tolerance window (allows for clock skew).
+ */
+export function verifyTotp(
+  secret: string,
+  code: string,
+  timestampMs = Date.now(),
+  step = 30,
+  window = 1,
+): boolean {
+  if (!/^\d{6}$/.test(code)) return false;
+  const keyBytes = base32Decode(secret);
+  const counter = BigInt(Math.floor(timestampMs / 1000 / step));
+  for (let delta = -window; delta <= window; delta++) {
+    const expected = hotp(keyBytes, counter + BigInt(delta), 6);
+    if (timingSafeEqual(expected, code)) return true;
+  }
+  return false;
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}
+
+// ---------------------------------------------------------------------------
+// Backup codes
+// ---------------------------------------------------------------------------
+
+const BACKUP_CODE_COUNT = 8;
+
+function generateBackupCodes(): { plain: string[]; hashed: string[] } {
+  const plain: string[] = [];
+  const hashed: string[] = [];
+  for (let i = 0; i < BACKUP_CODE_COUNT; i++) {
+    const code = crypto.randomBytes(5).toString('hex').toUpperCase(); // 10-char hex
+    plain.push(code);
+    hashed.push(crypto.createHash('sha256').update(code).digest('hex'));
+  }
+  return { plain, hashed };
+}
+
+// ---------------------------------------------------------------------------
+// MfaService
+// ---------------------------------------------------------------------------
+
+export class MfaService {
+  /** userId → MfaRecord */
+  private readonly store = new Map<string, MfaRecord>();
+
+  /**
+   * Begin MFA setup for a user.
+   * Generates a new TOTP secret and backup codes.
+   * The setup is NOT active until the user calls verifySetup().
+   */
+  setupMfa(userId: string, issuerLabel = 'QuorumProof'): MfaSetupResult {
+    const secretBytes = crypto.randomBytes(20); // 160-bit secret (recommended)
+    const secret = base32Encode(secretBytes);
+
+    const { plain, hashed } = generateBackupCodes();
+
+    // Store the record in pending state (enabled = false)
+    this.store.set(userId, {
+      userId,
+      secret,
+      enabled: false,
+      backupCodes: hashed,
+    });
+
+    const accountName = encodeURIComponent(userId);
+    const issuer = encodeURIComponent(issuerLabel);
+    const otpAuthUrl = `otpauth://totp/${issuer}:${accountName}?secret=${secret}&issuer=${issuer}&algorithm=SHA1&digits=6&period=30`;
+
+    return {
+      secret,
+      otpAuthUrl,
+      backupCodes: plain,
+    };
+  }
+
+  /**
+   * Confirm MFA setup by verifying the user's first TOTP code.
+   * Activates MFA if the code is valid.
+   */
+  verifySetup(userId: string, code: string): boolean {
+    const record = this.store.get(userId);
+    if (!record) return false;
+    if (record.enabled) return false; // already enabled — use verifyCode instead
+
+    if (!verifyTotp(record.secret, code)) return false;
+
+    record.enabled = true;
+    record.enabledAt = new Date().toISOString();
+    this.store.set(userId, record);
+    return true;
+  }
+
+  /**
+   * Verify a TOTP code for an already-enabled user.
+   * Also accepts backup codes (single-use).
+   */
+  verifyCode(userId: string, code: string): boolean {
+    const record = this.store.get(userId);
+    if (!record || !record.enabled) return false;
+
+    // Check TOTP
+    if (verifyTotp(record.secret, code)) return true;
+
+    // Check backup codes (case-insensitive)
+    const upper = code.toUpperCase();
+    const hash = crypto.createHash('sha256').update(upper).digest('hex');
+    const idx = record.backupCodes.indexOf(hash);
+    if (idx !== -1) {
+      // Consume the backup code
+      record.backupCodes.splice(idx, 1);
+      this.store.set(userId, record);
+      return true;
+    }
+
+    return false;
+  }
+
+  /** Check if MFA is enabled for a user. */
+  isMfaEnabled(userId: string): boolean {
+    return this.store.get(userId)?.enabled ?? false;
+  }
+
+  /** Get the MFA record for a user (without exposing the secret). */
+  getMfaStatus(userId: string): { enabled: boolean; enabledAt?: string; backupCodesRemaining: number } | null {
+    const record = this.store.get(userId);
+    if (!record) return null;
+    return {
+      enabled: record.enabled,
+      enabledAt: record.enabledAt,
+      backupCodesRemaining: record.backupCodes.length,
+    };
+  }
+
+  /** Disable MFA for a user (admin use / account recovery). */
+  disableMfa(userId: string): boolean {
+    const record = this.store.get(userId);
+    if (!record) return false;
+    this.store.delete(userId);
+    return true;
+  }
+
+  /** For testing only. */
+  _resetForTest(): void {
+    this.store.clear();
+  }
+}
+
+let defaultMfaService: MfaService | undefined;
+
+export function getDefaultMfaService(): MfaService {
+  if (!defaultMfaService) defaultMfaService = new MfaService();
+  return defaultMfaService;
+}
+
+export function _setDefaultMfaServiceForTest(svc: MfaService | undefined): void {
+  defaultMfaService = svc;
+}

--- a/api-server/src/services/sessionManager.ts
+++ b/api-server/src/services/sessionManager.ts
@@ -1,0 +1,323 @@
+/**
+ * Session Manager Service — Issue #1300
+ *
+ * Manages JWT-based sessions with expiry, refresh tokens, and revocation.
+ *
+ * Design decisions:
+ *  - Access tokens expire in 1 hour (configurable via SESSION_ACCESS_TTL_SECONDS).
+ *  - Refresh tokens expire in 7 days (configurable via SESSION_REFRESH_TTL_SECONDS).
+ *  - Sessions are tracked in-memory (Map) per-user so we can enumerate and revoke them.
+ *  - JWT signing uses HMAC-SHA256 with a secret from JWT_SECRET env var.
+ *  - No external JWT library is needed — we implement compact JWT signing here
+ *    using Node's built-in `crypto` module.
+ *  - mfaVerified flag in the access token payload signals that the user completed
+ *    MFA during login, enabling the requireMfa middleware to gate admin endpoints.
+ */
+
+import crypto from 'crypto';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+const ACCESS_TTL_SECONDS = parseInt(process.env.SESSION_ACCESS_TTL_SECONDS ?? '3600', 10);   // 1 hour
+const REFRESH_TTL_SECONDS = parseInt(process.env.SESSION_REFRESH_TTL_SECONDS ?? '604800', 10); // 7 days
+
+export function getJwtSecret(): string {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    // Warn loudly in development; in production this should be a hard error.
+    console.warn('[SessionManager] JWT_SECRET is not set — using ephemeral secret. Set JWT_SECRET in production!');
+    // Generate a random ephemeral secret for this process (sessions won't survive restarts)
+    return crypto.randomBytes(64).toString('hex');
+  }
+  return secret;
+}
+
+// Lazily resolved so tests can set process.env.JWT_SECRET before importing
+let _jwtSecret: string | undefined;
+function jwtSecret(): string {
+  if (!_jwtSecret) _jwtSecret = getJwtSecret();
+  return _jwtSecret;
+}
+
+// ---------------------------------------------------------------------------
+// Minimal JWT implementation (HS256)
+// ---------------------------------------------------------------------------
+function base64UrlEncode(data: string | Buffer): string {
+  const buf = typeof data === 'string' ? Buffer.from(data, 'utf8') : data;
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+function base64UrlDecode(encoded: string): Buffer {
+  const padded = encoded.replace(/-/g, '+').replace(/_/g, '/');
+  const padding = (4 - (padded.length % 4)) % 4;
+  return Buffer.from(padded + '='.repeat(padding), 'base64');
+}
+
+export interface JwtPayload {
+  sub: string;         // userId
+  jti: string;         // session ID (unique per token)
+  iat: number;         // issued at (unix seconds)
+  exp: number;         // expires at (unix seconds)
+  type: 'access' | 'refresh';
+  mfaVerified: boolean;
+  role?: string;
+}
+
+export function signJwt(payload: JwtPayload): string {
+  const header = base64UrlEncode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = base64UrlEncode(JSON.stringify(payload));
+  const signingInput = `${header}.${body}`;
+  const sig = crypto.createHmac('sha256', jwtSecret()).update(signingInput).digest();
+  return `${signingInput}.${base64UrlEncode(sig)}`;
+}
+
+export function verifyJwt(token: string): JwtPayload | null {
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+
+  const [header, body, signature] = parts;
+  const signingInput = `${header}.${body}`;
+  const expectedSig = crypto.createHmac('sha256', jwtSecret()).update(signingInput).digest();
+  const actualSig = base64UrlDecode(signature);
+
+  if (expectedSig.length !== actualSig.length) return null;
+  if (!crypto.timingSafeEqual(expectedSig, actualSig)) return null;
+
+  let payload: JwtPayload;
+  try {
+    payload = JSON.parse(base64UrlDecode(body).toString('utf8')) as JwtPayload;
+  } catch {
+    return null;
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (payload.exp < now) return null; // token expired
+
+  return payload;
+}
+
+// ---------------------------------------------------------------------------
+// Session storage
+// ---------------------------------------------------------------------------
+export interface Session {
+  sessionId: string;     // matches JTI in the access token
+  userId: string;
+  refreshTokenHash: string; // SHA256 of refresh token
+  createdAt: string;
+  accessExpiresAt: string;
+  refreshExpiresAt: string;
+  mfaVerified: boolean;
+  role: string;
+  revokedAt?: string;
+  active: boolean;
+}
+
+export interface TokenPair {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;     // seconds until access token expires
+  tokenType: 'Bearer';
+}
+
+// ---------------------------------------------------------------------------
+// SessionManager
+// ---------------------------------------------------------------------------
+export class SessionManager {
+  /** sessionId → Session */
+  private readonly sessions = new Map<string, Session>();
+
+  /**
+   * Create a new session and return a token pair.
+   * Call this after successful primary authentication (and MFA if enabled).
+   */
+  createSession(userId: string, options: { mfaVerified?: boolean; role?: string } = {}): TokenPair {
+    const sessionId = crypto.randomBytes(16).toString('hex');
+    const now = Math.floor(Date.now() / 1000);
+    const mfaVerified = options.mfaVerified ?? false;
+    const role = options.role ?? 'user';
+
+    // Build access token
+    const accessPayload: JwtPayload = {
+      sub: userId,
+      jti: sessionId,
+      iat: now,
+      exp: now + ACCESS_TTL_SECONDS,
+      type: 'access',
+      mfaVerified,
+      role,
+    };
+
+    // Build refresh token (longer TTL, separate jti)
+    const refreshId = crypto.randomBytes(16).toString('hex');
+    const refreshPayload: JwtPayload = {
+      sub: userId,
+      jti: refreshId,
+      iat: now,
+      exp: now + REFRESH_TTL_SECONDS,
+      type: 'refresh',
+      mfaVerified,
+      role,
+    };
+
+    const accessToken = signJwt(accessPayload);
+    const refreshToken = signJwt(refreshPayload);
+    const refreshTokenHash = crypto.createHash('sha256').update(refreshToken).digest('hex');
+
+    const session: Session = {
+      sessionId,
+      userId,
+      refreshTokenHash,
+      createdAt: new Date().toISOString(),
+      accessExpiresAt: new Date((now + ACCESS_TTL_SECONDS) * 1000).toISOString(),
+      refreshExpiresAt: new Date((now + REFRESH_TTL_SECONDS) * 1000).toISOString(),
+      mfaVerified,
+      role,
+      active: true,
+    };
+
+    this.sessions.set(sessionId, session);
+
+    return {
+      accessToken,
+      refreshToken,
+      expiresIn: ACCESS_TTL_SECONDS,
+      tokenType: 'Bearer',
+    };
+  }
+
+  /**
+   * Refresh an expired (or soon-to-expire) access token using a valid refresh token.
+   * Issues a new access token and rotates the refresh token.
+   */
+  refreshSession(refreshToken: string): TokenPair | null {
+    const payload = verifyJwt(refreshToken);
+    if (!payload || payload.type !== 'refresh') return null;
+
+    const tokenHash = crypto.createHash('sha256').update(refreshToken).digest('hex');
+
+    // Find session by userId + refreshTokenHash
+    let existingSession: Session | undefined;
+    for (const session of this.sessions.values()) {
+      if (
+        session.userId === payload.sub &&
+        session.refreshTokenHash === tokenHash &&
+        session.active
+      ) {
+        existingSession = session;
+        break;
+      }
+    }
+
+    if (!existingSession) return null;
+
+    // Revoke old session (token rotation — prevents refresh token reuse)
+    existingSession.active = false;
+    existingSession.revokedAt = new Date().toISOString();
+    this.sessions.set(existingSession.sessionId, existingSession);
+
+    // Issue a new session
+    return this.createSession(payload.sub, {
+      mfaVerified: existingSession.mfaVerified,
+      role: existingSession.role,
+    });
+  }
+
+  /**
+   * Validate an access token and return its payload.
+   * Returns null if the token is invalid, expired, or the session has been revoked.
+   */
+  validateAccessToken(accessToken: string): JwtPayload | null {
+    const payload = verifyJwt(accessToken);
+    if (!payload || payload.type !== 'access') return null;
+
+    const session = this.sessions.get(payload.jti);
+    if (!session || !session.active) return null; // session revoked
+
+    return payload;
+  }
+
+  /**
+   * Revoke a specific session by session ID.
+   */
+  revokeSession(sessionId: string): boolean {
+    const session = this.sessions.get(sessionId);
+    if (!session) return false;
+
+    session.active = false;
+    session.revokedAt = new Date().toISOString();
+    this.sessions.set(sessionId, session);
+    return true;
+  }
+
+  /**
+   * Revoke all active sessions for a user (e.g., on password change).
+   */
+  revokeAllSessions(userId: string): number {
+    let count = 0;
+    const now = new Date().toISOString();
+    for (const session of this.sessions.values()) {
+      if (session.userId === userId && session.active) {
+        session.active = false;
+        session.revokedAt = now;
+        this.sessions.set(session.sessionId, session);
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /**
+   * List all active sessions for a user.
+   */
+  listSessions(userId: string): Omit<Session, 'refreshTokenHash'>[] {
+    const result: Omit<Session, 'refreshTokenHash'>[] = [];
+    for (const session of this.sessions.values()) {
+      if (session.userId === userId) {
+        const { refreshTokenHash: _dropped, ...safe } = session;
+        result.push(safe);
+      }
+    }
+    return result.sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    );
+  }
+
+  /**
+   * Purge expired/revoked sessions to prevent unbounded memory growth.
+   * Safe to call periodically in a background job.
+   */
+  purgeExpiredSessions(): number {
+    const now = new Date().toISOString();
+    let count = 0;
+    for (const [id, session] of this.sessions.entries()) {
+      if (!session.active || session.refreshExpiresAt < now) {
+        this.sessions.delete(id);
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /** For testing only. */
+  _resetForTest(): void {
+    this.sessions.clear();
+    _jwtSecret = undefined;
+  }
+
+  /** Expose for tests. */
+  get _store(): Map<string, Session> {
+    return this.sessions;
+  }
+}
+
+let defaultSessionManager: SessionManager | undefined;
+
+export function getDefaultSessionManager(): SessionManager {
+  if (!defaultSessionManager) defaultSessionManager = new SessionManager();
+  return defaultSessionManager;
+}
+
+export function _setDefaultSessionManagerForTest(mgr: SessionManager | undefined): void {
+  defaultSessionManager = mgr;
+}


### PR DESCRIPTION
- services/mfa.ts: TOTP-based MFA (RFC 6238) with base32 encode/decode, HOTP/TOTP core, backup codes (SHA256-hashed, single-use), MfaService class with setup/verifySetup/verifyCode/disable methods

- services/sessionManager.ts: JWT session management with access tokens (1h TTL), refresh tokens (7d TTL), per-user session tracking, token rotation on refresh, and session revocation (single + all)

- middleware/auth.ts: requireAuth, requireMfa, and optionalAuth Express middleware; requireMfa gates admin endpoints to mfaVerified sessions

- routes/auth.ts: REST endpoints for full MFA + session lifecycle: POST /api/auth/login POST /api/auth/mfa/enable POST /api/auth/mfa/verify POST /api/auth/refresh GET  /api/auth/sessions DELETE /api/auth/sessions DELETE /api/auth/sessions/:id POST /api/auth/logout
Closes  #1299 
Closes #1300 