### PR TITLE
feat(api-server): add graceful shutdown with request draining (#1311)

### DIFF
--- a/api-server/src/index.ts
+++ b/api-server/src/index.ts
@@ -33,10 +33,21 @@ import { getSubscriberCount } from './ws/subscriptions.js';
 import { getWsMetrics, getWsMetricsPrometheus } from './ws/metrics.js';
 import { getDefaultRpcCircuitBreaker } from './services/rpcCircuitBreaker.js';
 import { getDefaultCriticalEventListener } from './services/criticalEventListener.js';
-import { broadcastEvent, getConnectionCount } from './ws/server.js';
+import { broadcastEvent, getConnectionCount, closeWsServer } from './ws/server.js';
+import { createGracefulShutdown } from './services/gracefulShutdown.js';
 import * as Soroban from './soroban.js';
 
 const app = express();
+
+// #1311: Create the HTTP server early so the graceful shutdown service can
+// reference it before httpServer.listen() is called.
+const httpServer = createServer(app);
+
+// #1311: Graceful shutdown — drains in-flight requests before exiting.
+// The drain timeout defaults to 30 s and is overridable via env var so
+// operators can tune it without a code change.
+const DRAIN_TIMEOUT_MS = parseInt(process.env.DRAIN_TIMEOUT_MS ?? '30000', 10);
+const gracefulShutdown = createGracefulShutdown(httpServer, { drainTimeoutMs: DRAIN_TIMEOUT_MS });
 
 // #1303: Apply CORS before all other middleware so preflight requests are handled
 // without requiring auth. Origins are configured via CORS_ALLOWED_ORIGINS env var.
@@ -47,6 +58,11 @@ const ddosProtection = createDDoSProtection();
 app.use(ddosProtection);
 
 app.use(express.json({ limit: '100kb' }));
+
+// #1311: Track in-flight HTTP requests. Must come after body parsers so
+// the counter includes the full request lifetime, and early enough that
+// every /api route is covered.
+app.use(gracefulShutdown.requestCountMiddleware());
 
 // #1297 per-API-key rate limiting: applies whenever a caller presents
 // x-api-key, independently of the general IP-based limiter below, and
@@ -122,6 +138,16 @@ const sorobanClient = {
 app.use('/api/me', createDashboardRouter(sorobanClient));
 
 app.get('/health', (_req, res) => {
+  // #1311: Return 503 during graceful shutdown so load-balancers stop
+  // routing new traffic to this instance while it finishes draining.
+  if (gracefulShutdown.isDraining()) {
+    res.status(503).json({
+      status: 'draining',
+      ts: new Date().toISOString(),
+      inFlightRequests: gracefulShutdown.inFlightCount(),
+    });
+    return;
+  }
   res.json({
     status: 'ok',
     ts: new Date().toISOString(),
@@ -176,8 +202,21 @@ app.get('/events/critical/recent', (_req, res) => {
 });
 
 const PORT = parseInt(process.env.PORT ?? '3000', 10);
-const httpServer = createServer(app);
 createWsServer(httpServer, '/ws');
+
+// #1311: Register cleanup tasks that run after the HTTP server stops
+// accepting connections — the WS server and critical event listener
+// hold their own resources that should be released cleanly.
+gracefulShutdown.addCleanupTask(() => {
+  criticalEventListener.stop();
+});
+gracefulShutdown.addCleanupTask(() => {
+  closeWsServer();
+});
+
+// #1311: Attach SIGTERM / SIGINT handlers. This is idempotent; the
+// handlers are registered with process.once so they fire at most once.
+gracefulShutdown.registerSignalHandlers();
 
 /**
  * Apply any pending database migrations before accepting traffic. Manual

--- a/api-server/src/services/gracefulShutdown.ts
+++ b/api-server/src/services/gracefulShutdown.ts
@@ -1,0 +1,244 @@
+/**
+ * Graceful Shutdown Service — Issue #1311
+ *
+ * Prevents in-flight HTTP requests from being abruptly killed when the
+ * process receives SIGTERM (container/orchestrator stop) or SIGINT (Ctrl-C).
+ *
+ * Sequence on signal receipt:
+ *   1. Flip isDraining → true. The /health endpoint returns 503 immediately
+ *      so load-balancers stop routing new traffic here.
+ *   2. Stop accepting new TCP connections by calling httpServer.close().
+ *   3. Wait for all in-flight requests to finish (i.e. inFlightCount → 0)
+ *      or until DRAIN_TIMEOUT_MS elapses, whichever comes first.
+ *   4. Optionally run any registered cleanup callbacks (DB pools, WS server,
+ *      cron timers, …).
+ *   5. Exit with code 0 on clean drain, code 1 on timeout.
+ *
+ * Usage in index.ts:
+ *   const gs = createGracefulShutdown(httpServer, { drainTimeoutMs: 30_000 });
+ *   gs.registerSignalHandlers();
+ *
+ *   // Track in-flight requests
+ *   app.use(gs.requestCountMiddleware());
+ *
+ *   // Expose draining state to /health
+ *   app.get('/health', (req, res) => {
+ *     if (gs.isDraining()) { res.status(503).json({ status: 'draining' }); return; }
+ *     res.json({ status: 'ok' });
+ *   });
+ */
+
+import { Server as HttpServer } from 'http';
+
+export const DEFAULT_DRAIN_TIMEOUT_MS = 30_000;
+
+export type CleanupFn = () => Promise<void> | void;
+
+export interface GracefulShutdownOptions {
+  /** Maximum time (ms) to wait for in-flight requests to complete. Default: 30 000 */
+  drainTimeoutMs?: number;
+  /** Called once the server stops accepting new connections, before waiting for drain. */
+  onShutdownStart?: () => void;
+  /** Called when all requests have finished or the timeout expires. */
+  onShutdownComplete?: (timedOut: boolean) => void;
+}
+
+export interface GracefulShutdown {
+  /** True once a shutdown signal has been received — gates the /health 503. */
+  isDraining: () => boolean;
+  /** Current number of requests being processed. */
+  inFlightCount: () => number;
+  /**
+   * Express middleware that increments the in-flight counter when a request
+   * arrives and decrements it when the response finishes.
+   */
+  requestCountMiddleware: () => (
+    req: import('express').Request,
+    res: import('express').Response,
+    next: import('express').NextFunction,
+  ) => void;
+  /**
+   * Register additional async cleanup tasks (e.g. close a DB pool,
+   * shut down the WS server) that run after the HTTP server stops
+   * accepting connections and before the process exits.
+   */
+  addCleanupTask: (fn: CleanupFn) => void;
+  /**
+   * Attach SIGTERM and SIGINT handlers to the process. Idempotent —
+   * calling more than once has no effect.
+   */
+  registerSignalHandlers: () => void;
+  /**
+   * Trigger shutdown programmatically (also used by the signal handlers
+   * and directly in tests). Resolves when shutdown is complete.
+   */
+  shutdown: () => Promise<void>;
+}
+
+export function createGracefulShutdown(
+  server: HttpServer,
+  options: GracefulShutdownOptions = {},
+): GracefulShutdown {
+  const drainTimeoutMs = options.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS;
+
+  let draining = false;
+  let inFlight = 0;
+  let resolveShutdown: (() => void) | null = null;
+  let signalsRegistered = false;
+  let shutdownInProgress = false;
+
+  const cleanupTasks: CleanupFn[] = [];
+
+  // Resolves when inFlight drops to zero; can also be resolved early on
+  // timeout by the shutdown() function.
+  let drainResolve: (() => void) | null = null;
+  const drainDone = (): void => {
+    if (drainResolve) {
+      drainResolve();
+      drainResolve = null;
+    }
+  };
+
+  function requestCountMiddleware() {
+    return (
+      _req: import('express').Request,
+      res: import('express').Response,
+      next: import('express').NextFunction,
+    ): void => {
+      inFlight++;
+      res.on('finish', () => {
+        inFlight--;
+        if (draining && inFlight === 0) {
+          drainDone();
+        }
+      });
+      res.on('close', () => {
+        // 'close' fires if the connection is destroyed before 'finish'
+        // (e.g. client disconnect mid-stream). Decrement only once.
+        if ((res as any).__countedClose) return;
+        (res as any).__countedClose = true;
+        // 'finish' already fired for normal responses; guard against
+        // double-decrement by checking whether we're still above zero.
+        inFlight = Math.max(0, inFlight - 1);
+        if (draining && inFlight === 0) {
+          drainDone();
+        }
+      });
+      next();
+    };
+  }
+
+  async function shutdown(): Promise<void> {
+    if (shutdownInProgress) return;
+    shutdownInProgress = true;
+    draining = true;
+
+    console.log(JSON.stringify({
+      ts: new Date().toISOString(),
+      level: 'info',
+      service: 'quorumproof-api',
+      event: 'graceful_shutdown_start',
+      inFlightRequests: inFlight,
+      drainTimeoutMs,
+    }));
+
+    options.onShutdownStart?.();
+
+    // Stop accepting new connections. Existing keep-alive connections are
+    // not forcibly closed here — they'll be reused for the remaining
+    // in-flight requests and will naturally close when idle.
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+
+    let timedOut = false;
+
+    if (inFlight > 0) {
+      // Wait for drain or timeout
+      await Promise.race([
+        new Promise<void>((resolve) => { drainResolve = resolve; }),
+        new Promise<void>((resolve) =>
+          setTimeout(() => {
+            timedOut = true;
+            resolve();
+          }, drainTimeoutMs),
+        ),
+      ]);
+    }
+
+    if (timedOut) {
+      console.warn(JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'warn',
+        service: 'quorumproof-api',
+        event: 'graceful_shutdown_timeout',
+        remainingInFlight: inFlight,
+        drainTimeoutMs,
+      }));
+    } else {
+      console.log(JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'info',
+        service: 'quorumproof-api',
+        event: 'graceful_shutdown_drained',
+        drainTimeoutMs,
+      }));
+    }
+
+    // Run registered cleanup tasks sequentially so each one sees a
+    // consistent state, and so a failing task doesn't skip the rest.
+    for (const task of cleanupTasks) {
+      try {
+        await task();
+      } catch (err) {
+        console.error(JSON.stringify({
+          ts: new Date().toISOString(),
+          level: 'error',
+          service: 'quorumproof-api',
+          event: 'graceful_shutdown_cleanup_error',
+          error: String(err),
+        }));
+      }
+    }
+
+    options.onShutdownComplete?.(timedOut);
+
+    console.log(JSON.stringify({
+      ts: new Date().toISOString(),
+      level: 'info',
+      service: 'quorumproof-api',
+      event: 'graceful_shutdown_complete',
+      timedOut,
+    }));
+
+    if (resolveShutdown) {
+      resolveShutdown();
+    }
+
+    process.exit(timedOut ? 1 : 0);
+  }
+
+  function registerSignalHandlers(): void {
+    if (signalsRegistered) return;
+    signalsRegistered = true;
+
+    const handler = () => {
+      shutdown().catch((err) => {
+        console.error('Graceful shutdown error:', err);
+        process.exit(1);
+      });
+    };
+
+    process.once('SIGTERM', handler);
+    process.once('SIGINT', handler);
+  }
+
+  return {
+    isDraining: () => draining,
+    inFlightCount: () => inFlight,
+    requestCountMiddleware,
+    addCleanupTask: (fn: CleanupFn) => { cleanupTasks.push(fn); },
+    registerSignalHandlers,
+    shutdown,
+  };
+}

--- a/api-server/tests/gracefulShutdown.test.ts
+++ b/api-server/tests/gracefulShutdown.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Tests for graceful shutdown service — Issue #1311
+ *
+ * Coverage:
+ *   1. Shutdown signal handling  (SIGTERM / SIGINT / programmatic)
+ *   2. Request draining period   (waits for in-flight requests)
+ *   3. Health check failure      (/health → 503 during draining)
+ *   4. Timeout protection        (exits on timeout when requests linger)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createServer } from 'http';
+import express from 'express';
+import request from 'supertest';
+import {
+  createGracefulShutdown,
+  DEFAULT_DRAIN_TIMEOUT_MS,
+  type GracefulShutdown,
+} from '../src/services/gracefulShutdown.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeServer(opts: { drainTimeoutMs?: number } = {}) {
+  const app = express();
+  const httpServer = createServer(app);
+
+  const gs = createGracefulShutdown(httpServer, {
+    drainTimeoutMs: opts.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS,
+  });
+
+  app.use(gs.requestCountMiddleware());
+
+  // A slow route that holds open for `delay` ms — used to simulate in-flight requests.
+  app.get('/slow', (req, res) => {
+    const delay = parseInt((req.query.delay as string) ?? '50', 10);
+    setTimeout(() => res.json({ done: true }), delay);
+  });
+
+  app.get('/fast', (_req, res) => res.json({ ok: true }));
+
+  app.get('/health', (_req, res) => {
+    if (gs.isDraining()) {
+      res.status(503).json({ status: 'draining', inFlightRequests: gs.inFlightCount() });
+      return;
+    }
+    res.json({ status: 'ok' });
+  });
+
+  return { app, httpServer, gs };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Shutdown signal handling
+// ---------------------------------------------------------------------------
+
+describe('Shutdown signal handling', () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Prevent the test process from actually exiting.
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number) => {
+      return undefined as never;
+    });
+  });
+
+  afterEach(() => {
+    processExitSpy.mockRestore();
+    // Clean up any leftover process.once listeners added during tests.
+    process.removeAllListeners('SIGTERM');
+    process.removeAllListeners('SIGINT');
+  });
+
+  it('starts in a non-draining state', () => {
+    const { gs, httpServer } = makeServer();
+    expect(gs.isDraining()).toBe(false);
+    httpServer.close();
+  });
+
+  it('flips isDraining to true when shutdown() is called programmatically', async () => {
+    const { gs, httpServer } = makeServer({ drainTimeoutMs: 50 });
+    httpServer.listen(0); // bind to an ephemeral port
+
+    const p = gs.shutdown();
+    expect(gs.isDraining()).toBe(true);
+    await p;
+
+    httpServer.close();
+  });
+
+  it('registerSignalHandlers() is idempotent — calling twice does not double-register', () => {
+    const { gs, httpServer } = makeServer();
+    gs.registerSignalHandlers();
+    gs.registerSignalHandlers(); // second call must be a no-op
+
+    const listenerCount = process.listenerCount('SIGTERM');
+    // Should have at most one listener per gs instance (could be 0 if this
+    // environment strips them, or 1 if not, but never 2+).
+    expect(listenerCount).toBeLessThanOrEqual(1);
+
+    httpServer.close();
+  });
+
+  it('process.exit(0) is called after a clean drain', async () => {
+    const { gs, httpServer } = makeServer({ drainTimeoutMs: 200 });
+    httpServer.listen(0);
+
+    await gs.shutdown();
+
+    expect(processExitSpy).toHaveBeenCalledWith(0);
+    httpServer.close();
+  });
+
+  it('onShutdownStart callback is invoked on shutdown', async () => {
+    const app = express();
+    const httpServer = createServer(app);
+    const onStart = vi.fn();
+    const gs = createGracefulShutdown(httpServer, { drainTimeoutMs: 50, onShutdownStart: onStart });
+    app.use(gs.requestCountMiddleware());
+    httpServer.listen(0);
+
+    await gs.shutdown();
+
+    expect(onStart).toHaveBeenCalledOnce();
+    httpServer.close();
+  });
+
+  it('onShutdownComplete callback receives timedOut=false on clean drain', async () => {
+    const app = express();
+    const httpServer = createServer(app);
+    const onComplete = vi.fn();
+    const gs = createGracefulShutdown(httpServer, {
+      drainTimeoutMs: 200,
+      onShutdownComplete: onComplete,
+    });
+    app.use(gs.requestCountMiddleware());
+    httpServer.listen(0);
+
+    await gs.shutdown();
+
+    expect(onComplete).toHaveBeenCalledWith(false);
+    httpServer.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Request draining period
+// ---------------------------------------------------------------------------
+
+describe('Request draining', () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number) => {
+      return undefined as never;
+    });
+  });
+
+  afterEach(() => {
+    processExitSpy.mockRestore();
+    process.removeAllListeners('SIGTERM');
+    process.removeAllListeners('SIGINT');
+  });
+
+  it('inFlightCount() is 0 when no requests are active', () => {
+    const { gs, httpServer } = makeServer();
+    expect(gs.inFlightCount()).toBe(0);
+    httpServer.close();
+  });
+
+  it('inFlightCount() increments while a request is in progress and decrements after', async () => {
+    const { app, httpServer, gs } = makeServer();
+    httpServer.listen(0);
+    const addr = httpServer.address() as { port: number };
+
+    // Fire a slow request without awaiting it so we can observe inFlight mid-request.
+    const slowReqPromise = request(`http://localhost:${addr.port}`)
+      .get('/slow?delay=80')
+      .then((r) => r);
+
+    // Give the request a moment to reach the handler and increment the counter.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(gs.inFlightCount()).toBe(1);
+
+    // Wait for it to complete.
+    await slowReqPromise;
+    expect(gs.inFlightCount()).toBe(0);
+
+    httpServer.close();
+  });
+
+  it('shutdown() waits for in-flight requests to finish before exiting', async () => {
+    // This test verifies the drain contract directly without depending on
+    // HTTP timing: we simulate an in-flight request by manually using the
+    // requestCountMiddleware to increment the counter, then decrement it
+    // after a delay — exactly what a real request does. The shutdown should
+    // wait for that decrement before exiting.
+    const app2 = express();
+    const httpServer2 = createServer(app2);
+    const gs2 = createGracefulShutdown(httpServer2, { drainTimeoutMs: 5000 });
+    app2.use(gs2.requestCountMiddleware());
+
+    // Simulate a request arriving: build a fake res object that fires
+    // 'finish' after a delay (simulating a slow response).
+    let finishCallback: (() => void) | null = null;
+    const fakeRes = {
+      on(event: string, cb: () => void) {
+        if (event === 'finish') finishCallback = cb;
+        // ignore 'close'
+      },
+    } as any;
+
+    const mw = gs2.requestCountMiddleware();
+    mw({} as any, fakeRes, () => {});
+
+    expect(gs2.inFlightCount()).toBe(1); // request is in flight
+
+    httpServer2.listen(0);
+    const shutdownPromise = gs2.shutdown();
+
+    // Shutdown has started but the counter is still 1, so it must be waiting.
+    expect(gs2.isDraining()).toBe(true);
+    expect(gs2.inFlightCount()).toBe(1);
+
+    // Simulate the response finishing after 50 ms.
+    setTimeout(() => {
+      if (finishCallback) finishCallback();
+    }, 50);
+
+    await shutdownPromise;
+
+    expect(processExitSpy).toHaveBeenCalledWith(0);
+    expect(gs2.inFlightCount()).toBe(0);
+    httpServer2.close();
+  }, 10_000);
+
+  it('cleanup tasks run after the server stops accepting connections', async () => {
+    const { gs, httpServer } = makeServer({ drainTimeoutMs: 200 });
+    const order: string[] = [];
+
+    gs.addCleanupTask(async () => { order.push('cleanup1'); });
+    gs.addCleanupTask(() => { order.push('cleanup2'); });
+
+    httpServer.listen(0);
+    await gs.shutdown();
+
+    expect(order).toEqual(['cleanup1', 'cleanup2']);
+    httpServer.close();
+  });
+
+  it('a failing cleanup task does not prevent subsequent tasks from running', async () => {
+    const { gs, httpServer } = makeServer({ drainTimeoutMs: 200 });
+    const ran: string[] = [];
+
+    gs.addCleanupTask(async () => { throw new Error('task failed'); });
+    gs.addCleanupTask(() => { ran.push('task2'); });
+
+    httpServer.listen(0);
+    await gs.shutdown(); // must not reject
+
+    expect(ran).toContain('task2');
+    httpServer.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Health check failure during draining
+// ---------------------------------------------------------------------------
+
+describe('Health check failure during draining', () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number) => {
+      return undefined as never;
+    });
+  });
+
+  afterEach(() => {
+    processExitSpy.mockRestore();
+    process.removeAllListeners('SIGTERM');
+    process.removeAllListeners('SIGINT');
+  });
+
+  it('GET /health returns 200 before shutdown', async () => {
+    const { app } = makeServer();
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+  });
+
+  it('GET /health returns 503 immediately after shutdown() is triggered', async () => {
+    const { app, httpServer, gs } = makeServer({ drainTimeoutMs: 5000 });
+    // We don't need a real listening server to test the express handler —
+    // supertest(app) handles the HTTP layer internally. Calling shutdown()
+    // will flip isDraining synchronously before waiting on server.close(),
+    // so a supertest request that arrives after the flag is flipped will
+    // see 503 even without a real port.
+    httpServer.listen(0);
+
+    // Trigger shutdown; do not await — we want to check health mid-drain.
+    const shutdownPromise = gs.shutdown();
+    // isDraining flips synchronously at the top of shutdown().
+    expect(gs.isDraining()).toBe(true);
+
+    // Check the handler directly through supertest (avoids the closed-port race).
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe('draining');
+
+    await shutdownPromise;
+    httpServer.close();
+  });
+
+  it('GET /health 503 body includes inFlightRequests', async () => {
+    const { app, httpServer, gs } = makeServer({ drainTimeoutMs: 5000 });
+    httpServer.listen(0);
+    const addr = httpServer.address() as { port: number };
+
+    // Start a slow request so inFlightRequests will be ≥ 1 when we check.
+    const slowPromise = request(`http://localhost:${addr.port}`)
+      .get('/slow?delay=200')
+      .then((r) => r);
+
+    await new Promise((r) => setTimeout(r, 30)); // wait for it to land
+
+    const shutdownPromise = gs.shutdown();
+    // isDraining is now true; check the handler directly via supertest.
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(503);
+    expect(typeof res.body.inFlightRequests).toBe('number');
+
+    await slowPromise;
+    await shutdownPromise;
+    httpServer.close();
+  });
+
+  it('isDraining() reflects the draining state observable by /health', async () => {
+    const { gs, httpServer } = makeServer({ drainTimeoutMs: 50 });
+    expect(gs.isDraining()).toBe(false);
+
+    httpServer.listen(0);
+    const shutdownPromise = gs.shutdown();
+
+    expect(gs.isDraining()).toBe(true);
+    await shutdownPromise;
+    httpServer.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Timeout protection
+// ---------------------------------------------------------------------------
+
+describe('Timeout protection', () => {
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number) => {
+      return undefined as never;
+    });
+  });
+
+  afterEach(() => {
+    processExitSpy.mockRestore();
+    process.removeAllListeners('SIGTERM');
+    process.removeAllListeners('SIGINT');
+  });
+
+  it('exits with code 1 when drain timeout is exceeded', async () => {
+    // A 30 ms drain timeout with a request that takes 300 ms — timeout fires first.
+    const app = express();
+    const httpServer = createServer(app);
+    const gs = createGracefulShutdown(httpServer, { drainTimeoutMs: 30 });
+    app.use(gs.requestCountMiddleware());
+
+    // Manually bump inFlight without providing a real request so it never
+    // decrements — simulates a request that hangs indefinitely.
+    const middleware = gs.requestCountMiddleware();
+    const fakeReq = {} as any;
+    const fakeRes = {
+      on: (_event: string, _cb: () => void) => {}, // ignore finish/close
+    } as any;
+    middleware(fakeReq, fakeRes, () => {});
+
+    expect(gs.inFlightCount()).toBe(1);
+
+    httpServer.listen(0);
+    await gs.shutdown();
+
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    httpServer.close();
+  });
+
+  it('onShutdownComplete receives timedOut=true on timeout', async () => {
+    const app = express();
+    const httpServer = createServer(app);
+    const onComplete = vi.fn();
+    const gs = createGracefulShutdown(httpServer, {
+      drainTimeoutMs: 30,
+      onShutdownComplete: onComplete,
+    });
+    app.use(gs.requestCountMiddleware());
+
+    // Simulate a stuck request.
+    const middleware = gs.requestCountMiddleware();
+    middleware({} as any, { on: () => {} } as any, () => {});
+
+    httpServer.listen(0);
+    await gs.shutdown();
+
+    expect(onComplete).toHaveBeenCalledWith(true);
+    httpServer.close();
+  });
+
+  it('DEFAULT_DRAIN_TIMEOUT_MS is 30 000', () => {
+    expect(DEFAULT_DRAIN_TIMEOUT_MS).toBe(30_000);
+  });
+
+  it('exits promptly when there are no in-flight requests (no timeout needed)', async () => {
+    const { gs, httpServer } = makeServer({ drainTimeoutMs: 10_000 });
+    httpServer.listen(0);
+
+    const start = Date.now();
+    await gs.shutdown();
+    const elapsed = Date.now() - start;
+
+    // Should exit well before the 10 s timeout (< 500 ms in practice).
+    expect(elapsed).toBeLessThan(500);
+    expect(processExitSpy).toHaveBeenCalledWith(0);
+    httpServer.close();
+  });
+
+  it('does not call shutdown twice when called concurrently', async () => {
+    const { gs, httpServer } = makeServer({ drainTimeoutMs: 50 });
+    httpServer.listen(0);
+
+    const [, ] = await Promise.all([gs.shutdown(), gs.shutdown()]);
+
+    // process.exit should only have been called once.
+    expect(processExitSpy).toHaveBeenCalledTimes(1);
+    httpServer.close();
+  });
+});


### PR DESCRIPTION
Implements graceful shutdown for the QuorumProof API server so that in-flight HTTP requests are never abruptly killed when the process
  receives a stop signal (e.g. from a container orchestrator or Ctrl-C).
  
  Changes
  
  api-server/src/services/gracefulShutdown.ts (new)
  A self-contained createGracefulShutdown service that orchestrates the full shutdown sequence:
  
  - Listens for SIGTERM and SIGINT via process.once (idempotent, safe to call multiple times)
  - Flips an isDraining flag synchronously on signal receipt
  - Calls server.close() to stop accepting new TCP connections
  - Waits for the in-flight request counter to reach zero before exiting
  - Races the drain wait against a configurable timeout (DRAIN_TIMEOUT_MS env var, default 30s)
  - Runs registered async cleanup callbacks sequentially (WS server, event listener, etc.)
  - Exits with code 0 on clean drain, 1 on timeout
  
  api-server/src/index.ts (modified)
  
  - httpServer moved to top-level so the shutdown service can reference it before listen()
  - requestCountMiddleware() installed after body parsers — increments on request arrival, decrements on res.finish/res.close
  - /health returns 503 { status: "draining", inFlightRequests: N } while draining so load-balancers stop routing traffic to the
  instance immediately
  - Cleanup tasks registered for closeWsServer() and criticalEventListener.stop()
  - registerSignalHandlers() called at startup
  
  api-server/tests/gracefulShutdown.test.ts (new)
  20 tests covering all four issue tasks:
  
  - Signal handling — isDraining flip, idempotent handler registration, process.exit(0), callbacks
  - Request draining — counter lifecycle, shutdown waits for in-flight requests, cleanup task ordering, error isolation
  - Health check failure — 200 before shutdown, 503 during drain, inFlightRequests in body
  - Timeout protection — process.exit(1) on timeout, onShutdownComplete(timedOut=true), no double-shutdown
  
  Testing
  
  Tests  20 passed (20)
  
  Notes
  
  - The drain timeout is tunable via DRAIN_TIMEOUT_MS (default 30000) — no code change needed for ops to adjust it per environment.
  - package-lock.json changes from npm install are intentionally excluded from this commit.

closes #1311 