### PR TITLE
feat: gzip compression middleware and enhanced request validation

### DIFF
--- a/api-server/scripts/benchmark-compression.ts
+++ b/api-server/scripts/benchmark-compression.ts
@@ -1,0 +1,232 @@
+/**
+ * Benchmark: Compression Middleware Overhead
+ * Issue #1313 — Gzip Compression
+ *
+ * Measures the latency and throughput impact of gzip compression at each
+ * configured compression level (0–9) across three representative payload
+ * sizes: small (< 1 KB), medium (10 KB), and large (100 KB).
+ *
+ * Run with: npx tsx scripts/benchmark-compression.ts
+ *
+ * Outputs a table like:
+ *
+ *   Payload      Level   Uncompressed   Compressed   Ratio   Throughput
+ *   -------      -----   ------------   ----------   -----   ----------
+ *   small         6      0.01 ms        N/A (skip)   -       -
+ *   medium (10KB) 6      0.05 ms        0.82 ms      68.4%   12.5 MB/s
+ *   large (100KB) 6      0.20 ms        6.10 ms      72.1%   15.9 MB/s
+ *
+ * Interpretation:
+ *   - "Ratio" is (1 - compressedSize/originalSize) * 100 — higher is better.
+ *   - "Throughput" is the decompressed MB per second the compressor achieves.
+ *   - Small payloads below the 1 KB threshold are skipped by the middleware
+ *     (shown as N/A).
+ */
+
+import zlib from 'zlib';
+import { performance } from 'perf_hooks';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const ITERATIONS = 1000;   // Warmup + measurement iterations per scenario
+const WARMUP = 100;        // Initial iterations discarded from timing
+const THRESHOLD_BYTES = 1024; // Must match middleware default
+
+// Compression levels to benchmark
+const LEVELS = [1, 3, 6, 9] as const;
+
+// ---------------------------------------------------------------------------
+// Payload generation
+// ---------------------------------------------------------------------------
+
+type PayloadSpec = { name: string; bytes: number; content: Buffer };
+
+function makeJsonPayload(targetBytes: number): Buffer {
+  const obj: Record<string, unknown> = {
+    credentials: [] as unknown[],
+    metadata: {
+      total: 0,
+      page: 1,
+      pageSize: 50,
+      generatedAt: new Date().toISOString(),
+    },
+  };
+
+  // Fill with realistic-looking JSON data (text compresses well)
+  const credentials: unknown[] = [];
+  const record = {
+    id: 'cred_12345',
+    subject: 'GABC123DEF456',
+    issuer: 'GIBR_ENGINEERING_COUNCIL',
+    credential_type: 2,
+    metadata: {
+      name: 'Professional Engineering License',
+      jurisdiction: 'BR',
+      expiry: '2028-01-01',
+    },
+    attestors: ['GATT1', 'GATT2', 'GATT3'],
+    attested_at: new Date().toISOString(),
+    revoked: false,
+    suspended: false,
+  };
+
+  while (JSON.stringify(obj).length < targetBytes) {
+    credentials.push({ ...record, id: `cred_${credentials.length}` });
+    obj.credentials = credentials;
+    obj.metadata = { ...obj.metadata as Record<string, unknown>, total: credentials.length };
+  }
+
+  return Buffer.from(JSON.stringify(obj));
+}
+
+const PAYLOADS: PayloadSpec[] = [
+  { name: 'small  (< 1 KB)', bytes: 512,     content: makeJsonPayload(512)     },
+  { name: 'medium (10 KB)',   bytes: 10240,   content: makeJsonPayload(10240)   },
+  { name: 'large  (100 KB)',  bytes: 102400,  content: makeJsonPayload(102400)  },
+];
+
+// ---------------------------------------------------------------------------
+// Benchmark runner
+// ---------------------------------------------------------------------------
+
+interface BenchResult {
+  payloadName: string;
+  payloadSize: number;
+  level: number;
+  skipped: boolean;            // true if below threshold
+  avgCompressMs: number;
+  p95CompressMs: number;
+  compressedSize: number;
+  ratio: number;               // 0–1, higher is more compression
+  throughputMBps: number;
+}
+
+async function benchmarkLevel(payload: PayloadSpec, level: number): Promise<BenchResult> {
+  if (payload.bytes < THRESHOLD_BYTES) {
+    return {
+      payloadName: payload.name,
+      payloadSize: payload.bytes,
+      level,
+      skipped: true,
+      avgCompressMs: 0,
+      p95CompressMs: 0,
+      compressedSize: 0,
+      ratio: 0,
+      throughputMBps: 0,
+    };
+  }
+
+  const samples: number[] = [];
+  let compressedSize = 0;
+
+  for (let i = 0; i < ITERATIONS + WARMUP; i++) {
+    const start = performance.now();
+    const compressed = await new Promise<Buffer>((resolve, reject) => {
+      zlib.gzip(payload.content, { level }, (err, result) => {
+        if (err) reject(err);
+        else resolve(result);
+      });
+    });
+    const elapsed = performance.now() - start;
+
+    if (i >= WARMUP) {
+      samples.push(elapsed);
+      if (i === WARMUP) compressedSize = compressed.length;
+    }
+  }
+
+  samples.sort((a, b) => a - b);
+  const avgCompressMs = samples.reduce((s, v) => s + v, 0) / samples.length;
+  const p95CompressMs = samples[Math.floor(samples.length * 0.95)];
+  const ratio = 1 - compressedSize / payload.bytes;
+  const throughputMBps = (payload.bytes / 1_048_576) / (avgCompressMs / 1000);
+
+  return {
+    payloadName: payload.name,
+    payloadSize: payload.bytes,
+    level,
+    skipped: false,
+    avgCompressMs,
+    p95CompressMs,
+    compressedSize,
+    ratio,
+    throughputMBps,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Report formatting
+// ---------------------------------------------------------------------------
+
+function fmt(n: number, decimals = 2): string {
+  return n.toFixed(decimals).padStart(8);
+}
+
+function printResults(results: BenchResult[]): void {
+  console.log('\n=== Compression Benchmark Results ===\n');
+  console.log(
+    'Payload               Level  Orig(B)   Comp(B)   Ratio    Avg(ms)  P95(ms)  Throughput'
+  );
+  console.log('-'.repeat(95));
+
+  for (const r of results) {
+    if (r.skipped) {
+      console.log(
+        `${r.payloadName.padEnd(22)} ${String(r.level).padStart(3)}    ` +
+        `${String(r.payloadSize).padStart(7)}   ${'(below threshold)'.padEnd(30)}`
+      );
+    } else {
+      console.log(
+        `${r.payloadName.padEnd(22)} ${String(r.level).padStart(3)}    ` +
+        `${String(r.payloadSize).padStart(7)}   ` +
+        `${String(r.compressedSize).padStart(7)}   ` +
+        `${fmt(r.ratio * 100, 1)}%  ` +
+        `${fmt(r.avgCompressMs, 3)} ms  ` +
+        `${fmt(r.p95CompressMs, 3)} ms  ` +
+        `${fmt(r.throughputMBps, 1)} MB/s`
+      );
+    }
+  }
+
+  console.log();
+}
+
+function summarise(results: BenchResult[]): void {
+  const active = results.filter((r) => !r.skipped);
+  if (active.length === 0) return;
+
+  const level6 = active.filter((r) => r.level === 6);
+  const avgRatio = level6.reduce((s, r) => s + r.ratio, 0) / level6.length;
+  const avgThroughput = level6.reduce((s, r) => s + r.throughputMBps, 0) / level6.length;
+
+  console.log('=== Summary (level=6 default) ===');
+  console.log(`  Average compression ratio : ${(avgRatio * 100).toFixed(1)}%`);
+  console.log(`  Average throughput        : ${avgThroughput.toFixed(1)} MB/s`);
+  console.log(`  Threshold                 : ${THRESHOLD_BYTES} bytes`);
+  console.log(`  Iterations (per scenario) : ${ITERATIONS} (${WARMUP} warmup discarded)`);
+  console.log();
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+(async () => {
+  console.log('Warming up…');
+
+  const results: BenchResult[] = [];
+
+  for (const payload of PAYLOADS) {
+    for (const level of LEVELS) {
+      process.stdout.write(`  ${payload.name} @ level ${level}…`);
+      const result = await benchmarkLevel(payload, level);
+      results.push(result);
+      process.stdout.write(result.skipped ? ' skipped (below threshold)\n' : ' done\n');
+    }
+  }
+
+  printResults(results);
+  summarise(results);
+})();

--- a/api-server/src/index.ts
+++ b/api-server/src/index.ts
@@ -1,7 +1,7 @@
 import express, { Request, Response, NextFunction } from 'express';
 import { createServer } from 'http';
-import compression from 'compression';
-import zlib from 'zlib';
+// #1313: Compression is configured via the dedicated middleware module.
+import { createCompressionFromEnv } from './middleware/compression.js';
 import slicesRouter from './routes/slices.js';
 import credentialsRouter from './routes/credentials.js';
 import credentialExportRouter from './routes/credentialExport.js';
@@ -42,6 +42,11 @@ const app = express();
 // without requiring auth. Origins are configured via CORS_ALLOWED_ORIGINS env var.
 const cors = createCorsFromEnv();
 app.use(cors);
+
+// #1313: Apply gzip compression early so all subsequent responses are eligible.
+// Only responses >= 1 KB threshold are compressed. Configure via env vars:
+//   COMPRESSION_ENABLED, COMPRESSION_LEVEL, COMPRESSION_THRESHOLD.
+app.use(createCompressionFromEnv());
 
 const ddosProtection = createDDoSProtection();
 app.use(ddosProtection);

--- a/api-server/src/middleware/compression.ts
+++ b/api-server/src/middleware/compression.ts
@@ -1,0 +1,180 @@
+/**
+ * Issue #1313 — Gzip Compression Middleware
+ *
+ * Adds response compression to the Express server using the `compression`
+ * package (zlib-backed).  Only responses larger than the configured threshold
+ * are compressed, so small payloads (e.g. 204 No Content or tiny JSON) are
+ * sent as-is to avoid the overhead of calling zlib for negligible savings.
+ *
+ * ## Configuration (environment variables)
+ *
+ *   COMPRESSION_LEVEL   — zlib compression level, 0–9 (default: 6).
+ *                          0 = no compression (store only), 9 = maximum.
+ *                          Use -1 to accept zlib's default.
+ *   COMPRESSION_THRESHOLD — minimum response size in bytes before compression
+ *                           is applied (default: 1024 = 1 KB).
+ *   COMPRESSION_ENABLED — set to "false" to disable entirely (useful in dev
+ *                         environments where CPU is precious and payloads are
+ *                         small).
+ *
+ * ## How it works
+ *
+ * The middleware wraps the standard `compression` npm package, which
+ * inspects the outgoing `Content-Type` and `Content-Length` headers before
+ * deciding whether to compress.  Binary content types (`image/*`,
+ * `video/*`, `audio/*`) are never compressed because they are already
+ * encoded and additional compression would expand the payload.
+ *
+ * The `filter` function below encodes these rules.  It is called once per
+ * response, before any body bytes are flushed.
+ *
+ * ## Usage
+ *
+ * ```ts
+ * import { createCompressionMiddleware } from './middleware/compression.js';
+ * app.use(createCompressionMiddleware());
+ * ```
+ */
+
+import compression from 'compression';
+import type { Request, Response } from 'express';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CompressionConfig {
+  /**
+   * zlib compression level, 0–9.
+   * 0  = no compression (passthrough, but adds zlib framing — use enabled=false
+   *      to skip entirely).
+   * 1  = fastest, largest output.
+   * 6  = balanced default (same as zlib's Z_DEFAULT_COMPRESSION).
+   * 9  = slowest, smallest output.
+   * -1 = let zlib pick (resolves to 6 in current versions).
+   */
+  level?: number;
+
+  /**
+   * Minimum response size (bytes) before compression is applied.
+   * Responses smaller than this are sent uncompressed.
+   * Default: 1024 (1 KB).
+   */
+  threshold?: number;
+
+  /**
+   * Whether compression is enabled at all.
+   * Default: true.  Set to false to disable without removing the middleware.
+   */
+  enabled?: boolean;
+
+  /**
+   * Content-type patterns that should NEVER be compressed.
+   * The built-in `compression` package already skips binary formats, but
+   * this list lets callers add application-specific exclusions (e.g. SSE
+   * streams that must not be buffered).
+   *
+   * Each entry is compared as a substring of the lower-cased Content-Type.
+   * Default: ['text/event-stream'].
+   */
+  excludeContentTypes?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Content-type substrings that should never be compressed.
+ * Media that is already encoded gains nothing and may even grow slightly.
+ */
+const ALWAYS_EXCLUDE_PREFIXES = [
+  'image/',
+  'video/',
+  'audio/',
+  'font/',
+  'application/zip',
+  'application/gzip',
+  'application/x-brotli',
+  'application/x-7z-compressed',
+  'application/x-rar-compressed',
+];
+
+/**
+ * Decide whether a response should be compressed.
+ *
+ * The `compression` package calls this function with the request and the
+ * response.  Returning `false` disables compression for that response;
+ * returning `true` defers to the package's own size threshold check.
+ */
+function shouldCompress(
+  req: Request,
+  res: Response,
+  excludeContentTypes: string[]
+): boolean {
+  const contentType = ((res.getHeader('Content-Type') as string | undefined) ?? '').toLowerCase();
+
+  // Never compress already-encoded / binary formats.
+  for (const prefix of ALWAYS_EXCLUDE_PREFIXES) {
+    if (contentType.startsWith(prefix)) return false;
+  }
+
+  // Never compress caller-specified exclusions.
+  for (const excluded of excludeContentTypes) {
+    if (contentType.includes(excluded.toLowerCase())) return false;
+  }
+
+  // Defer to the package's threshold check.
+  return compression.filter(req, res);
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a configured compression middleware instance.
+ *
+ * Call once at startup and pass the result to `app.use()`.
+ *
+ * @example
+ * ```ts
+ * app.use(createCompressionMiddleware({ level: 6, threshold: 1024 }));
+ * ```
+ */
+export function createCompressionMiddleware(config: CompressionConfig = {}) {
+  const enabled = config.enabled !== false;
+
+  if (!enabled) {
+    // Return a no-op middleware so callers never need to conditionalise.
+    return (_req: Request, _res: Response, next: () => void) => next();
+  }
+
+  const level = config.level ?? parseInt(process.env.COMPRESSION_LEVEL ?? '6', 10);
+  const threshold = config.threshold ?? parseInt(process.env.COMPRESSION_THRESHOLD ?? '1024', 10);
+  const excludeContentTypes = config.excludeContentTypes ?? ['text/event-stream'];
+
+  return compression({
+    level,
+    threshold,
+    filter: (req, res) => shouldCompress(req, res, excludeContentTypes),
+  });
+}
+
+/**
+ * Create a compression middleware from environment variables.
+ *
+ * Environment variables:
+ *   COMPRESSION_ENABLED   — 'true' | 'false' (default: true)
+ *   COMPRESSION_LEVEL     — integer 0–9 (default: 6)
+ *   COMPRESSION_THRESHOLD — bytes (default: 1024)
+ */
+export function createCompressionFromEnv(): ReturnType<typeof createCompressionMiddleware> {
+  const enabled = process.env.COMPRESSION_ENABLED !== 'false';
+  const level = parseInt(process.env.COMPRESSION_LEVEL ?? '6', 10);
+  const threshold = parseInt(process.env.COMPRESSION_THRESHOLD ?? '1024', 10);
+
+  return createCompressionMiddleware({ enabled, level, threshold });
+}
+
+export default createCompressionFromEnv;

--- a/api-server/src/middleware/validate.ts
+++ b/api-server/src/middleware/validate.ts
@@ -1,51 +1,244 @@
+/**
+ * Issue #1312 — Request Validation Middleware
+ *
+ * Provides a composable, schema-driven validation middleware for Express
+ * endpoints.  Uses AJV for JSON Schema validation with coercion and defaults,
+ * and supports custom validator functions for complex business-logic checks
+ * that cannot be expressed purely in JSON Schema.
+ *
+ * ## Features
+ *
+ * 1. **JSON Schema validation** — body, query, and params can each have a
+ *    JSON Schema.  Schemas are compiled once at startup and reused across
+ *    requests (AJV caches compiled validators internally).
+ *
+ * 2. **Detailed error responses** — on validation failure the 400 body
+ *    includes a `details` array describing every AJV error:
+ *    `{ path, keyword, message }`.  This lets API clients surface precise
+ *    field-level errors rather than a generic "invalid" message.
+ *
+ * 3. **Custom validators** — each location (body / query / params) accepts an
+ *    optional `custom` function `(data) => true | string | string[]`.
+ *    Returning a string (or array of strings) means validation failed; the
+ *    string becomes the error message in the 400 response.  This is useful for
+ *    cross-field invariants, Stellar address checks, etc.
+ *
+ * ## Usage
+ *
+ * ```ts
+ * import { validate, schemas } from '../middleware/validate.js';
+ *
+ * router.post(
+ *   '/batch',
+ *   validate({
+ *     body: {
+ *       schema: schemas.verifyBatch.body,
+ *       custom: (data) => {
+ *         const d = data as { credential_ids: number[]; slice_id: number };
+ *         if (d.credential_ids.includes(d.slice_id)) {
+ *           return 'slice_id must not appear in credential_ids';
+ *         }
+ *         return true;
+ *       },
+ *     },
+ *   }),
+ *   handler,
+ * );
+ * ```
+ */
+
 import { Request, Response, NextFunction } from 'express';
 import { default as AjvLib } from 'ajv';
 
 const Ajv = AjvLib as unknown as new (opts: Record<string, unknown>) => {
-  compile: (schema: Record<string, unknown>) => (data: unknown) => boolean;
+  compile: (schema: Record<string, unknown>) => AjvValidatorFn;
 };
 const ajv = new Ajv({ coerceTypes: true, useDefaults: true, removeAdditional: true });
 
-type ValidationSchemas = {
-  body?: Record<string, unknown>;
-  query?: Record<string, unknown>;
-  params?: Record<string, unknown>;
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+interface AjvError {
+  schemaPath: string;
+  keyword: string;
+  message: string;
+  data: unknown;
+}
+
+interface AjvValidatorFn {
+  (data: unknown): boolean;
+  errors?: AjvError[];
+}
+
+/**
+ * A custom validator that runs *after* the JSON Schema check passes.
+ *
+ * Return `true` to indicate the value is valid.
+ * Return a `string` (or `string[]`) to indicate failure; the string(s) become
+ * the error message(s) in the 400 response body.
+ */
+export type CustomValidator = (data: unknown) => true | string | string[];
+
+/**
+ * Per-location validation configuration.  You can supply either a plain JSON
+ * Schema object (backward-compatible with the previous API) or a richer
+ * `LocationConfig` object that also carries a custom validator.
+ */
+export type LocationSchema = Record<string, unknown>;
+
+export interface LocationConfig {
+  /** AJV-compatible JSON Schema for structural validation. */
+  schema?: LocationSchema;
+  /**
+   * Custom validator for business-logic checks.
+   * Runs only when the JSON Schema check passes (or when no schema is
+   * provided).
+   */
+  custom?: CustomValidator;
+}
+
+export type LocationInput = LocationSchema | LocationConfig;
+
+export type ValidationSchemas = {
+  body?: LocationInput;
+  query?: LocationInput;
+  params?: LocationInput;
 };
 
-export function validate(schemas: ValidationSchemas) {
-  const validators: { check: (data: unknown) => boolean; location: string }[] = [];
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
-  if (schemas.body) {
-    const validateBody = ajv.compile(schemas.body);
-    validators.push({ check: (d) => validateBody(d), location: 'body' });
+/**
+ * Normalise a `LocationInput` to a `LocationConfig`.
+ * A plain schema object is wrapped in `{ schema }`.
+ */
+function normalise(input: LocationInput): LocationConfig {
+  if ('schema' in input || 'custom' in input) {
+    return input as LocationConfig;
   }
-  if (schemas.query) {
-    const validateQuery = ajv.compile(schemas.query);
-    validators.push({ check: (d) => validateQuery(d), location: 'query' });
-  }
-  if (schemas.params) {
-    const validateParams = ajv.compile(schemas.params);
-    validators.push({ check: (d) => validateParams(d), location: 'params' });
+  // Plain JSON Schema object — treat as `{ schema: input }`.
+  return { schema: input as LocationSchema };
+}
+
+// ---------------------------------------------------------------------------
+// Middleware factory
+// ---------------------------------------------------------------------------
+
+export function validate(schemas: ValidationSchemas) {
+  type Entry = {
+    location: 'body' | 'query' | 'params';
+    validator: AjvValidatorFn | null;
+    custom: CustomValidator | null;
+  };
+
+  const entries: Entry[] = [];
+
+  for (const location of ['body', 'query', 'params'] as const) {
+    const input = schemas[location];
+    if (!input) continue;
+
+    const cfg = normalise(input);
+
+    const validator = cfg.schema
+      ? (ajv.compile(cfg.schema) as AjvValidatorFn)
+      : null;
+
+    entries.push({
+      location,
+      validator,
+      custom: cfg.custom ?? null,
+    });
   }
 
   return (req: Request, res: Response, next: NextFunction): void => {
-    for (const v of validators) {
+    for (const { location, validator, custom } of entries) {
       let data: unknown;
-      if (v.location === 'body') data = req.body;
-      else if (v.location === 'query') data = req.query;
-      else if (v.location === 'params') data = req.params;
+      if (location === 'body') data = req.body;
+      else if (location === 'query') data = req.query;
+      else data = req.params;
 
-      if (!v.check(data)) {
+      // 1. JSON Schema validation
+      if (validator !== null && !validator(data)) {
+        const errors = validator.errors ?? [];
         res.status(400).json({
           error: 'Validation failed',
-          location: v.location,
+          location,
+          details: errors.map((err) => ({
+            path: err.schemaPath,
+            keyword: err.keyword,
+            message: err.message,
+          })),
         });
         return;
       }
+
+      // 2. Custom validation (only reached when schema check passes or absent)
+      if (custom !== null) {
+        const result = custom(data);
+        if (result !== true) {
+          const messages = Array.isArray(result) ? result : [result];
+          res.status(400).json({
+            error: 'Validation failed',
+            location,
+            details: messages.map((message) => ({ path: '#', keyword: 'custom', message })),
+          });
+          return;
+        }
+      }
     }
+
     next();
   };
 }
+
+// ---------------------------------------------------------------------------
+// Built-in custom validators
+// ---------------------------------------------------------------------------
+
+/**
+ * Checks that a string value looks like a valid Stellar account address
+ * (G-address, 56 characters, base32 alphabet).
+ *
+ * This is a lightweight format check — it does not verify the checksum.
+ * Use `@stellar/stellar-sdk`'s `StrKey.isValidEd25519PublicKey` for a
+ * rigorous check when the SDK is already in scope.
+ */
+export function stellarAddressValidator(fieldName: string): CustomValidator {
+  const STELLAR_G_ADDRESS = /^G[A-Z2-7]{55}$/;
+  return (data) => {
+    if (typeof data !== 'object' || data === null) return true;
+    const value = (data as Record<string, unknown>)[fieldName];
+    if (value === undefined || value === null) return true; // required-ness enforced by schema
+    if (typeof value !== 'string' || !STELLAR_G_ADDRESS.test(value)) {
+      return `${fieldName} must be a valid Stellar G-address`;
+    }
+    return true;
+  };
+}
+
+/**
+ * Ensures that an array field has no duplicate values.
+ */
+export function noDuplicatesValidator(fieldName: string): CustomValidator {
+  return (data) => {
+    if (typeof data !== 'object' || data === null) return true;
+    const arr = (data as Record<string, unknown>)[fieldName];
+    if (!Array.isArray(arr)) return true;
+    const seen = new Set();
+    for (const item of arr) {
+      const key = JSON.stringify(item);
+      if (seen.has(key)) return `${fieldName} must not contain duplicate values`;
+      seen.add(key);
+    }
+    return true;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shared schemas
+// ---------------------------------------------------------------------------
 
 export const schemas = {
   verifyBatch: {

--- a/api-server/tests/compression.test.ts
+++ b/api-server/tests/compression.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for Issue #1313 — Gzip Compression Middleware
+ *
+ * Verifies:
+ *   - Responses above the 1 KB threshold are compressed
+ *   - Responses below the threshold are NOT compressed
+ *   - Compression level is configurable
+ *   - Excluded content types are never compressed
+ *   - Middleware can be disabled via config
+ *   - `Accept-Encoding: gzip` is respected
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { createCompressionMiddleware } from '../src/middleware/compression.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal Express app with compression applied. */
+function buildApp(config: Parameters<typeof createCompressionMiddleware>[0] = {}): Express {
+  const app = express();
+  app.use(createCompressionMiddleware(config));
+
+  /** Returns a JSON body of approximately `size` bytes. */
+  app.get('/large', (_req, res) => {
+    // Build a payload comfortably over 1 KB
+    const payload = { data: 'x'.repeat(2048) };
+    res.json(payload);
+  });
+
+  app.get('/small', (_req, res) => {
+    res.json({ ok: true });
+  });
+
+  app.get('/text', (_req, res) => {
+    res.set('Content-Type', 'text/plain');
+    res.send('x'.repeat(2048));
+  });
+
+  app.get('/image', (_req, res) => {
+    res.set('Content-Type', 'image/png');
+    res.send(Buffer.alloc(2048)); // 2 KB binary blob
+  });
+
+  app.get('/sse', (_req, res) => {
+    res.set('Content-Type', 'text/event-stream');
+    res.send('data: hello\n\n'.repeat(200));
+  });
+
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Compression enabled (default)
+// ---------------------------------------------------------------------------
+
+describe('Compression middleware — enabled', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = buildApp({ level: 6, threshold: 1024 });
+  });
+
+  it('compresses a large JSON response when client accepts gzip', async () => {
+    const res = await request(app)
+      .get('/large')
+      .set('Accept-Encoding', 'gzip')
+      .expect(200);
+
+    // The compressed response must declare gzip encoding.
+    expect(res.headers['content-encoding']).toBe('gzip');
+  });
+
+  it('does NOT compress a small response (below 1 KB threshold)', async () => {
+    const res = await request(app)
+      .get('/small')
+      .set('Accept-Encoding', 'gzip')
+      .expect(200);
+
+    // Content-Encoding should be absent or not 'gzip'
+    expect(res.headers['content-encoding'] ?? '').not.toBe('gzip');
+  });
+
+  it('compresses text/plain responses above threshold', async () => {
+    const res = await request(app)
+      .get('/text')
+      .set('Accept-Encoding', 'gzip')
+      .expect(200);
+
+    expect(res.headers['content-encoding']).toBe('gzip');
+  });
+
+  it('does NOT compress image/* responses (already encoded)', async () => {
+    const res = await request(app)
+      .get('/image')
+      .set('Accept-Encoding', 'gzip')
+      .expect(200);
+
+    expect(res.headers['content-encoding'] ?? '').not.toBe('gzip');
+  });
+
+  it('does NOT compress text/event-stream (SSE must not be buffered)', async () => {
+    const res = await request(app)
+      .get('/sse')
+      .set('Accept-Encoding', 'gzip')
+      .expect(200);
+
+    expect(res.headers['content-encoding'] ?? '').not.toBe('gzip');
+  });
+
+  it('does NOT compress when client explicitly requests identity (no compression)', async () => {
+    const res = await request(app)
+      .get('/large')
+      .set('Accept-Encoding', 'identity')
+      .expect(200);
+
+    expect(res.headers['content-encoding'] ?? '').not.toBe('gzip');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compression disabled
+// ---------------------------------------------------------------------------
+
+describe('Compression middleware — disabled', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = buildApp({ enabled: false });
+  });
+
+  it('does not compress any response when middleware is disabled', async () => {
+    const res = await request(app)
+      .get('/large')
+      .set('Accept-Encoding', 'gzip')
+      .expect(200);
+
+    expect(res.headers['content-encoding'] ?? '').not.toBe('gzip');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Custom threshold
+// ---------------------------------------------------------------------------
+
+describe('Compression middleware — custom threshold', () => {
+  it('compresses responses above a low custom threshold', async () => {
+    const app = buildApp({ threshold: 10 }); // anything > 10 bytes
+
+    const res = await request(app)
+      .get('/small')
+      .set('Accept-Encoding', 'gzip')
+      .expect(200);
+
+    // { ok: true } is ~11 bytes — should be compressed with threshold=10
+    expect(res.headers['content-encoding']).toBe('gzip');
+  });
+
+  it('does not compress when threshold is set very high', async () => {
+    const app = buildApp({ threshold: 1_000_000 }); // 1 MB
+
+    const res = await request(app)
+      .get('/large')
+      .set('Accept-Encoding', 'gzip')
+      .expect(200);
+
+    expect(res.headers['content-encoding'] ?? '').not.toBe('gzip');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Custom exclude list
+// ---------------------------------------------------------------------------
+
+describe('Compression middleware — excludeContentTypes', () => {
+  it('does not compress a custom excluded content type', async () => {
+    const app = buildApp({
+      threshold: 1,
+      excludeContentTypes: ['application/json'],
+    });
+
+    const res = await request(app)
+      .get('/large')
+      .set('Accept-Encoding', 'gzip')
+      .expect(200);
+
+    expect(res.headers['content-encoding'] ?? '').not.toBe('gzip');
+  });
+});

--- a/api-server/tests/validate.test.ts
+++ b/api-server/tests/validate.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Tests for Issue #1312 — Request Validation Middleware
+ *
+ * Verifies:
+ *   - JSON Schema validation of body / query / params
+ *   - Detailed AJV error information in 400 responses
+ *   - Custom validators for complex business-logic checks
+ *   - Built-in validators (stellarAddressValidator, noDuplicatesValidator)
+ *   - Backward-compatible plain-schema usage
+ *   - Multiple locations validated in a single middleware call
+ */
+
+import { describe, it, expect } from 'vitest';
+import express, { type Express } from 'express';
+import request from 'supertest';
+import {
+  validate,
+  stellarAddressValidator,
+  noDuplicatesValidator,
+  type CustomValidator,
+} from '../src/middleware/validate.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Plain schema (backward-compatible API)
+// ---------------------------------------------------------------------------
+
+describe('validate — plain JSON Schema', () => {
+  it('passes valid body', async () => {
+    const app = buildApp();
+    app.post(
+      '/batch',
+      validate({
+        body: {
+          type: 'object',
+          properties: {
+            credential_ids: { type: 'array', items: { type: 'integer' }, minItems: 1 },
+            slice_id: { type: 'integer' },
+          },
+          required: ['credential_ids', 'slice_id'],
+          additionalProperties: false,
+        },
+      }),
+      (_req, res) => res.json({ ok: true }),
+    );
+
+    const res = await request(app)
+      .post('/batch')
+      .send({ credential_ids: [1, 2, 3], slice_id: 5 })
+      .expect(200);
+
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('rejects invalid body with 400 and details array', async () => {
+    const app = buildApp();
+    app.post(
+      '/batch',
+      validate({
+        body: {
+          type: 'object',
+          properties: {
+            credential_ids: { type: 'array', items: { type: 'integer' }, minItems: 1 },
+            slice_id: { type: 'integer' },
+          },
+          required: ['credential_ids', 'slice_id'],
+          additionalProperties: false,
+        },
+      }),
+      (_req, res) => res.json({ ok: true }),
+    );
+
+    const res = await request(app)
+      .post('/batch')
+      .send({ credential_ids: [] }) // missing slice_id, empty array
+      .expect(400);
+
+    expect(res.body.error).toBe('Validation failed');
+    expect(res.body.location).toBe('body');
+    expect(Array.isArray(res.body.details)).toBe(true);
+    expect(res.body.details.length).toBeGreaterThan(0);
+    // Each detail must have keyword and message
+    for (const detail of res.body.details) {
+      expect(typeof detail.keyword).toBe('string');
+      expect(typeof detail.message).toBe('string');
+    }
+  });
+
+  it('validates query params', async () => {
+    const app = buildApp();
+    app.get(
+      '/search',
+      validate({
+        query: {
+          type: 'object',
+          properties: { limit: { type: 'integer', minimum: 1, maximum: 100 } },
+          required: ['limit'],
+          additionalProperties: false,
+        },
+      }),
+      (req, res) => res.json({ limit: req.query.limit }),
+    );
+
+    // Valid
+    await request(app).get('/search?limit=10').expect(200);
+
+    // Missing required field
+    const res = await request(app).get('/search').expect(400);
+    expect(res.body.location).toBe('query');
+  });
+
+  it('validates route params', async () => {
+    const app = buildApp();
+    app.get(
+      '/items/:id',
+      validate({
+        params: {
+          type: 'object',
+          properties: { id: { type: 'integer', minimum: 1 } },
+          required: ['id'],
+          additionalProperties: false,
+        },
+      }),
+      (req, res) => res.json({ id: req.params.id }),
+    );
+
+    // AJV with coerceTypes will parse the string '42' to integer 42
+    await request(app).get('/items/42').expect(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Custom validators
+// ---------------------------------------------------------------------------
+
+describe('validate — custom validators', () => {
+  it('passes when custom validator returns true', async () => {
+    const app = buildApp();
+    const noop: CustomValidator = () => true;
+
+    app.post(
+      '/custom',
+      validate({ body: { schema: { type: 'object', additionalProperties: true }, custom: noop } }),
+      (_req, res) => res.json({ ok: true }),
+    );
+
+    await request(app).post('/custom').send({ foo: 'bar' }).expect(200);
+  });
+
+  it('rejects with 400 when custom validator returns a string message', async () => {
+    const app = buildApp();
+    const alwaysFail: CustomValidator = () => 'always fails';
+
+    app.post(
+      '/custom',
+      validate({
+        body: {
+          schema: { type: 'object', additionalProperties: true },
+          custom: alwaysFail,
+        },
+      }),
+      (_req, res) => res.json({ ok: true }),
+    );
+
+    const res = await request(app).post('/custom').send({ foo: 'bar' }).expect(400);
+    expect(res.body.error).toBe('Validation failed');
+    expect(res.body.details[0].message).toBe('always fails');
+    expect(res.body.details[0].keyword).toBe('custom');
+  });
+
+  it('returns multiple error messages when custom returns string[]', async () => {
+    const app = buildApp();
+    const multiError: CustomValidator = () => ['error one', 'error two'];
+
+    app.post(
+      '/custom',
+      validate({ body: { schema: { type: 'object', additionalProperties: true }, custom: multiError } }),
+      (_req, res) => res.json({ ok: true }),
+    );
+
+    const res = await request(app).post('/custom').send({}).expect(400);
+    expect(res.body.details).toHaveLength(2);
+    expect(res.body.details[0].message).toBe('error one');
+    expect(res.body.details[1].message).toBe('error two');
+  });
+
+  it('skips custom validator when schema check fails', async () => {
+    const app = buildApp();
+    let customCalled = false;
+    const shouldNotBeReached: CustomValidator = () => {
+      customCalled = true;
+      return true;
+    };
+
+    app.post(
+      '/custom',
+      validate({
+        body: {
+          schema: {
+            type: 'object',
+            properties: { n: { type: 'integer' } },
+            required: ['n'],
+            additionalProperties: false,
+          },
+          custom: shouldNotBeReached,
+        },
+      }),
+      (_req, res) => res.json({ ok: true }),
+    );
+
+    // Missing required field — schema check fails before custom runs
+    await request(app).post('/custom').send({}).expect(400);
+    expect(customCalled).toBe(false);
+  });
+
+  it('runs custom validator without a schema', async () => {
+    const app = buildApp();
+
+    app.post(
+      '/custom-only',
+      validate({
+        body: {
+          custom: (data) => {
+            const d = data as Record<string, unknown>;
+            return d['magic'] === 42 ? true : 'magic must be 42';
+          },
+        },
+      }),
+      (_req, res) => res.json({ ok: true }),
+    );
+
+    await request(app).post('/custom-only').send({ magic: 42 }).expect(200);
+    const res = await request(app).post('/custom-only').send({ magic: 0 }).expect(400);
+    expect(res.body.details[0].message).toBe('magic must be 42');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Built-in validators
+// ---------------------------------------------------------------------------
+
+describe('stellarAddressValidator', () => {
+  it('accepts a valid Stellar G-address', async () => {
+    const app = buildApp();
+    app.post(
+      '/issue',
+      validate({
+        body: {
+          schema: {
+            type: 'object',
+            properties: { address: { type: 'string' } },
+            required: ['address'],
+            additionalProperties: false,
+          },
+          custom: stellarAddressValidator('address'),
+        },
+      }),
+      (_req, res) => res.json({ ok: true }),
+    );
+
+    const validAddress = 'G' + 'A'.repeat(55); // 56 chars, all uppercase
+    await request(app).post('/issue').send({ address: validAddress }).expect(200);
+  });
+
+  it('rejects an invalid Stellar address', async () => {
+    const app = buildApp();
+    app.post(
+      '/issue',
+      validate({
+        body: {
+          schema: {
+            type: 'object',
+            properties: { address: { type: 'string' } },
+            required: ['address'],
+            additionalProperties: false,
+          },
+          custom: stellarAddressValidator('address'),
+        },
+      }),
+      (_req, res) => res.json({ ok: true }),
+    );
+
+    const res = await request(app)
+      .post('/issue')
+      .send({ address: 'not-a-stellar-address' })
+      .expect(400);
+
+    expect(res.body.details[0].message).toContain('address');
+  });
+});
+
+describe('noDuplicatesValidator', () => {
+  it('passes when array has no duplicates', async () => {
+    const app = buildApp();
+    app.post(
+      '/batch',
+      validate({
+        body: {
+          schema: {
+            type: 'object',
+            properties: { ids: { type: 'array', items: { type: 'integer' } } },
+            required: ['ids'],
+            additionalProperties: false,
+          },
+          custom: noDuplicatesValidator('ids'),
+        },
+      }),
+      (_req, res) => res.json({ ok: true }),
+    );
+
+    await request(app).post('/batch').send({ ids: [1, 2, 3] }).expect(200);
+  });
+
+  it('rejects array with duplicate values', async () => {
+    const app = buildApp();
+    app.post(
+      '/batch',
+      validate({
+        body: {
+          schema: {
+            type: 'object',
+            properties: { ids: { type: 'array', items: { type: 'integer' } } },
+            required: ['ids'],
+            additionalProperties: false,
+          },
+          custom: noDuplicatesValidator('ids'),
+        },
+      }),
+      (_req, res) => res.json({ ok: true }),
+    );
+
+    const res = await request(app)
+      .post('/batch')
+      .send({ ids: [1, 2, 2, 3] })
+      .expect(400);
+
+    expect(res.body.details[0].message).toContain('duplicate');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple locations
+// ---------------------------------------------------------------------------
+
+describe('validate — multiple locations', () => {
+  it('validates body and params simultaneously', async () => {
+    const app = buildApp();
+    app.put(
+      '/items/:id',
+      validate({
+        params: {
+          type: 'object',
+          properties: { id: { type: 'integer', minimum: 1 } },
+          required: ['id'],
+          additionalProperties: false,
+        },
+        body: {
+          type: 'object',
+          properties: { name: { type: 'string', minLength: 1 } },
+          required: ['name'],
+          additionalProperties: false,
+        },
+      }),
+      (_req, res) => res.json({ ok: true }),
+    );
+
+    // Both valid
+    await request(app).put('/items/5').send({ name: 'test' }).expect(200);
+
+    // Body invalid (missing name)
+    const res = await request(app).put('/items/5').send({}).expect(400);
+    expect(res.body.location).toBe('body');
+  });
+});


### PR DESCRIPTION
## Summary

Implements two related API-server improvements: gzip compression for bandwidth reduction and enhanced request validation with detailed error reporting.

---

### #1313 — Add Request/Response Compression

**New file**: `api-server/src/middleware/compression.ts`

- `createCompressionMiddleware(config)` factory wraps the `compression` npm package
- `createCompressionFromEnv()` reads config from environment variables
- **Compression level** configurable via `COMPRESSION_LEVEL` (0–9, default: 6)
- **1 KB threshold**: responses smaller than `COMPRESSION_THRESHOLD` (default: 1024 bytes) are sent uncompressed — zero overhead for small payloads
- Binary content types (`image/*`, `video/*`, `audio/*`, `font/*`, archives) are never compressed (already encoded; compressing them wastes CPU)
- SSE streams (`text/event-stream`) are excluded to prevent buffering issues
- Custom exclusion list configurable per deployment
- Wired in `index.ts` early in the middleware stack (after CORS, before routes)

**Environment variables**:
| Variable | Default | Description |
|---|---|---|
| `COMPRESSION_ENABLED` | `true` | Set to `false` to disable entirely |
| `COMPRESSION_LEVEL` | `6` | zlib level 0–9 (1=fastest, 9=smallest) |
| `COMPRESSION_THRESHOLD` | `1024` | Min bytes before compressing |

**Benchmark script**: `api-server/scripts/benchmark-compression.ts`
- Measures avg/p95 latency, compression ratio, and throughput
- Tests levels 1, 3, 6, 9 across small (<1 KB), medium (10 KB), and large (100 KB) payloads
- Run with: `npx tsx scripts/benchmark-compression.ts`

---

### #1312 — Implement Request Validation Middleware

**Updated file**: `api-server/src/middleware/validate.ts`

- **Detailed AJV error responses**: 400 body now includes a `details` array with `path`, `keyword`, and `message` per validation failure, so clients can surface field-level errors
- **Custom validators**: new `LocationConfig` API allows pairing a JSON Schema with a `custom: (data) => true | string | string[]` function for business-logic checks that cannot be expressed in JSON Schema alone
- **Built-in validators**:
  - `stellarAddressValidator(field)` — validates G-address format (56-char base32)
  - `noDuplicatesValidator(field)` — rejects arrays with duplicate values
- **Backward compatible**: plain schema objects still work exactly as before

---

## Testing

- **`tests/compression.test.ts`** — 10 tests: threshold enforcement, content-type exclusions, disabled mode, custom threshold and exclude list
- **`tests/validate.test.ts`** — 14 tests: plain schema validation, custom validators, built-in validators, multiple locations, error detail structure

All 24 new tests pass. The 3 pre-existing failures (`contract-tests.test.ts`, `issuer.test.ts`, `issuer-metrics.test.ts`) are unrelated to these changes and were failing before this PR.

Closes #1312
Closes #1313