### PR TITLE
feat(#1315): Add content negotiation middleware (CSV/XML/JSON)

### DIFF
--- a/api-server/src/middleware/contentNegotiation.ts
+++ b/api-server/src/middleware/contentNegotiation.ts
@@ -1,0 +1,274 @@
+/**
+ * #1315 — Content Negotiation middleware
+ *
+ * Parses the Accept header and attaches a `respond` helper to `res.locals`
+ * that serialises a payload to JSON, CSV, or XML based on the negotiated
+ * media type.
+ *
+ * Supported types (in preference order):
+ *   application/json   → JSON (default)
+ *   text/csv           → CSV  (flat object arrays only; nested fields are
+ *                              JSON-stringified so the output is always valid CSV)
+ *   application/xml    → XML
+ *   text/xml           → XML (alias)
+ *
+ * Usage in a route handler:
+ *
+ *   import { respondNegotiated } from '../middleware/contentNegotiation.js';
+ *
+ *   router.get('/list', (req, res) => {
+ *     const data = [{ id: 1, name: 'foo' }];
+ *     respondNegotiated(req, res, data, { rootElement: 'attestors', itemElement: 'attestor' });
+ *   });
+ *
+ * The middleware itself is optional at the application level — routes call
+ * `respondNegotiated` directly instead.
+ */
+
+import { Request, Response, NextFunction } from 'express';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface NegotiationOptions {
+  /**
+   * XML root-element name (default: "response").
+   * Only used when the negotiated type is XML.
+   */
+  rootElement?: string;
+  /**
+   * XML element name for each item in an array (default: "item").
+   * Only used when the negotiated type is XML and the payload is an array.
+   */
+  itemElement?: string;
+  /**
+   * Override the HTTP status code (default: 200).
+   */
+  status?: number;
+}
+
+type SupportedType = 'json' | 'csv' | 'xml';
+
+// ── Accept-header negotiation ─────────────────────────────────────────────────
+
+const MIME_TO_TYPE: Record<string, SupportedType> = {
+  'application/json': 'json',
+  'text/json': 'json',
+  '*/*': 'json',
+  'text/csv': 'csv',
+  'application/csv': 'csv',
+  'application/xml': 'xml',
+  'text/xml': 'xml',
+};
+
+/**
+ * Parse an Accept header value and return the negotiated internal type.
+ *
+ * The parser respects `q=` quality factors, picks the highest-q supported
+ * type, and falls back to JSON when no acceptable match is found (rather than
+ * returning 406 — changing that policy is left to individual routes).
+ */
+export function negotiateType(acceptHeader: string | undefined): SupportedType {
+  if (!acceptHeader || acceptHeader.trim() === '') return 'json';
+
+  // Split by comma, parse each entry: "type/subtype; q=0.9"
+  const entries = acceptHeader
+    .split(',')
+    .map((part) => {
+      const [mediaType, ...params] = part.trim().split(';');
+      const qParam = params.find((p) => p.trim().startsWith('q='));
+      const q = qParam ? parseFloat(qParam.split('=')[1] ?? '1') : 1;
+      return { mediaType: (mediaType ?? '').trim().toLowerCase(), q: isNaN(q) ? 1 : q };
+    })
+    .filter((e) => e.q > 0)
+    .sort((a, b) => b.q - a.q); // highest quality first
+
+  for (const { mediaType } of entries) {
+    const mapped = MIME_TO_TYPE[mediaType];
+    if (mapped) return mapped;
+  }
+
+  return 'json'; // default
+}
+
+// ── CSV serialiser ────────────────────────────────────────────────────────────
+
+/**
+ * Escape a single CSV field: wrap in quotes and double any interior quotes.
+ */
+function csvEscape(value: unknown): string {
+  const str =
+    value === null || value === undefined
+      ? ''
+      : typeof value === 'object'
+      ? JSON.stringify(value)
+      : String(value);
+  // Wrap in double-quotes if the value contains commas, newlines, or quotes
+  if (str.includes('"') || str.includes(',') || str.includes('\n') || str.includes('\r')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/**
+ * Serialise an array of objects to RFC 4180 CSV.
+ * If `data` is a plain object, it is wrapped in a one-element array.
+ * Non-array / non-object values are returned as a plain text line.
+ */
+export function toCSV(data: unknown): string {
+  const rows: Record<string, unknown>[] = [];
+
+  if (Array.isArray(data)) {
+    for (const item of data) {
+      rows.push(typeof item === 'object' && item !== null ? (item as Record<string, unknown>) : { value: item });
+    }
+  } else if (data !== null && typeof data === 'object') {
+    rows.push(data as Record<string, unknown>);
+  } else {
+    return String(data ?? '');
+  }
+
+  if (rows.length === 0) return '';
+
+  // Collect all column headers from all rows (union of keys in order of first appearance)
+  const headers: string[] = [];
+  const headerSet = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      if (!headerSet.has(key)) {
+        headerSet.add(key);
+        headers.push(key);
+      }
+    }
+  }
+
+  const lines: string[] = [headers.map(csvEscape).join(',')];
+  for (const row of rows) {
+    lines.push(headers.map((h) => csvEscape(row[h])).join(','));
+  }
+
+  return lines.join('\r\n');
+}
+
+// ── XML serialiser ────────────────────────────────────────────────────────────
+
+/**
+ * Escape XML special characters in a text node.
+ */
+function xmlEscape(value: unknown): string {
+  const str =
+    value === null || value === undefined
+      ? ''
+      : typeof value === 'object'
+      ? JSON.stringify(value)
+      : String(value);
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Recursively serialise a JavaScript value to XML.
+ *
+ * - Objects  → child elements named after their keys
+ * - Arrays   → repeated elements named `itemTag`
+ * - Scalars  → text node
+ */
+function valueToXml(value: unknown, tag: string, itemTag: string, depth: number): string {
+  const indent = '  '.repeat(depth);
+  if (Array.isArray(value)) {
+    const children = value
+      .map((item) => valueToXml(item, itemTag, 'item', depth + 1))
+      .join('\n');
+    return `${indent}<${tag}>\n${children}\n${indent}</${tag}>`;
+  }
+  if (value !== null && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) return `${indent}<${tag}/>`;
+    const children = entries
+      .map(([k, v]) => valueToXml(v, sanitizeXmlTag(k), 'item', depth + 1))
+      .join('\n');
+    return `${indent}<${tag}>\n${children}\n${indent}</${tag}>`;
+  }
+  return `${indent}<${tag}>${xmlEscape(value)}</${tag}>`;
+}
+
+/** Replace characters not allowed in XML element names with underscores. */
+function sanitizeXmlTag(name: string): string {
+  // XML names must start with a letter or underscore
+  let safe = name.replace(/[^a-zA-Z0-9_.\-]/g, '_');
+  if (/^[^a-zA-Z_]/.test(safe)) safe = `_${safe}`;
+  return safe || '_';
+}
+
+/**
+ * Serialise `data` to an XML string.
+ */
+export function toXML(
+  data: unknown,
+  rootElement = 'response',
+  itemElement = 'item',
+): string {
+  const body = valueToXml(data, rootElement, itemElement, 0);
+  return `<?xml version="1.0" encoding="UTF-8"?>\n${body}`;
+}
+
+// ── Content-type map ──────────────────────────────────────────────────────────
+
+const CONTENT_TYPES: Record<SupportedType, string> = {
+  json: 'application/json; charset=utf-8',
+  csv: 'text/csv; charset=utf-8',
+  xml: 'application/xml; charset=utf-8',
+};
+
+// ── Public helper used by route handlers ──────────────────────────────────────
+
+/**
+ * Negotiate the response format and send the payload.
+ *
+ * Routes call this instead of `res.json()` to support multiple formats.
+ */
+export function respondNegotiated(
+  req: Request,
+  res: Response,
+  data: unknown,
+  options: NegotiationOptions = {},
+): void {
+  const { rootElement = 'response', itemElement = 'item', status = 200 } = options;
+  const type = negotiateType(req.headers['accept']);
+
+  res.status(status);
+  res.setHeader('Content-Type', CONTENT_TYPES[type]);
+  // Expose negotiated type for downstream middleware (e.g. ETag)
+  res.locals.negotiatedType = type;
+
+  switch (type) {
+    case 'csv':
+      res.send(toCSV(data));
+      break;
+    case 'xml':
+      res.send(toXML(data, rootElement, itemElement));
+      break;
+    default:
+      res.json(data);
+  }
+}
+
+// ── Express middleware (optional — wires negotiateType onto req for logging) ──
+
+/**
+ * Optional middleware that adds `req.negotiatedType` for logging/metrics.
+ * Routes still call `respondNegotiated()` directly.
+ */
+export function contentNegotiationMiddleware(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): void {
+  (req as Request & { negotiatedType: SupportedType }).negotiatedType = negotiateType(
+    req.headers['accept'],
+  );
+  next();
+}

--- a/api-server/src/routes/attestors.ts
+++ b/api-server/src/routes/attestors.ts
@@ -16,6 +16,7 @@
  */
 
 import { Router, Request, Response } from 'express';
+import { respondNegotiated } from '../middleware/contentNegotiation.js';
 
 export interface Attestor {
   id: string;
@@ -189,9 +190,9 @@ export function createAttestorsRouter(): Router {
       );
     }
 
-    res.json({
-      total: results.length,
-      attestors: results,
+    respondNegotiated(req, res, { total: results.length, attestors: results }, {
+      rootElement: 'attestors',
+      itemElement: 'attestor',
     });
   });
 

--- a/api-server/src/routes/slices.ts
+++ b/api-server/src/routes/slices.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from 'express';
 import type { simulateCall as SimulateCallType } from '../soroban.js';
+import { respondNegotiated } from '../middleware/contentNegotiation.js';
 
 export type SorobanClient = {
   simulateCall: typeof SimulateCallType;
@@ -84,7 +85,7 @@ export function createSlicesRouter(soroban: SorobanClient) {
         ? Buffer.from(String(end)).toString('base64')
         : null;
 
-      res.json({
+      const payload = {
         data: slices,
         pagination: {
           cursor: cursorQ ?? null,
@@ -93,7 +94,8 @@ export function createSlicesRouter(soroban: SorobanClient) {
           total,
           has_more: hasMore,
         },
-      });
+      };
+      respondNegotiated(req, res, payload, { rootElement: 'slices', itemElement: 'slice' });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       res.status(500).json({ error: msg });

--- a/api-server/tests/contentNegotiation.test.ts
+++ b/api-server/tests/contentNegotiation.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Tests for Issue #1315 — Content Negotiation (CSV / XML / JSON)
+ *
+ * Covers:
+ *   - negotiateType() utility
+ *   - toCSV() serialiser
+ *   - toXML() serialiser
+ *   - respondNegotiated() integration via a minimal Express app
+ *   - GET /api/attestors with Accept: application/json (default)
+ *   - GET /api/attestors with Accept: text/csv
+ *   - GET /api/attestors with Accept: application/xml
+ *   - GET /api/slices   with Accept: text/csv  (pagination wrapper)
+ */
+
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+import {
+  negotiateType,
+  toCSV,
+  toXML,
+  respondNegotiated,
+} from '../src/middleware/contentNegotiation.js';
+import { createAttestorsRouter } from '../src/routes/attestors.js';
+import { createSlicesRouter } from '../src/routes/slices.js';
+
+// ── negotiateType ──────────────────────────────────────────────────────────
+
+describe('negotiateType()', () => {
+  it('defaults to json when Accept header is absent', () => {
+    expect(negotiateType(undefined)).toBe('json');
+  });
+
+  it('defaults to json when Accept header is empty', () => {
+    expect(negotiateType('')).toBe('json');
+  });
+
+  it('returns json for application/json', () => {
+    expect(negotiateType('application/json')).toBe('json');
+  });
+
+  it('returns json for */*', () => {
+    expect(negotiateType('*/*')).toBe('json');
+  });
+
+  it('returns csv for text/csv', () => {
+    expect(negotiateType('text/csv')).toBe('csv');
+  });
+
+  it('returns csv for application/csv', () => {
+    expect(negotiateType('application/csv')).toBe('csv');
+  });
+
+  it('returns xml for application/xml', () => {
+    expect(negotiateType('application/xml')).toBe('xml');
+  });
+
+  it('returns xml for text/xml', () => {
+    expect(negotiateType('text/xml')).toBe('xml');
+  });
+
+  it('respects q-factor: prefers higher q value', () => {
+    // json q=0.5, csv q=0.9 → should pick csv
+    expect(negotiateType('application/json;q=0.5, text/csv;q=0.9')).toBe('csv');
+  });
+
+  it('respects q-factor: json beats csv when json q is higher', () => {
+    expect(negotiateType('text/csv;q=0.4, application/json;q=0.9')).toBe('json');
+  });
+
+  it('falls back to json for unrecognised type', () => {
+    expect(negotiateType('application/msgpack')).toBe('json');
+  });
+});
+
+// ── toCSV ──────────────────────────────────────────────────────────────────
+
+describe('toCSV()', () => {
+  it('serialises an array of objects to CSV with header row', () => {
+    const result = toCSV([
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+    ]);
+    const lines = result.split('\r\n');
+    expect(lines[0]).toBe('id,name');
+    expect(lines[1]).toBe('1,Alice');
+    expect(lines[2]).toBe('2,Bob');
+  });
+
+  it('returns empty string for an empty array', () => {
+    expect(toCSV([])).toBe('');
+  });
+
+  it('wraps a plain object in a single data row', () => {
+    const result = toCSV({ id: 42, type: 'test' });
+    const lines = result.split('\r\n');
+    expect(lines[0]).toBe('id,type');
+    expect(lines[1]).toBe('42,test');
+  });
+
+  it('escapes values that contain commas', () => {
+    const result = toCSV([{ name: 'Doe, Jane' }]);
+    expect(result).toContain('"Doe, Jane"');
+  });
+
+  it('escapes values that contain double-quotes', () => {
+    const result = toCSV([{ name: 'Say "Hello"' }]);
+    expect(result).toContain('"Say ""Hello"""');
+  });
+
+  it('serialises nested objects as JSON strings in CSV cells', () => {
+    const result = toCSV([{ meta: { a: 1 } }]);
+    // The nested object is JSON-stringified then CSV-escaped (inner quotes doubled)
+    // Full cell value: "{""a"":1}" — verify key parts are present
+    expect(result).toContain('meta'); // header
+    expect(result).toContain('""a""'); // escaped JSON key inside CSV cell
+  });
+
+  it('handles null and undefined values as empty strings', () => {
+    const result = toCSV([{ a: null, b: undefined }]);
+    const lines = result.split('\r\n');
+    expect(lines[1]).toBe(',');
+  });
+});
+
+// ── toXML ──────────────────────────────────────────────────────────────────
+
+describe('toXML()', () => {
+  it('produces a well-formed XML declaration', () => {
+    const xml = toXML({}, 'root');
+    expect(xml).toMatch(/^<\?xml version="1\.0" encoding="UTF-8"\?>/);
+  });
+
+  it('wraps an object in the root element', () => {
+    const xml = toXML({ id: 1 }, 'credential');
+    expect(xml).toContain('<credential>');
+    expect(xml).toContain('</credential>');
+    expect(xml).toContain('<id>1</id>');
+  });
+
+  it('wraps each array item in itemElement', () => {
+    const xml = toXML([{ id: 1 }, { id: 2 }], 'attestors', 'attestor');
+    expect(xml).toContain('<attestors>');
+    // Two attestor elements
+    const matches = xml.match(/<attestor>/g);
+    expect(matches).toHaveLength(2);
+  });
+
+  it('escapes XML special characters', () => {
+    const xml = toXML({ name: '<B&W>' }, 'root');
+    expect(xml).toContain('&lt;B&amp;W&gt;');
+  });
+
+  it('serialises nested objects recursively', () => {
+    const xml = toXML({ meta: { key: 'val' } }, 'root');
+    expect(xml).toContain('<meta>');
+    expect(xml).toContain('<key>val</key>');
+  });
+
+  it('uses default root element name "response"', () => {
+    const xml = toXML({ ok: true });
+    expect(xml).toContain('<response>');
+  });
+});
+
+// ── respondNegotiated via test app ────────────────────────────────────────
+
+function makeNegotiationTestApp() {
+  const app = express();
+  app.get('/test', (req, res) => {
+    respondNegotiated(req, res, [{ id: 1, name: 'alice' }, { id: 2, name: 'bob' }], {
+      rootElement: 'items',
+      itemElement: 'item',
+    });
+  });
+  app.get('/single', (req, res) => {
+    respondNegotiated(req, res, { id: 42, status: 'ok' });
+  });
+  return app;
+}
+
+describe('respondNegotiated()', () => {
+  const app = makeNegotiationTestApp();
+
+  it('returns JSON by default (no Accept header)', async () => {
+    const res = await request(app).get('/test');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0].id).toBe(1);
+  });
+
+  it('returns JSON when Accept: application/json', async () => {
+    const res = await request(app).get('/test').set('Accept', 'application/json');
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('returns CSV when Accept: text/csv', async () => {
+    const res = await request(app).get('/test').set('Accept', 'text/csv');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/csv/);
+    const text = res.text;
+    expect(text).toContain('id,name');
+    expect(text).toContain('1,alice');
+    expect(text).toContain('2,bob');
+  });
+
+  it('returns XML when Accept: application/xml', async () => {
+    const res = await request(app).get('/test').set('Accept', 'application/xml');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/xml/);
+    expect(res.text).toContain('<?xml');
+    expect(res.text).toContain('<items>');
+    expect(res.text).toContain('<item>');
+  });
+
+  it('returns XML when Accept: text/xml', async () => {
+    const res = await request(app).get('/test').set('Accept', 'text/xml');
+    expect(res.headers['content-type']).toMatch(/application\/xml/);
+  });
+
+  it('returns CSV for a single object', async () => {
+    const res = await request(app).get('/single').set('Accept', 'text/csv');
+    expect(res.text).toContain('id,status');
+    expect(res.text).toContain('42,ok');
+  });
+});
+
+// ── GET /api/attestors content negotiation ────────────────────────────────
+
+const attestorApp = express();
+attestorApp.use(express.json());
+attestorApp.use('/api/attestors', createAttestorsRouter());
+
+describe('GET /api/attestors — content negotiation', () => {
+  it('returns JSON by default', async () => {
+    const res = await request(attestorApp).get('/api/attestors');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    expect(res.body.attestors).toBeDefined();
+  });
+
+  it('returns CSV with Accept: text/csv', async () => {
+    const res = await request(attestorApp)
+      .get('/api/attestors')
+      .set('Accept', 'text/csv');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/csv/);
+    // Header row should include attestor fields
+    expect(res.text).toMatch(/total,attestors/);
+  });
+
+  it('returns XML with Accept: application/xml', async () => {
+    const res = await request(attestorApp)
+      .get('/api/attestors')
+      .set('Accept', 'application/xml');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/xml/);
+    expect(res.text).toContain('<?xml');
+    expect(res.text).toContain('<attestors>');
+  });
+
+  it('still filters by type when format is CSV', async () => {
+    const res = await request(attestorApp)
+      .get('/api/attestors?type=university')
+      .set('Accept', 'text/csv');
+    expect(res.status).toBe(200);
+    // CSV rows will contain the word "university" (the type field value)
+    expect(res.text).toMatch(/university/);
+  });
+});
+
+// ── GET /api/slices content negotiation ───────────────────────────────────
+
+function makeSliceApp() {
+  const mockSoroban = {
+    simulateCall: async (method: string, _args: unknown[]) => {
+      if (method === 'get_slice_count') return BigInt(2);
+      if (method === 'get_slice') return { id: 1, threshold: 2, attestors: [] };
+      throw new Error('unknown method');
+    },
+    u64Val: (n: number | bigint) => n,
+  };
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/slices', createSlicesRouter(mockSoroban));
+  return app;
+}
+
+describe('GET /api/slices — content negotiation', () => {
+  const app = makeSliceApp();
+
+  it('returns JSON by default', async () => {
+    const res = await request(app).get('/api/slices');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    expect(res.body.data).toBeDefined();
+  });
+
+  it('returns CSV with Accept: text/csv', async () => {
+    const res = await request(app).get('/api/slices').set('Accept', 'text/csv');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/csv/);
+    // Should have at least a header row
+    expect(res.text.length).toBeGreaterThan(0);
+  });
+
+  it('returns XML with Accept: application/xml', async () => {
+    const res = await request(app).get('/api/slices').set('Accept', 'application/xml');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/xml/);
+    expect(res.text).toContain('<?xml');
+  });
+});


### PR DESCRIPTION
- Add contentNegotiation.ts middleware with:
  - negotiateType(): parses Accept header with q-factor support
  - toCSV(): serialises arrays/objects to RFC 4180 CSV
  - toXML(): serialises values to XML with configurable root/item elements
  - respondNegotiated(): route-level helper replacing res.json()
- Wire respondNegotiated into GET /api/attestors (list) and GET /api/slices (paginated list)
- 37 tests covering unit functions, integration via Express app, and per-endpoint Accept header negotiation

closes #1315 