### PR TITLE
feat(api): implement URL path versioning strategy (#1310)

### DIFF
--- a/api-server/docs/API_VERSIONING.md
+++ b/api-server/docs/API_VERSIONING.md
@@ -1,0 +1,393 @@
+# API Versioning — QuorumProof API Server
+
+This document describes the versioning strategy for the QuorumProof API server,
+the deprecation schedule for v1, and the migration path to v2.
+
+## Contents
+
+1. [URL Path Versioning](#url-path-versioning)
+2. [Version Catalogue](#version-catalogue)
+3. [Deprecation Schedule](#deprecation-schedule)
+4. [v1 Response Envelope](#v1-response-envelope)
+5. [v2 Changes](#v2-changes)
+6. [Backward-Compatible Unversioned Routes](#backward-compatible-unversioned-routes)
+7. [Response Headers](#response-headers)
+8. [Error Responses](#error-responses)
+9. [Client Migration Guide](#client-migration-guide)
+10. [Architecture Notes](#architecture-notes)
+
+---
+
+## URL Path Versioning
+
+All versioned endpoints follow the pattern:
+
+```
+/api/{version}/{resource}
+```
+
+Examples:
+
+```
+GET /api/v1/credentials/:id
+GET /api/v2/credentials/:id
+POST /api/v1/slices
+GET /api/v1/verify/:id
+```
+
+The version segment is always a lowercase `v` followed by an integer (`v1`, `v2`, …).
+
+Requests to an unknown version receive `404 Not Found`:
+
+```json
+{
+  "error": "Unknown API version",
+  "message": "Version \"v99\" is not supported. Supported versions: v1, v2.",
+  "supported_versions": ["v1", "v2"],
+  "docs": "https://docs.quorumproof.io/api/versioning"
+}
+```
+
+---
+
+## Version Catalogue
+
+| Version | Status      | Stable Since | Maintenance Date | Sunset Date  |
+|---------|-------------|--------------|-----------------|--------------|
+| v1      | Stable      | 2025-01-01   | 2026-09-01      | 2027-03-01   |
+| v2      | Development | —            | GA: 2026-09-01  | —            |
+
+**Status definitions:**
+
+- **Stable** — production-ready, no breaking changes, all bug fixes applied.
+- **Development** — active feature work, may have breaking changes between minor versions.
+- **Maintenance** — security and critical bug fixes only; no new features.
+- **Deprecated** — EOL announced; breaking-change header emitted on every response.
+- **Sunset** — removed; returns `410 Gone`.
+
+---
+
+## Deprecation Schedule
+
+### v1 Timeline
+
+| Date           | Event                                                        |
+|----------------|--------------------------------------------------------------|
+| 2026-09-01     | v1 enters **maintenance** mode; `Deprecation` header emitted |
+| 2026-09-01     | v2 reaches **GA / Stable**                                   |
+| 2027-01-01     | v1 status changes to **deprecated**; migration warnings added to logs |
+| 2027-03-01     | v1 **sunset** — all requests return `410 Gone`               |
+
+### What happens at each stage
+
+**Maintenance (2026-09-01):**
+Every v1 response will include:
+```
+Deprecation: 2026-09-01
+Sunset: 2027-03-01
+Link: <https://docs.quorumproof.io/api/migration/v1-to-v2>; rel="successor-version"
+X-API-Deprecation-Info: v1 enters maintenance on 2026-09-01 and will be sunset on 2027-03-01.
+```
+
+**Sunset (2027-03-01):**
+All `/api/v1/*` requests return:
+```http
+HTTP/1.1 410 Gone
+Content-Type: application/json
+
+{
+  "error": "API version sunset",
+  "message": "Version \"v1\" has been retired and is no longer available.",
+  "docs": "https://docs.quorumproof.io/api/versioning"
+}
+```
+
+---
+
+## v1 Response Envelope
+
+All v1 responses are wrapped in a standard envelope to ease client-side error
+handling. The `ok` flag allows clients to check success without inspecting the
+HTTP status code.
+
+### Success (2xx)
+
+```json
+{
+  "ok": true,
+  "version": "v1",
+  "data": { ... }
+}
+```
+
+Example — `GET /api/v1/slices/1`:
+
+```json
+{
+  "ok": true,
+  "version": "v1",
+  "data": {
+    "id": "1",
+    "creator": "GABC…",
+    "attestors": ["GATT1", "GATT2"],
+    "threshold": 2,
+    "metadata_hash": "abc123",
+    "metadata": "abc123"
+  }
+}
+```
+
+### Error (4xx / 5xx)
+
+```json
+{
+  "ok": false,
+  "version": "v1",
+  "error": "<human-readable message>",
+  "details": { ... }
+}
+```
+
+### v1 Field Aliases
+
+v2 renames several fields for consistency. v1 responses include **both** the
+canonical v2 name and the v1 alias so migration can be done incrementally.
+
+| v2 field name    | v1 alias       |
+|------------------|----------------|
+| `metadata_hash`  | `metadata`     |
+| `stellar_address`| `address`      |
+
+---
+
+## v2 Changes
+
+v2 is in active development. Planned breaking changes vs v1:
+
+### No response envelope
+
+v2 returns resource objects directly:
+
+```json
+{
+  "id": "1",
+  "creator": "GABC…",
+  "attestors": ["GATT1"],
+  "threshold": 1
+}
+```
+
+### Field renames
+
+| v1 name          | v2 name          |
+|------------------|------------------|
+| `metadata`       | `metadata_hash`  |
+| `address`        | `stellar_address`|
+
+### RFC 9457 error format
+
+Errors use the [Problem Details](https://www.rfc-editor.org/rfc/rfc9457) schema:
+
+```json
+{
+  "type": "https://docs.quorumproof.io/errors/not-found",
+  "title": "Resource not found",
+  "status": 404,
+  "detail": "Credential 99 does not exist"
+}
+```
+
+### New endpoints (v2-only)
+
+| Path                             | Description                                |
+|----------------------------------|--------------------------------------------|
+| `GET /api/v2/proof-requests`     | Managed ZK proof-request lifecycle         |
+| `POST /api/v2/proof-requests`    | Create a new proof request                 |
+| `GET /api/v2/revocation-registry`| Batch revocation with time-locks           |
+| `GET /api/v2/bbs-credentials`    | BBS+ selective-disclosure credential list  |
+
+---
+
+## Backward-Compatible Unversioned Routes
+
+The original `/api/*` paths remain available for backward compatibility. They
+behave identically to v2 (raw responses, no envelope).
+
+These paths will be **sunset together with v1 on 2027-03-01**. Clients on
+unversioned paths should migrate to `/api/v1` or `/api/v2`.
+
+```
+GET /api/credentials  →  GET /api/v1/credentials  (with envelope)
+GET /api/credentials  →  GET /api/v2/credentials  (without envelope)
+```
+
+---
+
+## Response Headers
+
+Every versioned request receives an `API-Version` header confirming which
+version was matched:
+
+```
+API-Version: v1
+```
+
+When a version is in maintenance or deprecated state:
+
+```
+Deprecation: 2026-09-01
+Sunset: 2027-03-01
+Link: <https://docs.quorumproof.io/api/migration/v1-to-v2>; rel="successor-version"
+X-API-Deprecation-Info: v1 enters maintenance on 2026-09-01 and will be sunset on 2027-03-01.
+```
+
+v1 responses also include:
+
+```
+X-API-Compat-Layer: v1
+```
+
+---
+
+## Error Responses
+
+### Unknown version
+
+```http
+HTTP/1.1 404 Not Found
+
+{
+  "error": "Unknown API version",
+  "message": "Version \"v99\" is not supported. Supported versions: v1, v2.",
+  "supported_versions": ["v1", "v2"],
+  "docs": "https://docs.quorumproof.io/api/versioning"
+}
+```
+
+### Sunset version
+
+```http
+HTTP/1.1 410 Gone
+
+{
+  "error": "API version sunset",
+  "message": "Version \"v1\" has been retired and is no longer available.",
+  "docs": "https://docs.quorumproof.io/api/versioning"
+}
+```
+
+---
+
+## Client Migration Guide
+
+### From unversioned `/api/*` to `/api/v1`
+
+1. **Add `/v1` to your base URL:**
+
+   ```diff
+   - const BASE = 'https://api.quorumproof.io/api';
+   + const BASE = 'https://api.quorumproof.io/api/v1';
+   ```
+
+2. **Unwrap the response envelope:**
+
+   ```typescript
+   const raw = await fetch(`${BASE}/credentials/${id}`).then(r => r.json());
+   const credential = raw.data; // was: raw directly
+   ```
+
+3. **Update error handling:**
+
+   ```typescript
+   if (!raw.ok) {
+     throw new Error(raw.error);
+   }
+   ```
+
+4. **Field aliases:** `metadata_hash` is now also available as `metadata`,
+   `stellar_address` as `address`. Both are present in v1 responses so no
+   rename is strictly required — but prefer the canonical v2 names for
+   forward compatibility.
+
+### From `/api/v1` to `/api/v2`
+
+1. **Change your base URL:**
+
+   ```diff
+   - const BASE = 'https://api.quorumproof.io/api/v1';
+   + const BASE = 'https://api.quorumproof.io/api/v2';
+   ```
+
+2. **Remove envelope unwrapping** — v2 returns the resource directly:
+
+   ```diff
+   - const credential = response.data;
+   + const credential = response;
+   ```
+
+3. **Remove `ok` checks** — use HTTP status codes instead:
+
+   ```diff
+   - if (!raw.ok) throw new Error(raw.error);
+   + if (!response.ok) throw new Error(data.detail ?? data.title);
+   ```
+
+4. **Rename fields** if you switched to v2 canonical names:
+   - `metadata` → `metadata_hash`
+   - `address` → `stellar_address`
+
+5. **Update error handling** to [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457).
+
+---
+
+## Architecture Notes
+
+### Middleware stack
+
+```
+CORS → DDoS protection → json body → rate limiter
+  → apiVersionMiddleware       # parses /api/vN segment, sets req.apiVersion
+      ├─ /api/v1/*  →  v1Compat middleware  →  v1Router
+      ├─ /api/v2/*  →  (no compat)          →  v2Router
+      └─ /api/*     →  (no versioning)      →  legacy routers (backward compat)
+```
+
+### Route handler reuse
+
+Route handlers (`createCredentialsRouter`, `createSlicesRouter`, etc.) are
+**not duplicated**. Both v1 and v2 routers import the same factory-created
+router instances. The `v1Compat` middleware intercepts `res.json()` after the
+handler runs to apply the envelope transform, leaving handler code untouched.
+
+### Adding a v2-only or breaking change
+
+1. Create a new router in `src/routes/v2/`:
+   ```typescript
+   // src/routes/v2/credentials.ts
+   export function createCredentialsRouterV2(...) { ... }
+   ```
+
+2. Import and mount it in `src/routes/v2/index.ts`, overriding the shared handler:
+   ```typescript
+   import { createCredentialsRouterV2 } from './credentials.js';
+   router.use('/credentials', createCredentialsRouterV2(soroban));
+   ```
+
+3. Leave `src/routes/v1/index.ts` unchanged — v1 clients are unaffected.
+
+### Version catalogue updates
+
+The single source of truth for version lifecycle dates is the
+`VERSION_CATALOGUE` constant in `src/middleware/apiVersion.ts`. Updating
+the `status` field automatically changes the headers emitted on every
+response — no other code changes are required to enter maintenance mode.
+
+```typescript
+// src/middleware/apiVersion.ts
+v1: {
+  status: 'maintenance',   // ← change this when entering maintenance
+  maintenanceDate: '2026-09-01',
+  sunsetDate: '2027-03-01',
+  ...
+},
+```

--- a/api-server/package-lock.json
+++ b/api-server/package-lock.json
@@ -22,6 +22,7 @@
         "express": "^4.21.2",
         "ioredis": "^5.11.1",
         "pdfkit": "^0.19.1",
+        "pg": "^8.13.1",
         "qrcode": "^1.5.4",
         "ws": "^8.21.0"
       },
@@ -30,6 +31,7 @@
         "@types/express": "^5.0.3",
         "@types/node": "^24.12.0",
         "@types/pdfkit": "^0.17.6",
+        "@types/pg": "^8.11.10",
         "@types/qrcode": "^1.5.6",
         "@types/supertest": "^7.2.0",
         "@types/ws": "^8.18.1",
@@ -1542,6 +1544,18 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/qrcode": {
@@ -3923,6 +3937,95 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3998,6 +4101,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/pretty-format": {
@@ -4527,6 +4669,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -5632,6 +5783,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/api-server/src/index.ts
+++ b/api-server/src/index.ts
@@ -23,6 +23,11 @@ import { cacheControl } from './middleware/cacheControl.js';
 import { createCorsFromEnv } from './middleware/cors.js';
 // #1304: Adaptive rate limiter
 import { createAdaptiveRateLimiter } from './middleware/adaptiveRateLimiter.js';
+// #1310: API versioning
+import { createApiVersionMiddleware } from './middleware/apiVersion.js';
+import { v1Compat } from './middleware/v1Compat.js';
+import v1Router from './routes/v1/index.js';
+import v2Router from './routes/v2/index.js';
 import { createRequestDeduplication } from './middleware/requestDeduplication.js';
 import { rbac } from './middleware/rbac.js';
 import { createDDoSProtection } from './middleware/ddosProtection.js';
@@ -93,6 +98,34 @@ app.use((req, _res, next) => {
   }));
   next();
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #1310: Versioned API routes
+//
+// Version middleware runs first on all /api/* requests.  It parses the
+// version segment from the URL and attaches it to req.apiVersion.  Unknown
+// version strings receive 404 immediately.
+//
+// Route layout:
+//   /api/v1/**  — v1 (stable) with backward-compat response envelope
+//   /api/v2/**  — v2 (development) — raw responses, no envelope
+//   /api/**     — unversioned legacy paths (kept for backward compat)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const apiVersionMiddleware = createApiVersionMiddleware();
+app.use(apiVersionMiddleware);
+
+// v1: apply compat layer (envelope wrapping) before the routes run
+app.use('/api/v1', v1Compat, v1Router);
+
+// v2: no compat layer — raw handlers, ready for breaking changes
+app.use('/api/v2', v2Router);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unversioned /api/* legacy routes
+// Kept for backward compatibility.  Clients should migrate to /api/v1 or
+// /api/v2.  These will be sunset together with v1 on 2027-03-01.
+// ─────────────────────────────────────────────────────────────────────────────
 
 app.use('/api/slices', slicesRouter);
 app.use('/api/credentials', credentialsRouter);

--- a/api-server/src/middleware/apiVersion.ts
+++ b/api-server/src/middleware/apiVersion.ts
@@ -1,0 +1,160 @@
+/**
+ * API Versioning Middleware (Issue #1310)
+ *
+ * Extracts the API version from the URL path (e.g. /api/v1/... → "v1"),
+ * attaches it to `req.apiVersion`, and adds deprecation headers when a
+ * client is using an end-of-life or sunset version.
+ *
+ * Supported versions:
+ *   v1  — current stable, enters maintenance 2026-09-01, sunset 2027-03-01
+ *   v2  — current development, GA planned 2026-09-01
+ *
+ * Unknown version segments are rejected with 404 so clients get a clear
+ * signal rather than silently falling through to unversioned routes.
+ */
+
+import { Request, Response, NextFunction, Router } from 'express';
+
+// ─── Version catalogue ────────────────────────────────────────────────────────
+
+export type ApiVersion = 'v1' | 'v2';
+
+export interface VersionMeta {
+  /** Human-readable stability label */
+  status: 'stable' | 'maintenance' | 'deprecated' | 'sunset' | 'development';
+  /** ISO-8601 date after which no new features land (maintenance-only) */
+  maintenanceDate?: string;
+  /** ISO-8601 sunset date — after this date the version will return 410 Gone */
+  sunsetDate?: string;
+  /** Short human-readable reason shown in the Deprecation header */
+  deprecationReason?: string;
+  /** Link to migration guide */
+  migrationGuide?: string;
+}
+
+export const VERSION_CATALOGUE: Record<ApiVersion, VersionMeta> = {
+  v1: {
+    status: 'stable',
+    maintenanceDate: '2026-09-01',
+    sunsetDate: '2027-03-01',
+    deprecationReason: 'v1 enters maintenance on 2026-09-01 and will be sunset on 2027-03-01.',
+    migrationGuide: 'https://docs.quorumproof.io/api/migration/v1-to-v2',
+  },
+  v2: {
+    status: 'development',
+    migrationGuide: 'https://docs.quorumproof.io/api/v2',
+  },
+};
+
+const SUPPORTED_VERSIONS = new Set<string>(Object.keys(VERSION_CATALOGUE));
+
+// ─── Module augmentation ──────────────────────────────────────────────────────
+
+declare global {
+  namespace Express {
+    interface Request {
+      /** Parsed API version from the URL, or undefined for unversioned paths */
+      apiVersion?: ApiVersion;
+    }
+  }
+}
+
+// ─── Middleware factory ───────────────────────────────────────────────────────
+
+/**
+ * Returns an Express middleware that:
+ *   1. Parses `/api/v{N}/...` paths to extract the version segment.
+ *   2. Rejects unknown versions with 404.
+ *   3. Sets `req.apiVersion` for downstream handlers.
+ *   4. Adds `API-Version` response header.
+ *   5. Adds `Deprecation`, `Sunset`, and `Link` headers for maintenance /
+ *      deprecated versions.
+ */
+export function createApiVersionMiddleware() {
+  return function apiVersionMiddleware(req: Request, res: Response, next: NextFunction): void {
+    // Match /api/vN/... or /api/vN (with optional trailing slash)
+    const match = req.path.match(/^\/api\/(v\d+)(\/|$)/);
+
+    if (!match) {
+      // Unversioned path — pass through for backward-compat /api/* routes.
+      next();
+      return;
+    }
+
+    const versionSegment = match[1]; // e.g. "v1", "v2"
+
+    if (!SUPPORTED_VERSIONS.has(versionSegment)) {
+      res.status(404).json({
+        error: 'Unknown API version',
+        message: `Version "${versionSegment}" is not supported. Supported versions: ${[...SUPPORTED_VERSIONS].join(', ')}.`,
+        supported_versions: [...SUPPORTED_VERSIONS],
+        docs: 'https://docs.quorumproof.io/api/versioning',
+      });
+      return;
+    }
+
+    const version = versionSegment as ApiVersion;
+    const meta = VERSION_CATALOGUE[version];
+
+    // Attach to request so downstream handlers / middleware can branch on it.
+    req.apiVersion = version;
+
+    // Always emit the resolved version so clients know what they're talking to.
+    res.setHeader('API-Version', version);
+
+    // Emit deprecation signals for versions in maintenance or deprecated state.
+    if (meta.status === 'maintenance' || meta.status === 'deprecated') {
+      res.setHeader('Deprecation', meta.maintenanceDate ?? 'true');
+      if (meta.sunsetDate) {
+        res.setHeader('Sunset', meta.sunsetDate);
+      }
+      if (meta.migrationGuide) {
+        res.setHeader('Link', `<${meta.migrationGuide}>; rel="successor-version"`);
+      }
+      if (meta.deprecationReason) {
+        res.setHeader('X-API-Deprecation-Info', meta.deprecationReason);
+      }
+    }
+
+    next();
+  };
+}
+
+// ─── Version gate helper ──────────────────────────────────────────────────────
+
+/**
+ * Returns an Express middleware that restricts a sub-router to a specific
+ * API version.  If the request version doesn't match, passes through to the
+ * next handler (allows stacking version-specific routers).
+ *
+ * Usage:
+ *   app.use('/api/v1', versionGate('v1'), v1Router);
+ *   app.use('/api/v2', versionGate('v2'), v2Router);
+ */
+export function versionGate(expectedVersion: ApiVersion) {
+  return function versionGateMiddleware(req: Request, res: Response, next: NextFunction): void {
+    if (req.apiVersion === expectedVersion) {
+      next();
+    } else {
+      next('router');
+    }
+  };
+}
+
+// ─── Sunset handler ───────────────────────────────────────────────────────────
+
+/**
+ * Terminates requests to sunset versions with `410 Gone` and a descriptive
+ * body.  Mount this before the version's router:
+ *
+ *   app.use('/api/v0', sunsetHandler('v0'));
+ */
+export function sunsetHandler(version: string) {
+  return function sunsetMiddleware(_req: Request, res: Response): void {
+    res.status(410).json({
+      error: 'API version sunset',
+      message: `Version "${version}" has been retired and is no longer available.`,
+      docs: 'https://docs.quorumproof.io/api/versioning',
+    });
+  };
+}

--- a/api-server/src/middleware/v1Compat.ts
+++ b/api-server/src/middleware/v1Compat.ts
@@ -1,0 +1,130 @@
+/**
+ * v1 Compatibility Layer (Issue #1310)
+ *
+ * Normalises responses produced by the existing route handlers into the
+ * envelope shape that v1 clients expect, and backfills field aliases that
+ * v2 will rename.
+ *
+ * Design:
+ *  - The existing handler code is NOT modified — it stays the canonical
+ *    implementation for both versions.
+ *  - This middleware intercepts `res.json()` after the handler runs and
+ *    applies a deterministic transform *only* when `req.apiVersion === 'v1'`.
+ *  - v2 (and unversioned /api/*) routes are completely unaffected.
+ *
+ * v1 envelope contract
+ * ─────────────────────
+ * Every successful (2xx) response is wrapped in:
+ *   { ok: true, version: "v1", data: <original body> }
+ *
+ * Every error (4xx / 5xx) response is wrapped in:
+ *   { ok: false, version: "v1", error: <string>, details?: <original body> }
+ *
+ * Field aliases (applied inside `data` for object and array-of-object responses)
+ * ────────────────────────────────────────────────────────────────────────────
+ * v2 name          → v1 alias (kept alongside for forward compat)
+ * metadata_hash    → metadata
+ * stellar_address  → address
+ */
+
+import { Request, Response, NextFunction } from 'express';
+
+// ─── Type helpers ─────────────────────────────────────────────────────────────
+
+type JsonValue = string | number | boolean | null | JsonObject | JsonArray;
+type JsonObject = { [key: string]: JsonValue };
+type JsonArray = JsonValue[];
+
+// ─── Field alias map ──────────────────────────────────────────────────────────
+
+/**
+ * Pairs of [v2_field_name, v1_alias].
+ * The alias is *added* alongside the canonical name so code that already
+ * uses the canonical name keeps working.
+ */
+const FIELD_ALIASES: Array<[string, string]> = [
+  ['metadata_hash', 'metadata'],
+  ['stellar_address', 'address'],
+];
+
+// ─── Transform helpers ────────────────────────────────────────────────────────
+
+function applyAliases(obj: JsonObject): JsonObject {
+  const result: JsonObject = { ...obj };
+  for (const [canonical, alias] of FIELD_ALIASES) {
+    if (canonical in result && !(alias in result)) {
+      result[alias] = result[canonical];
+    }
+  }
+  return result;
+}
+
+function transformValue(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) {
+    return value.map((item) =>
+      item !== null && typeof item === 'object' && !Array.isArray(item)
+        ? applyAliases(item as JsonObject)
+        : item
+    );
+  }
+  if (value !== null && typeof value === 'object') {
+    return applyAliases(value as JsonObject);
+  }
+  return value;
+}
+
+function wrapSuccessEnvelope(body: JsonValue): JsonObject {
+  return {
+    ok: true,
+    version: 'v1',
+    data: transformValue(body),
+  };
+}
+
+function wrapErrorEnvelope(body: JsonValue): JsonObject {
+  const errMsg =
+    body !== null && typeof body === 'object' && !Array.isArray(body)
+      ? ((body as JsonObject).error as string | undefined) ?? 'An error occurred'
+      : String(body);
+
+  return {
+    ok: false,
+    version: 'v1',
+    error: errMsg,
+    details: body,
+  };
+}
+
+// ─── Middleware ───────────────────────────────────────────────────────────────
+
+/**
+ * Intercepts `res.json()` for v1 requests only.
+ *
+ * This middleware must be mounted *before* the route handlers so that the
+ * patched `res.json` is in place when the handler calls it.
+ */
+export function v1Compat(req: Request, res: Response, next: NextFunction): void {
+  if (req.apiVersion !== 'v1') {
+    next();
+    return;
+  }
+
+  const originalJson = res.json.bind(res);
+
+  // Override res.json to apply the envelope transform
+  res.json = function wrappedJson(body?: JsonValue): Response {
+    const statusCode = res.statusCode;
+    const isError = statusCode >= 400;
+
+    const envelope = isError
+      ? wrapErrorEnvelope(body ?? null)
+      : wrapSuccessEnvelope(body ?? null);
+
+    return originalJson(envelope);
+  };
+
+  // Emit a header so clients can detect the compat layer is active
+  res.setHeader('X-API-Compat-Layer', 'v1');
+
+  next();
+}

--- a/api-server/src/routes/v1/index.ts
+++ b/api-server/src/routes/v1/index.ts
@@ -1,0 +1,91 @@
+/**
+ * API v1 Router Registry (Issue #1310)
+ *
+ * Mounts all current route handlers under /api/v1.
+ *
+ * This registry is the canonical v1 surface.  Route handlers themselves are
+ * not duplicated — the same factory-created or pre-built routers that power
+ * the backward-compatible /api/* paths are reused here.  The v1Compat
+ * middleware (applied by index.ts before mounting this router) wraps every
+ * response in the v1 envelope.
+ *
+ * Lifecycle:
+ *   Stable now → Maintenance 2026-09-01 → Sunset 2027-03-01
+ */
+
+import { Router } from 'express';
+
+// ── Route imports ──────────────────────────────────────────────────────────────
+import slicesRouter from '../slices.js';
+import credentialsRouter from '../credentials.js';
+import credentialExportRouter from '../credentialExport.js';
+import verifyRouter from '../verify.js';
+import notificationsRouter from '../notifications.js';
+import analyticsRouter from '../analytics.js';
+import issuerAnalyticsRouter from '../issuerAnalytics.js';
+import attestorRouter from '../attestor.js';
+import issuerRouter from '../issuer.js';
+import recoveryRouter from '../recovery.js';
+import shareLinksRouter from '../shareLinks.js';
+import consentRouter from '../consent.js';
+import webhooksRouter from '../webhooks.js';
+import gdprRouter from '../gdpr.js';
+import apiKeysRouter from '../apiKeys.js';
+import oauth2Router from '../oauth2.js';
+import { createDashboardRouter } from '../dashboard.js';
+import * as Soroban from '../../soroban.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+const sorobanClient = {
+  simulateCall: Soroban.simulateCall,
+  u64Val: Soroban.u64Val as ReturnType<typeof createDashboardRouter> extends never ? never : Parameters<typeof createDashboardRouter>[0]['u64Val'],
+  u32Val: Soroban.u32Val,
+  addressVal: Soroban.addressVal,
+};
+
+/**
+ * Creates the v1 router.
+ *
+ * Accepts an optional soroban client override for testing.
+ */
+export function createV1Router(soroban = sorobanClient): Router {
+  const router = Router();
+
+  // Core credential lifecycle
+  router.use('/slices', slicesRouter);
+  router.use('/credentials', credentialsRouter);
+  router.use('/credentials', credentialExportRouter);   // JSON/PDF/QR export
+  router.use('/credentials', shareLinksRouter);          // Share link management
+  router.use('/credentials', consentRouter);             // Consent management
+
+  // Verification
+  router.use('/verify', verifyRouter);
+
+  // Notifications & analytics
+  router.use('/notifications', notificationsRouter);
+  router.use('/analytics', analyticsRouter);
+  router.use('/analytics', issuerAnalyticsRouter);       // Issuer-scoped analytics
+
+  // Attestors & issuers
+  router.use('/attestor', attestorRouter);
+  router.use('/issuer', issuerRouter);
+
+  // Account recovery
+  router.use('/recovery', recoveryRouter);
+
+  // Compliance & data-privacy
+  router.use('/webhooks', webhooksRouter);
+  router.use('/gdpr', gdprRouter);
+
+  // Auth subsystem
+  router.use('/api-keys', apiKeysRouter);
+  router.use('/oauth2', oauth2Router);
+
+  // Credential holder dashboard
+  router.use('/me', createDashboardRouter(soroban));
+
+  return router;
+}
+
+export default createV1Router();

--- a/api-server/src/routes/v2/index.ts
+++ b/api-server/src/routes/v2/index.ts
@@ -1,0 +1,96 @@
+/**
+ * API v2 Router Registry (Issue #1310)
+ *
+ * Forward-looking stub for the v2 API surface.
+ *
+ * v2 is currently in development and exposes the same handlers as v1.
+ * As breaking changes are introduced they will be implemented here as
+ * version-specific overrides rather than touching the shared handlers.
+ *
+ * v2 design goals / planned breaking changes vs v1:
+ *
+ *   - No response envelope wrapper (`ok`, `version`, `data`) — raw resource
+ *     objects are returned directly, which is friendlier for typed SDKs.
+ *   - Field renames: `metadata` → `metadata_hash`, `address` → `stellar_address`.
+ *   - Pagination cursor format migrated to opaque base64-encoded tokens
+ *     (same behaviour, but the field name changes from `next_cursor` to `cursor`).
+ *   - Error shape aligned with RFC 9457 Problem Details.
+ *   - New endpoints: /api/v2/proof-requests, /api/v2/revocation-registry.
+ *
+ * Lifecycle:
+ *   Development now → GA / Stable 2026-09-01
+ *
+ * NOTE: Until v2 deviates from v1 handlers all traffic to /api/v2/* will
+ * resolve identically to /api/v1/* minus the compat envelope.  This ensures
+ * v2 clients can start integrating early against the stable route structure.
+ */
+
+import { Router } from 'express';
+
+// ── Shared route imports (same as v1 — override here when v2 diverges) ────────
+import slicesRouter from '../slices.js';
+import credentialsRouter from '../credentials.js';
+import credentialExportRouter from '../credentialExport.js';
+import verifyRouter from '../verify.js';
+import notificationsRouter from '../notifications.js';
+import analyticsRouter from '../analytics.js';
+import issuerAnalyticsRouter from '../issuerAnalytics.js';
+import attestorRouter from '../attestor.js';
+import issuerRouter from '../issuer.js';
+import recoveryRouter from '../recovery.js';
+import shareLinksRouter from '../shareLinks.js';
+import consentRouter from '../consent.js';
+import webhooksRouter from '../webhooks.js';
+import gdprRouter from '../gdpr.js';
+import apiKeysRouter from '../apiKeys.js';
+import oauth2Router from '../oauth2.js';
+import { createDashboardRouter } from '../dashboard.js';
+import * as Soroban from '../../soroban.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+const sorobanClient = {
+  simulateCall: Soroban.simulateCall,
+  u64Val: Soroban.u64Val as Parameters<typeof createDashboardRouter>[0]['u64Val'],
+  u32Val: Soroban.u32Val,
+  addressVal: Soroban.addressVal,
+};
+
+/**
+ * Creates the v2 router.
+ *
+ * Accepts an optional soroban client override for testing.
+ */
+export function createV2Router(soroban = sorobanClient): Router {
+  const router = Router();
+
+  // ── Shared with v1 — replace with v2-specific handlers as they land ─────────
+
+  router.use('/slices', slicesRouter);
+  router.use('/credentials', credentialsRouter);
+  router.use('/credentials', credentialExportRouter);
+  router.use('/credentials', shareLinksRouter);
+  router.use('/credentials', consentRouter);
+  router.use('/verify', verifyRouter);
+  router.use('/notifications', notificationsRouter);
+  router.use('/analytics', analyticsRouter);
+  router.use('/analytics', issuerAnalyticsRouter);
+  router.use('/attestor', attestorRouter);
+  router.use('/issuer', issuerRouter);
+  router.use('/recovery', recoveryRouter);
+  router.use('/webhooks', webhooksRouter);
+  router.use('/gdpr', gdprRouter);
+  router.use('/api-keys', apiKeysRouter);
+  router.use('/oauth2', oauth2Router);
+  router.use('/me', createDashboardRouter(soroban));
+
+  // ── v2-only stubs (expand as features graduate from design to implementation)
+
+  // Planned: /proof-requests  — managed ZK proof-request lifecycle
+  // Planned: /revocation-registry — batch revocation with time-locks
+  // Planned: /bbs-credentials  — BBS+ selective-disclosure credentials
+
+  return router;
+}
+
+export default createV2Router();

--- a/api-server/tests/apiVersioning.test.ts
+++ b/api-server/tests/apiVersioning.test.ts
@@ -1,0 +1,534 @@
+/**
+ * API Versioning Tests (Issue #1310)
+ *
+ * Covers:
+ *   - Version middleware: URL parsing, req.apiVersion attachment, API-Version header
+ *   - Deprecation / sunset headers for maintenance versions
+ *   - Unknown version → 404
+ *   - Sunset version → 410 helper
+ *   - v1 compatibility layer: response envelope (ok / version / data)
+ *   - v1 compatibility layer: error envelope (ok: false / version / error)
+ *   - v1 compatibility layer: field aliasing (metadata_hash → metadata)
+ *   - v2 routes: raw responses without envelope
+ *   - Unversioned /api/* routes: pass-through (backward compat)
+ *   - Version routing: same handler accessible under both /api/v1/* and /api/v2/*
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express, { type Request, type Response } from 'express';
+import request from 'supertest';
+import {
+  createApiVersionMiddleware,
+  versionGate,
+  sunsetHandler,
+  VERSION_CATALOGUE,
+  type ApiVersion,
+} from '../src/middleware/apiVersion.js';
+import { v1Compat } from '../src/middleware/v1Compat.js';
+import { createV1Router } from '../src/routes/v1/index.js';
+import { createV2Router } from '../src/routes/v2/index.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Minimal mock Soroban client used everywhere route factories are called */
+const mockSoroban = {
+  simulateCall: vi.fn(),
+  u64Val: (n: number | bigint) => n as any,
+  u32Val: (n: number) => n as any,
+  addressVal: (a: string) => a as any,
+};
+
+/** Builds a minimal test app with the version middleware mounted */
+function buildVersionedApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(createApiVersionMiddleware());
+  return app;
+}
+
+/** Adds a simple echo handler at `path` that returns `{ payload: "ok" }` */
+function addEchoRoute(app: ReturnType<typeof express>, path: string) {
+  app.get(path, (_req: Request, res: Response) => {
+    res.json({ payload: 'ok' });
+  });
+}
+
+// ─── Version middleware ───────────────────────────────────────────────────────
+
+describe('createApiVersionMiddleware()', () => {
+  describe('version extraction', () => {
+    it('sets req.apiVersion to "v1" for /api/v1/* paths', async () => {
+      const app = buildVersionedApp();
+      app.get('/api/v1/test', (req, res) => {
+        res.json({ apiVersion: req.apiVersion });
+      });
+
+      const res = await request(app).get('/api/v1/test');
+      expect(res.status).toBe(200);
+      expect(res.body.apiVersion).toBe('v1');
+    });
+
+    it('sets req.apiVersion to "v2" for /api/v2/* paths', async () => {
+      const app = buildVersionedApp();
+      app.get('/api/v2/test', (req, res) => {
+        res.json({ apiVersion: req.apiVersion });
+      });
+
+      const res = await request(app).get('/api/v2/test');
+      expect(res.status).toBe(200);
+      expect(res.body.apiVersion).toBe('v2');
+    });
+
+    it('does not set req.apiVersion for unversioned /api/* paths', async () => {
+      const app = buildVersionedApp();
+      app.get('/api/test', (req, res) => {
+        res.json({ apiVersion: req.apiVersion ?? null });
+      });
+
+      const res = await request(app).get('/api/test');
+      expect(res.status).toBe(200);
+      expect(res.body.apiVersion).toBeNull();
+    });
+
+    it('does not set req.apiVersion for non-/api paths', async () => {
+      const app = buildVersionedApp();
+      app.get('/health', (req, res) => {
+        res.json({ apiVersion: req.apiVersion ?? null });
+      });
+
+      const res = await request(app).get('/health');
+      expect(res.status).toBe(200);
+      expect(res.body.apiVersion).toBeNull();
+    });
+  });
+
+  describe('API-Version response header', () => {
+    it('sets API-Version header on versioned requests', async () => {
+      const app = buildVersionedApp();
+      addEchoRoute(app, '/api/v1/test');
+
+      const res = await request(app).get('/api/v1/test');
+      expect(res.headers['api-version']).toBe('v1');
+    });
+
+    it('sets API-Version: v2 on v2 requests', async () => {
+      const app = buildVersionedApp();
+      addEchoRoute(app, '/api/v2/test');
+
+      const res = await request(app).get('/api/v2/test');
+      expect(res.headers['api-version']).toBe('v2');
+    });
+
+    it('does NOT set API-Version on unversioned requests', async () => {
+      const app = buildVersionedApp();
+      addEchoRoute(app, '/api/test');
+
+      const res = await request(app).get('/api/test');
+      expect(res.headers['api-version']).toBeUndefined();
+    });
+  });
+
+  describe('unknown version → 404', () => {
+    it('returns 404 for an unknown version segment', async () => {
+      const app = buildVersionedApp();
+
+      const res = await request(app).get('/api/v99/test');
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Unknown API version');
+      expect(res.body.supported_versions).toContain('v1');
+      expect(res.body.supported_versions).toContain('v2');
+    });
+
+    it('returns 404 for /api/v0 (never existed)', async () => {
+      const app = buildVersionedApp();
+
+      const res = await request(app).get('/api/v0/slices');
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Unknown API version');
+    });
+
+    it('returns 404 for /api/v3 (not yet released)', async () => {
+      const app = buildVersionedApp();
+
+      const res = await request(app).get('/api/v3/credentials');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('deprecation headers for maintenance versions', () => {
+    it('does NOT add Deprecation header for stable v1 (not yet in maintenance)', async () => {
+      // v1 is currently "stable" — the Deprecation header should only appear
+      // once the status is flipped to "maintenance".
+      const app = buildVersionedApp();
+      addEchoRoute(app, '/api/v1/test');
+
+      const res = await request(app).get('/api/v1/test');
+      // Stable means no deprecation signal yet
+      expect(res.headers['deprecation']).toBeUndefined();
+    });
+
+    it('does NOT add Deprecation header for v2 (development)', async () => {
+      const app = buildVersionedApp();
+      addEchoRoute(app, '/api/v2/test');
+
+      const res = await request(app).get('/api/v2/test');
+      expect(res.headers['deprecation']).toBeUndefined();
+    });
+
+    it('adds Deprecation + Sunset + Link headers when status is "maintenance"', async () => {
+      // Temporarily patch the catalogue to simulate a version entering maintenance
+      const original = VERSION_CATALOGUE['v1' as ApiVersion];
+      (VERSION_CATALOGUE as any).v1 = {
+        ...original,
+        status: 'maintenance',
+        maintenanceDate: '2026-09-01',
+        sunsetDate: '2027-03-01',
+        migrationGuide: 'https://docs.quorumproof.io/api/migration/v1-to-v2',
+      };
+
+      const app = buildVersionedApp();
+      addEchoRoute(app, '/api/v1/test');
+
+      try {
+        const res = await request(app).get('/api/v1/test');
+        expect(res.headers['deprecation']).toBe('2026-09-01');
+        expect(res.headers['sunset']).toBe('2027-03-01');
+        expect(res.headers['link']).toContain('successor-version');
+        expect(res.headers['x-api-deprecation-info']).toBeDefined();
+      } finally {
+        (VERSION_CATALOGUE as any).v1 = original;
+      }
+    });
+  });
+});
+
+// ─── sunsetHandler helper ─────────────────────────────────────────────────────
+
+describe('sunsetHandler()', () => {
+  it('returns 410 Gone for sunset versions', async () => {
+    const app = express();
+    app.use('/api/v0', sunsetHandler('v0'));
+
+    const res = await request(app).get('/api/v0/credentials');
+    expect(res.status).toBe(410);
+    expect(res.body.error).toBe('API version sunset');
+    expect(res.body.message).toContain('v0');
+  });
+});
+
+// ─── v1 compatibility layer ───────────────────────────────────────────────────
+
+describe('v1Compat middleware', () => {
+  function buildV1App() {
+    const app = express();
+    app.use(express.json());
+    // Simulate what the main app does: attach apiVersion then apply compat
+    app.use((req, _res, next) => {
+      req.apiVersion = 'v1';
+      next();
+    });
+    app.use(v1Compat);
+    return app;
+  }
+
+  describe('success envelope', () => {
+    it('wraps 200 responses in { ok, version, data }', async () => {
+      const app = buildV1App();
+      app.get('/test', (_req, res) => {
+        res.json({ id: '1', name: 'Alice' });
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.version).toBe('v1');
+      expect(res.body.data).toEqual({ id: '1', name: 'Alice' });
+    });
+
+    it('sets X-API-Compat-Layer: v1 header', async () => {
+      const app = buildV1App();
+      app.get('/test', (_req, res) => res.json({}));
+
+      const res = await request(app).get('/test');
+      expect(res.headers['x-api-compat-layer']).toBe('v1');
+    });
+
+    it('wraps array responses inside data', async () => {
+      const app = buildV1App();
+      app.get('/test', (_req, res) => {
+        res.json([{ id: '1' }, { id: '2' }]);
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.body.ok).toBe(true);
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body.data).toHaveLength(2);
+    });
+
+    it('wraps null body in data', async () => {
+      const app = buildV1App();
+      app.get('/test', (_req, res) => res.json(null));
+
+      const res = await request(app).get('/test');
+      expect(res.body.ok).toBe(true);
+      expect(res.body.data).toBeNull();
+    });
+  });
+
+  describe('error envelope', () => {
+    it('wraps 400 responses in { ok: false, version, error }', async () => {
+      const app = buildV1App();
+      app.get('/test', (_req, res) => {
+        res.status(400).json({ error: 'Invalid ID', detail: 'must be a number' });
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.status).toBe(400);
+      expect(res.body.ok).toBe(false);
+      expect(res.body.version).toBe('v1');
+      expect(res.body.error).toBe('Invalid ID');
+      expect(res.body.details).toBeDefined();
+    });
+
+    it('wraps 404 responses in error envelope', async () => {
+      const app = buildV1App();
+      app.get('/test', (_req, res) => {
+        res.status(404).json({ error: 'Not found' });
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.body.ok).toBe(false);
+      expect(res.body.error).toBe('Not found');
+    });
+
+    it('wraps 500 responses in error envelope', async () => {
+      const app = buildV1App();
+      app.get('/test', (_req, res) => {
+        res.status(500).json({ error: 'Internal error' });
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.body.ok).toBe(false);
+    });
+  });
+
+  describe('field aliasing', () => {
+    it('adds metadata alias for metadata_hash', async () => {
+      const app = buildV1App();
+      app.get('/test', (_req, res) => {
+        res.json({ id: '1', metadata_hash: 'abc123' });
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.body.data.metadata_hash).toBe('abc123');
+      expect(res.body.data.metadata).toBe('abc123');
+    });
+
+    it('adds address alias for stellar_address', async () => {
+      const app = buildV1App();
+      app.get('/test', (_req, res) => {
+        res.json({ id: '1', stellar_address: 'GABC' });
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.body.data.stellar_address).toBe('GABC');
+      expect(res.body.data.address).toBe('GABC');
+    });
+
+    it('applies aliases to all items in an array response', async () => {
+      const app = buildV1App();
+      app.get('/test', (_req, res) => {
+        res.json([
+          { id: '1', metadata_hash: 'hash1' },
+          { id: '2', metadata_hash: 'hash2' },
+        ]);
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.body.data[0].metadata).toBe('hash1');
+      expect(res.body.data[1].metadata).toBe('hash2');
+    });
+
+    it('does not overwrite an existing alias field if already set', async () => {
+      const app = buildV1App();
+      app.get('/test', (_req, res) => {
+        res.json({ id: '1', metadata_hash: 'new', metadata: 'existing' });
+      });
+
+      const res = await request(app).get('/test');
+      // Pre-existing alias should not be clobbered
+      expect(res.body.data.metadata).toBe('existing');
+    });
+  });
+
+  describe('v2 requests skip compat layer', () => {
+    it('passes v2 responses through unmodified', async () => {
+      const app = express();
+      app.use(express.json());
+      app.use((req, _res, next) => {
+        req.apiVersion = 'v2';
+        next();
+      });
+      app.use(v1Compat);
+      app.get('/test', (_req, res) => {
+        res.json({ id: '1', payload: 'raw' });
+      });
+
+      const res = await request(app).get('/test');
+      expect(res.body.ok).toBeUndefined();
+      expect(res.body.id).toBe('1');
+    });
+
+    it('does not set X-API-Compat-Layer header on v2 requests', async () => {
+      const app = express();
+      app.use(express.json());
+      app.use((req, _res, next) => {
+        req.apiVersion = 'v2';
+        next();
+      });
+      app.use(v1Compat);
+      app.get('/test', (_req, res) => res.json({}));
+
+      const res = await request(app).get('/test');
+      expect(res.headers['x-api-compat-layer']).toBeUndefined();
+    });
+  });
+
+  describe('unversioned requests skip compat layer', () => {
+    it('passes unversioned responses through unmodified', async () => {
+      const app = express();
+      app.use(express.json());
+      // No apiVersion set — simulates unversioned /api/* path
+      app.use(v1Compat);
+      app.get('/api/test', (_req, res) => {
+        res.json({ id: '1', payload: 'raw' });
+      });
+
+      const res = await request(app).get('/api/test');
+      expect(res.body.ok).toBeUndefined();
+      expect(res.body.payload).toBe('raw');
+    });
+  });
+});
+
+// ─── Full integration: version routing ───────────────────────────────────────
+
+describe('Version routing integration', () => {
+  let app: ReturnType<typeof express>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSoroban.simulateCall.mockReset();
+  });
+
+  /**
+   * Builds a minimal app with versioning middleware + v1/v2 routers containing
+   * a single test endpoint that returns a known payload.
+   */
+  function buildIntegrationApp() {
+    const a = express();
+    a.use(express.json());
+    a.use(createApiVersionMiddleware());
+
+    // Mount a tiny versioned sub-router for testing
+    const testRouterV1 = express.Router();
+    testRouterV1.get('/ping', (_req, res) => res.json({ pong: 'v1' }));
+
+    const testRouterV2 = express.Router();
+    testRouterV2.get('/ping', (_req, res) => res.json({ pong: 'v2' }));
+
+    a.use('/api/v1', v1Compat, testRouterV1);
+    a.use('/api/v2', testRouterV2);
+
+    // Unversioned legacy
+    a.get('/api/ping', (_req, res) => res.json({ pong: 'legacy' }));
+
+    return a;
+  }
+
+  it('routes /api/v1/* through the v1 router', async () => {
+    const a = buildIntegrationApp();
+    const res = await request(a).get('/api/v1/ping');
+    expect(res.status).toBe(200);
+    // v1 envelope wraps the response
+    expect(res.body.version).toBe('v1');
+    expect(res.body.data.pong).toBe('v1');
+  });
+
+  it('routes /api/v2/* through the v2 router (no envelope)', async () => {
+    const a = buildIntegrationApp();
+    const res = await request(a).get('/api/v2/ping');
+    expect(res.status).toBe(200);
+    // v2 has no envelope
+    expect(res.body.ok).toBeUndefined();
+    expect(res.body.pong).toBe('v2');
+  });
+
+  it('routes /api/* through legacy paths (no envelope, no API-Version header)', async () => {
+    const a = buildIntegrationApp();
+    const res = await request(a).get('/api/ping');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBeUndefined();
+    expect(res.body.pong).toBe('legacy');
+    expect(res.headers['api-version']).toBeUndefined();
+  });
+
+  it('returns 404 for unsupported version prefix', async () => {
+    const a = buildIntegrationApp();
+    const res = await request(a).get('/api/v99/ping');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Unknown API version');
+  });
+
+  it('v1 envelope wraps errors produced by route handlers', async () => {
+    const a = express();
+    a.use(express.json());
+    a.use(createApiVersionMiddleware());
+    const testRouter = express.Router();
+    testRouter.get('/fail', (_req, res) => {
+      res.status(404).json({ error: 'not found in v1' });
+    });
+    a.use('/api/v1', v1Compat, testRouter);
+
+    const res = await request(a).get('/api/v1/fail');
+    expect(res.status).toBe(404);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.version).toBe('v1');
+    expect(res.body.error).toBe('not found in v1');
+  });
+
+  it('v2 errors are NOT wrapped in an envelope', async () => {
+    const a = express();
+    a.use(express.json());
+    a.use(createApiVersionMiddleware());
+    const testRouter = express.Router();
+    testRouter.get('/fail', (_req, res) => {
+      res.status(404).json({ error: 'not found in v2' });
+    });
+    a.use('/api/v2', testRouter);
+
+    const res = await request(a).get('/api/v2/fail');
+    expect(res.status).toBe(404);
+    expect(res.body.ok).toBeUndefined();
+    expect(res.body.error).toBe('not found in v2');
+  });
+});
+
+// ─── VERSION_CATALOGUE contract ───────────────────────────────────────────────
+
+describe('VERSION_CATALOGUE', () => {
+  it('defines v1 with a sunsetDate in the future', () => {
+    const v1 = VERSION_CATALOGUE.v1;
+    expect(v1.sunsetDate).toBeDefined();
+    const sunset = new Date(v1.sunsetDate!);
+    expect(sunset.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('defines v2 with development status', () => {
+    expect(VERSION_CATALOGUE.v2.status).toBe('development');
+  });
+
+  it('provides a migrationGuide for v1', () => {
+    expect(VERSION_CATALOGUE.v1.migrationGuide).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Introduces a versioning strategy for the QuorumProof API server so breaking changes can be shipped without affecting
  existing clients. All current routes are now reachable under /api/v1/… and /api/v2/… in addition to the original /api/…
   paths, which remain fully functional.
  
  Changes
  
  Middleware
  
  - apiVersion.ts — parses the version segment from /api/vN/… URLs, attaches req.apiVersion to every request, and emits an
  API-Version response header. Unknown version strings return 404 immediately. Deprecation/Sunset/Link headers are emitted
  automatically once a version's status is changed to "maintenance" in the catalogue — no other code change required.
  - v1Compat.ts — intercepts res.json() for v1 requests only. Wraps 2xx responses in { ok: true, version: "v1", data: … }
   and errors in { ok: false, version: "v1", error: … }. Also backfills field aliases (metadata_hash → metadata,
  stellar_address → address) so clients can migrate field names incrementally without a hard cutover.
  
  Versioned routers
  
  - routes/v1/index.ts — mounts all existing route handlers under /api/v1. No handler code was duplicated or modified.
  - routes/v2/index.ts — stub router using the same handlers today (raw responses, no envelope). Structured so v2-specific
  overrides can be dropped in alongside the shared handlers as breaking changes land.
  
  Backward compatibility
  
  All existing /api/* unversioned routes are preserved unchanged. Clients that haven't migrated continue to work exactly
  as before.
  
  Deprecation schedule
  
  ┌────────────┬──────────────────────────────────────────────────────────────────────────┐
  │ Date       │ Event                                                                    │
  ├────────────┼──────────────────────────────────────────────────────────────────────────┤
  │ 2026-09-01 │ v1 → maintenance (deprecation headers appear on every response); v2 → GA │
  ├────────────┼──────────────────────────────────────────────────────────────────────────┤
  │ 2027-01-01 │ v1 → deprecated                                                          │
  ├────────────┼──────────────────────────────────────────────────────────────────────────┤
  │ 2027-03-01 │ v1 sunset — all requests return 410 Gone                                 │
  └────────────┴──────────────────────────────────────────────────────────────────────────┘
  
  Tests
  
  37 new tests in tests/apiVersioning.test.ts covering:
  
  - Version URL parsing and req.apiVersion attachment
  - API-Version response header presence/absence
  - Unknown version → 404
  - sunsetHandler → 410
  - v1 success envelope (ok, version, data)
  - v1 error envelope (ok: false, error, details)
  - Field aliasing on objects and arrays
  - v2 responses pass through unmodified (no envelope)
  - Unversioned /api/* responses pass through unmodified
  - Full integration routing across v1, v2, and legacy paths
  - VERSION_CATALOGUE contract (sunset date is in the future, v2 is development)
  
  All 37 new tests pass. Existing tests (credentials, slices, rateLimiter) unaffected.
  
  Documentation
  
  api-server/docs/API_VERSIONING.md covers the full version catalogue, deprecation schedule, v1 envelope spec, v2 planned
  breaking changes, response headers reference, and step-by-step client migration guide for both unversioned → v1 and v1 →
  v2.

closes #1310 