### PR TITLE
feat(#1314): Implement caching headers and ETag support

### DIFF
--- a/api-server/src/middleware/cacheControl.ts
+++ b/api-server/src/middleware/cacheControl.ts
@@ -1,10 +1,216 @@
+/**
+ * #1314 — Caching Headers and ETag Support
+ *
+ * Middleware that:
+ *  1. Sets a sensible Cache-Control header on GET responses (unless the route
+ *     already set one).
+ *  2. Generates a deterministic ETag for every GET response body and checks
+ *     the If-None-Match request header, returning 304 Not Modified when the
+ *     resource has not changed.
+ *  3. Exposes per-endpoint Cache-Control overrides via `cacheStrategy()`, so
+ *     individual routes can opt into immutable, no-store, or custom max-age
+ *     values without touching shared middleware.
+ *
+ * Caching strategy per endpoint class:
+ *
+ *   /api/credentials/*     private, max-age=30, must-revalidate
+ *   /api/slices/*          private, max-age=60, must-revalidate
+ *   /api/attestors/*       public,  max-age=300, stale-while-revalidate=60
+ *   /api/verify/*          no-store (verification results must never be cached)
+ *   /api/analytics/*       private, max-age=120, must-revalidate
+ *   /health                public,  max-age=10
+ *   everything else        private, max-age=30, must-revalidate  (default)
+ *
+ * ETag format: W/"<sha256-hex-prefix-16>"
+ * The weak ETag prefix ("W/") signals that two representations are semantically
+ * equivalent (same body) but may not be byte-for-byte identical, which is
+ * correct here because we don't track byte-level headers like Content-Encoding.
+ *
+ * 304 handling:
+ *   When If-None-Match matches the computed ETag the middleware:
+ *     - responds with 304 (no body)
+ *     - still sets Cache-Control and ETag so the client can update its cache
+ *     - skips the route handler entirely (calls res.end() after setting headers)
+ */
+
+import { createHash } from 'crypto';
 import { Request, Response, NextFunction } from 'express';
 
-const CACHE_CONTROL_VALUE = 'private, max-age=30, must-revalidate';
+// ── Cache-Control strategy map ────────────────────────────────────────────────
 
-export function cacheControl(req: Request, res: Response, next: NextFunction): void {
-  if (req.method === 'GET' && !res.getHeader('Cache-Control')) {
-    res.setHeader('Cache-Control', CACHE_CONTROL_VALUE);
+interface CacheStrategy {
+  value: string;
+  /** Should we generate / check ETags for this strategy? */
+  etag: boolean;
+}
+
+const PATH_STRATEGIES: Array<{ prefix: string; strategy: CacheStrategy }> = [
+  // Verification results must never be cached — they carry real-time trust
+  // decisions that could be stale if the credential is revoked.
+  { prefix: '/api/verify', strategy: { value: 'no-store', etag: false } },
+
+  // Attestor registry changes infrequently; public CDN caching is acceptable.
+  {
+    prefix: '/api/attestors',
+    strategy: { value: 'public, max-age=300, stale-while-revalidate=60', etag: true },
+  },
+
+  // Analytics data is user-scoped and changes every few minutes.
+  { prefix: '/api/analytics', strategy: { value: 'private, max-age=120, must-revalidate', etag: true } },
+
+  // Slice data is moderately stable.
+  { prefix: '/api/slices', strategy: { value: 'private, max-age=60, must-revalidate', etag: true } },
+
+  // Credentials are sensitive — keep private and short-lived.
+  { prefix: '/api/credentials', strategy: { value: 'private, max-age=30, must-revalidate', etag: true } },
+
+  // Health endpoint — very short public cache for load-balancer checks.
+  { prefix: '/health', strategy: { value: 'public, max-age=10', etag: false } },
+];
+
+const DEFAULT_STRATEGY: CacheStrategy = {
+  value: 'private, max-age=30, must-revalidate',
+  etag: true,
+};
+
+function strategyFor(path: string): CacheStrategy {
+  for (const { prefix, strategy } of PATH_STRATEGIES) {
+    if (path.startsWith(prefix)) return strategy;
   }
+  return DEFAULT_STRATEGY;
+}
+
+// ── ETag generation ───────────────────────────────────────────────────────────
+
+/**
+ * Compute a weak ETag for `body`.
+ * Uses the first 16 hex characters of a SHA-256 digest — short enough to
+ * keep headers small while virtually eliminating collision probability for
+ * typical API response sizes.
+ */
+export function computeETag(body: string | Buffer): string {
+  const hash = createHash('sha256')
+    .update(typeof body === 'string' ? body : body)
+    .digest('hex')
+    .slice(0, 16);
+  return `W/"${hash}"`;
+}
+
+// ── Route-level override helper ───────────────────────────────────────────────
+
+/**
+ * Express middleware factory for per-route cache strategy overrides.
+ *
+ * Usage:
+ *   router.get('/expensive', cacheStrategy('public, max-age=3600, immutable'), handler);
+ */
+export function cacheStrategy(value: string): (req: Request, res: Response, next: NextFunction) => void {
+  return (_req: Request, res: Response, next: NextFunction) => {
+    res.setHeader('Cache-Control', value);
+    next();
+  };
+}
+
+// ── Main middleware ────────────────────────────────────────────────────────────
+
+/**
+ * Apply Cache-Control, ETag, and 304 Not Modified handling to all GET responses.
+ *
+ * This replaces the simpler one-liner that existed before #1314. The old
+ * single-constant `CACHE_CONTROL_VALUE` is gone; strategy selection is now
+ * path-based (see `strategyFor()` above).
+ */
+export function cacheControl(req: Request, res: Response, next: NextFunction): void {
+  // For non-GET/HEAD requests: strip any ETag that Express's built-in etag
+  // generator might have set and move on — we don't cache mutations.
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    const originalEnd = res.end.bind(res);
+    let cleared = false;
+    (res.end as Function) = function clearETagOnMutation(
+      chunk?: unknown,
+      encodingOrCb?: unknown,
+      cb?: () => void,
+    ): Response {
+      if (!cleared) {
+        cleared = true;
+        res.removeHeader('ETag');
+      }
+      return originalEnd(chunk, encodingOrCb as BufferEncoding, cb);
+    };
+    next();
+    return;
+  }
+
+  const strategy = strategyFor(req.path);
+
+  // Set Cache-Control unless the route already provided one.
+  if (!res.getHeader('Cache-Control')) {
+    res.setHeader('Cache-Control', strategy.value);
+  }
+
+  // For no-etag strategies (e.g. no-store): actively remove any ETag that
+  // Express's own etag generator may add after the response is sent.
+  if (!strategy.etag) {
+    const originalEnd = res.end.bind(res);
+    let cleared = false;
+    (res.end as Function) = function clearETagForNoStore(
+      chunk?: unknown,
+      encodingOrCb?: unknown,
+      cb?: () => void,
+    ): Response {
+      if (!cleared) {
+        cleared = true;
+        res.removeHeader('ETag');
+      }
+      return originalEnd(chunk, encodingOrCb as BufferEncoding, cb);
+    };
+    next();
+    return;
+  }
+
+  // Intercept res.json / res.send / res.end to inject ETag + 304 logic.
+  // We wrap res.end because Express ultimately funnels all response writes
+  // through it (including res.json → res.send → res.end).
+  const originalEnd = res.end.bind(res);
+
+  // Track whether we've already patched this response to avoid double-patching
+  // (e.g. if both res.json and res.send call end).
+  let patched = false;
+
+  (res.end as Function) = function patchedEnd(
+    chunk?: unknown,
+    encodingOrCb?: unknown,
+    cb?: () => void,
+  ): Response {
+    if (patched) {
+      // Already handled — pass through to avoid infinite recursion.
+      return originalEnd(chunk, encodingOrCb as BufferEncoding, cb);
+    }
+    patched = true;
+
+    // Only inject ETag for 2xx responses with a body.
+    if (res.statusCode >= 200 && res.statusCode < 300 && chunk) {
+      const body = chunk instanceof Buffer ? chunk : Buffer.from(String(chunk));
+      const etag = computeETag(body);
+
+      // Set ETag regardless (client may store it for future requests).
+      res.setHeader('ETag', etag);
+
+      // Check If-None-Match.
+      const ifNoneMatch = req.headers['if-none-match'];
+      if (ifNoneMatch && (ifNoneMatch === etag || ifNoneMatch === '*')) {
+        // Resource hasn't changed — send 304.
+        res.statusCode = 304;
+        // Strip body-related headers that are invalid on 304.
+        res.removeHeader('Content-Type');
+        res.removeHeader('Content-Length');
+        res.removeHeader('Transfer-Encoding');
+        return originalEnd(undefined, encodingOrCb as BufferEncoding, cb);
+      }
+    }
+
+    return originalEnd(chunk, encodingOrCb as BufferEncoding, cb);
+  };
+
   next();
 }

--- a/api-server/tests/cacheControl.test.ts
+++ b/api-server/tests/cacheControl.test.ts
@@ -1,42 +1,256 @@
+/**
+ * Tests for Issue #1314 — Caching Headers and ETag Support
+ *
+ * Covers:
+ *   - Cache-Control header is set on GET responses
+ *   - Per-path strategy selection
+ *   - Custom route-level override via cacheStrategy()
+ *   - ETag header is generated for GET responses
+ *   - 304 Not Modified when If-None-Match matches
+ *   - Cache-Control is not set on non-GET requests
+ *   - Routes that set their own Cache-Control are not overridden
+ *   - computeETag() determinism and uniqueness
+ *   - /api/verify gets no-store (ETags disabled)
+ */
+
 import { describe, it, expect } from 'vitest';
 import express from 'express';
 import request from 'supertest';
-import { cacheControl } from '../src/middleware/cacheControl.js';
+import { cacheControl, cacheStrategy, computeETag } from '../src/middleware/cacheControl.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function createTestApp() {
   const app = express();
   app.use(cacheControl);
+
+  // Default endpoint — triggers the default strategy
   app.get('/api/test', (_req, res) => res.json({ ok: true }));
+
+  // Non-GET endpoint
   app.post('/api/test', (_req, res) => res.json({ ok: true }));
+
+  // Route overrides Cache-Control before cacheControl middleware runs
   app.get('/api/custom', (_req, res) => {
     res.setHeader('Cache-Control', 'no-store');
     res.json({ ok: true });
   });
+
+  // Slice-class path
+  app.get('/api/slices', (_req, res) => res.json({ data: [] }));
+
+  // Attestor-class path (public caching)
+  app.get('/api/attestors', (_req, res) => res.json({ attestors: [] }));
+
+  // Verify-class path (no-store, no etag)
+  app.get('/api/verify/1', (_req, res) => res.json({ verified: true }));
+
+  // Analytics path
+  app.get('/api/analytics/summary', (_req, res) => res.json({ events: 0 }));
+
+  // Credentials path
+  app.get('/api/credentials', (_req, res) => res.json({ credentials: [] }));
+
+  // Health
+  app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+
+  // Route-level override using cacheStrategy()
+  app.get(
+    '/api/expensive',
+    cacheStrategy('public, max-age=3600, immutable'),
+    (_req, res) => res.json({ computed: true }),
+  );
+
   return app;
 }
 
-describe('Cache Control Middleware', () => {
+// ---------------------------------------------------------------------------
+// Cache-Control header
+// ---------------------------------------------------------------------------
+
+describe('Cache-Control header', () => {
+  const app = createTestApp();
+
   it('sets Cache-Control on GET responses', async () => {
-    const res = await request(createTestApp()).get('/api/test');
-
-    expect(res.headers['cache-control']).toBe('private, max-age=30, must-revalidate');
+    const res = await request(app).get('/api/test');
+    expect(res.headers['cache-control']).toBeDefined();
   });
 
-  it('sets an ETag header on GET responses', async () => {
-    const res = await request(createTestApp()).get('/api/test');
-
-    expect(res.headers['etag']).toBeDefined();
+  it('does not set Cache-Control on POST responses', async () => {
+    const res = await request(app).post('/api/test');
+    expect(res.headers['cache-control']).toBeUndefined();
   });
 
-  it('does not override a Cache-Control header set by a route', async () => {
-    const res = await request(createTestApp()).get('/api/custom');
-
+  it('does not override Cache-Control set by a route', async () => {
+    const res = await request(app).get('/api/custom');
     expect(res.headers['cache-control']).toBe('no-store');
   });
 
-  it('does not set Cache-Control on non-GET requests', async () => {
-    const res = await request(createTestApp()).post('/api/test');
+  it('uses default strategy for unknown paths', async () => {
+    const res = await request(app).get('/api/test');
+    expect(res.headers['cache-control']).toBe('private, max-age=30, must-revalidate');
+  });
 
-    expect(res.headers['cache-control']).toBeUndefined();
+  it('uses credentials strategy for /api/credentials', async () => {
+    const res = await request(app).get('/api/credentials');
+    expect(res.headers['cache-control']).toBe('private, max-age=30, must-revalidate');
+  });
+
+  it('uses slices strategy for /api/slices', async () => {
+    const res = await request(app).get('/api/slices');
+    expect(res.headers['cache-control']).toBe('private, max-age=60, must-revalidate');
+  });
+
+  it('uses attestors strategy (public) for /api/attestors', async () => {
+    const res = await request(app).get('/api/attestors');
+    expect(res.headers['cache-control']).toBe(
+      'public, max-age=300, stale-while-revalidate=60',
+    );
+  });
+
+  it('uses no-store for /api/verify paths', async () => {
+    const res = await request(app).get('/api/verify/1');
+    expect(res.headers['cache-control']).toBe('no-store');
+  });
+
+  it('uses analytics strategy for /api/analytics', async () => {
+    const res = await request(app).get('/api/analytics/summary');
+    expect(res.headers['cache-control']).toBe('private, max-age=120, must-revalidate');
+  });
+
+  it('uses health strategy for /health', async () => {
+    const res = await request(app).get('/health');
+    expect(res.headers['cache-control']).toBe('public, max-age=10');
+  });
+
+  it('respects cacheStrategy() route-level override', async () => {
+    const res = await request(app).get('/api/expensive');
+    expect(res.headers['cache-control']).toBe('public, max-age=3600, immutable');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ETag header
+// ---------------------------------------------------------------------------
+
+describe('ETag header', () => {
+  const app = createTestApp();
+
+  it('sets an ETag header on GET responses', async () => {
+    const res = await request(app).get('/api/test');
+    expect(res.headers['etag']).toBeDefined();
+  });
+
+  it('ETag is a weak ETag (starts with W/")', async () => {
+    const res = await request(app).get('/api/test');
+    expect(res.headers['etag']).toMatch(/^W\//);
+  });
+
+  it('same response body produces the same ETag on repeated requests', async () => {
+    const res1 = await request(app).get('/api/test');
+    const res2 = await request(app).get('/api/test');
+    expect(res1.headers['etag']).toBe(res2.headers['etag']);
+  });
+
+  it('different response bodies produce different ETags', async () => {
+    const res1 = await request(app).get('/api/test');
+    const res2 = await request(app).get('/api/slices');
+    expect(res1.headers['etag']).not.toBe(res2.headers['etag']);
+  });
+
+  it('does NOT set ETag on /api/verify (no-store strategy)', async () => {
+    const res = await request(app).get('/api/verify/1');
+    // no-store endpoints skip ETag logic entirely
+    expect(res.headers['etag']).toBeUndefined();
+  });
+
+  it('does not set ETag on POST responses', async () => {
+    const res = await request(app).post('/api/test');
+    expect(res.headers['etag']).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 304 Not Modified
+// ---------------------------------------------------------------------------
+
+describe('304 Not Modified', () => {
+  const app = createTestApp();
+
+  it('returns 304 when If-None-Match matches the ETag', async () => {
+    // First request — capture ETag
+    const first = await request(app).get('/api/test');
+    const etag = first.headers['etag'];
+    expect(etag).toBeDefined();
+
+    // Second request with the ETag
+    const second = await request(app)
+      .get('/api/test')
+      .set('If-None-Match', etag as string);
+    expect(second.status).toBe(304);
+    expect(second.text).toBe('');
+  });
+
+  it('still sends Cache-Control and ETag on 304 responses', async () => {
+    const first = await request(app).get('/api/slices');
+    const etag = first.headers['etag'] as string;
+
+    const second = await request(app)
+      .get('/api/slices')
+      .set('If-None-Match', etag);
+
+    expect(second.status).toBe(304);
+    expect(second.headers['cache-control']).toBeDefined();
+    expect(second.headers['etag']).toBe(etag);
+  });
+
+  it('returns 200 when If-None-Match does not match', async () => {
+    const res = await request(app)
+      .get('/api/test')
+      .set('If-None-Match', 'W/"stale-etag-value"');
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 304 for If-None-Match: * (wildcard)', async () => {
+    const res = await request(app)
+      .get('/api/test')
+      .set('If-None-Match', '*');
+    expect(res.status).toBe(304);
+  });
+
+  it('does not 304 /api/verify even with If-None-Match (no ETag emitted)', async () => {
+    // no-store paths don't emit ETag headers — so a normal client will never
+    // send back a matching If-None-Match. We verify the ETag is absent.
+    const res = await request(app).get('/api/verify/1');
+    expect(res.headers['etag']).toBeUndefined();
+    expect(res.headers['cache-control']).toBe('no-store');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeETag() unit tests
+// ---------------------------------------------------------------------------
+
+describe('computeETag()', () => {
+  it('returns a string starting with W/"', () => {
+    expect(computeETag('hello')).toMatch(/^W\//);
+  });
+
+  it('is deterministic for the same input', () => {
+    expect(computeETag('same')).toBe(computeETag('same'));
+  });
+
+  it('produces different values for different inputs', () => {
+    expect(computeETag('a')).not.toBe(computeETag('b'));
+  });
+
+  it('accepts Buffer input', () => {
+    const buf = Buffer.from('buffer data');
+    const tag = computeETag(buf);
+    expect(tag).toMatch(/^W\//);
+    // Should equal the string version
+    expect(tag).toBe(computeETag('buffer data'));
   });
 });


### PR DESCRIPTION
- Expand cacheControl middleware with:
  - Per-path Cache-Control strategy map:
    - /api/verify          → no-store (real-time trust decisions)
    - /api/attestors       → public, max-age=300, stale-while-revalidate=60
    - /api/analytics       → private, max-age=120, must-revalidate
    - /api/slices          → private, max-age=60, must-revalidate
    - /api/credentials     → private, max-age=30, must-revalidate
    - /health              → public, max-age=10
    - default              → private, max-age=30, must-revalidate
  - computeETag(): SHA-256 weak ETag generation (W/"<16-hex>")
  - cacheStrategy(): per-route middleware factory for overrides
  - 304 Not Modified: intercepts res.end(), checks If-None-Match
  - ETag suppression for no-store paths and non-GET methods
- 26 tests covering all strategies, ETag generation/determinism,
  304 round-trips, cacheStrategy() override, and computeETag() unit


closes #1314 