### PR TITLE
Add API documentation auto-generation (OpenAPI 3.1, Swagger UI, ReDoc, TS client)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,11 @@ dashboard/dist/
 frontend/dist/
 api-server/dist/
 
+# Generated TypeScript API client (issue #1309) — regenerate with
+# `npm --prefix api-server run generate:client`. The OpenAPI spec it's
+# generated from (api-server/openapi/openapi.json) IS committed.
+api-server/generated/
+
 # Durable runtime state (GDPR request store, crypto-shredding vault)
 .data/
 api-server/.data/

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Follow the step-by-step guide in `demo/demo-script.md`
 - [Troubleshooting Guide](docs/troubleshooting-guide.md)
 - [Backup System](docs/backup-system.md)
 - [Roadmap](docs/roadmap.md)
+- [REST API Documentation Auto-Generation](api-server/docs/API_DOCUMENTATION.md) — OpenAPI 3.1, Swagger UI, ReDoc, TypeScript client
 
 ## 🎓 Smart Contract API
 

--- a/api-server/docs/API_DOCUMENTATION.md
+++ b/api-server/docs/API_DOCUMENTATION.md
@@ -1,0 +1,120 @@
+# API Documentation Auto-Generation — QuorumProof API Server
+
+Issue #1309. Hand-maintained API docs go stale the moment a route changes.
+This replaces them with an OpenAPI 3.1 document generated from typed
+definitions that live next to the code, served as interactive Swagger UI
+and ReDoc pages, plus a TypeScript client generated from that same
+document.
+
+## Contents
+
+1. [How it's generated](#how-its-generated)
+2. [Endpoints](#endpoints)
+3. [Adding or changing a documented endpoint](#adding-or-changing-a-documented-endpoint)
+4. [TypeScript client library](#typescript-client-library)
+5. [What's intentionally not documented](#whats-intentionally-not-documented)
+
+---
+
+## How it's generated
+
+The spec is assembled by [`src/openapi/index.ts`](../src/openapi/index.ts)
+from:
+
+- **`src/openapi/components.ts`** — shared schemas, security schemes
+  (`bearerAuth` for session JWTs, `apiKeyAuth` for the `x-api-key` header),
+  and tags. A handful of request schemas (`VerifyBatchClaimsRequest`,
+  `NotificationSendRequest`, etc.) are imported directly from
+  [`src/middleware/validate.ts`](../src/middleware/validate.ts) — the
+  actual AJV JSON Schema objects the server validates requests against —
+  so the documented request shape can never drift from what's enforced at
+  runtime.
+- **`src/openapi/paths/*.ts`** — one file per route module (mirroring
+  `src/routes/*.ts`), each exporting a typed `PathsFragment` of operation
+  definitions (summary, parameters, request/response schemas).
+
+`buildOpenApiSpec()` is called fresh on every request to
+`/api-docs/openapi.json`, not read from a static file — the served spec is
+always in sync with what's checked into `src/openapi/`.
+
+Only routers that are actually `app.use()`'d in
+[`src/index.ts`](../src/index.ts) are represented. A few route modules
+(`auth.ts`, `passwordlessAuth.ts`, `bridge.ts`, `graphql.ts`, `reports.ts`,
+`costs.ts`, `verification.ts`, `audit.ts`, `authAudit.ts`) exist in the
+codebase but aren't currently wired into the running app — only exercised
+directly by their own unit tests — so documenting them would describe
+endpoints that 404 in practice. `tests/docs.test.ts` asserts they stay
+excluded; once one of those routers is actually mounted, add its path
+file and delete the corresponding assertion.
+
+## Endpoints
+
+| Path                     | What                                                    |
+|---------------------------|---------------------------------------------------------|
+| `GET /api-docs/openapi.json` | The generated OpenAPI 3.1 document (JSON)             |
+| `GET /api-docs/`             | Swagger UI — interactive, supports "try it out"       |
+| `GET /api-docs/redoc`        | ReDoc — three-pane reference viewer, better for reading |
+
+None of these are gated behind auth — they describe the API's shape, not
+its data.
+
+## Adding or changing a documented endpoint
+
+1. Find (or create) the matching file in `src/openapi/paths/` — e.g. a
+   change to `src/routes/webhooks.ts` belongs in
+   `src/openapi/paths/webhooks.ts`.
+2. Update the operation's parameters / request body / responses. Reuse a
+   `$ref` to an existing `components.schemas` entry where one already
+   fits; add a new one to `src/openapi/components.ts` if not. If the route
+   uses `validate(schemas.xyz)` from `middleware/validate.ts`, reference
+   that schema directly (see `components.ts` for the existing examples)
+   instead of re-describing it by hand.
+3. If you newly mount a previously-unmounted router in `src/index.ts`,
+   add its path file to the `mergePaths(...)` call in
+   `src/openapi/index.ts` and delete the matching assertion in
+   `tests/docs.test.ts`'s "does not document routers that are not
+   actually mounted" test.
+4. Run `npm test -- docs.test.ts` — it checks the spec is valid OpenAPI
+   3.1 shape, every `$ref` resolves, and the mounted-routers-only
+   invariant above.
+5. Run `npm run generate:client` to refresh the on-disk spec snapshot
+   (`openapi/openapi.json`, committed) and the generated TypeScript
+   client (`generated/`, gitignored — regenerated on demand, see below).
+
+## TypeScript client library
+
+`generated/client/` is produced by [`@hey-api/openapi-ts`](https://heyapi.dev/)
+from `openapi/openapi.json`, configured in
+[`openapi-ts.config.ts`](../openapi-ts.config.ts). It's a `fetch`-based
+client: one typed function per operation (`getHealth`, `postApiVerifyBatch`,
+...), plus the request/response TypeScript types.
+
+```bash
+npm run generate:client   # regenerates openapi/openapi.json, then generated/client/
+```
+
+`generated/` is gitignored (like `dist/`) since it's fully derived from
+`openapi/openapi.json`, which *is* committed. Consumers (the `frontend/`
+or `dashboard/` packages, or an external service) run the command above
+after pulling, or point their own `openapi-ts` config at
+`api-server/openapi/openapi.json` / the live `/api-docs/openapi.json`
+endpoint.
+
+Usage once generated:
+
+```ts
+import { client, getHealth, postApiVerifyBatch } from '../api-server/generated/client';
+
+client.setConfig({ baseUrl: 'https://api.quorumproof.io' });
+
+const { data } = await postApiVerifyBatch({
+  body: { items: [{ credential_id: 42, claim_type: 'degree' }] },
+});
+```
+
+## What's intentionally not documented
+
+See [How it's generated](#how-its-generated) above — routers not mounted
+in `src/index.ts` are excluded on purpose. Everything else that's live
+under `/api`, `/auth`, `/health`, `/metrics`, `/rpc`, `/events`, or
+`/ws/metrics` is covered.

--- a/api-server/openapi-ts.config.ts
+++ b/api-server/openapi-ts.config.ts
@@ -1,0 +1,14 @@
+/**
+ * Issue #1309 — Config for `@hey-api/openapi-ts`, which generates the
+ * TypeScript client library in `generated/client` from `openapi/openapi.json`.
+ *
+ * Run `npm run generate:client` (regenerates the spec first, then the
+ * client) after changing anything under `src/openapi/`.
+ */
+import { defineConfig } from '@hey-api/openapi-ts';
+
+export default defineConfig({
+  input: './openapi/openapi.json',
+  output: './generated/client',
+  plugins: ['@hey-api/typescript', '@hey-api/sdk', '@hey-api/client-fetch'],
+});

--- a/api-server/openapi/openapi.json
+++ b/api-server/openapi/openapi.json
@@ -1,0 +1,7170 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "QuorumProof API",
+    "version": "1.0.0",
+    "description": "REST API for the QuorumProof credential issuance, attestation and verification platform, backed by Soroban smart contracts on Stellar.\n\nThis document is generated from typed operation definitions in `api-server/src/openapi/paths/*` — see `docs/API_DOCUMENTATION.md` for how to regenerate it and the TypeScript client after changing a route.",
+    "contact": {
+      "name": "QuorumProof",
+      "url": "https://github.com/QuorumProof/QuorumProof"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000",
+      "description": "Configured server (PUBLIC_APP_BASE_URL)"
+    },
+    {
+      "url": "http://localhost:3000",
+      "description": "Local development"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Health",
+      "description": "Liveness / readiness probes and service status."
+    },
+    {
+      "name": "Verification",
+      "description": "Credential and batch claim verification."
+    },
+    {
+      "name": "Credentials",
+      "description": "Credential search, metadata, revocation list, sharded storage stats."
+    },
+    {
+      "name": "Slices",
+      "description": "Credential slice (batch) lookups."
+    },
+    {
+      "name": "Attestors",
+      "description": "Attestor directory, availability and reputation."
+    },
+    {
+      "name": "Issuer",
+      "description": "Per-issuer metrics and analytics."
+    },
+    {
+      "name": "Analytics",
+      "description": "Platform-wide event ingestion and derived metrics."
+    },
+    {
+      "name": "Dashboard",
+      "description": "Credential-holder dashboard (my credentials, disputes, access log)."
+    },
+    {
+      "name": "Notifications",
+      "description": "Notification preferences and delivery."
+    },
+    {
+      "name": "Webhooks",
+      "description": "Outbound event webhook subscriptions and delivery logs."
+    },
+    {
+      "name": "GDPR",
+      "description": "Data subject access / erasure requests, consent records."
+    },
+    {
+      "name": "Consent",
+      "description": "Per-credential verifier consent grants."
+    },
+    {
+      "name": "Share Links",
+      "description": "Time-limited shareable credential links."
+    },
+    {
+      "name": "API Keys",
+      "description": "API key issuance, rotation and usage."
+    },
+    {
+      "name": "OAuth2",
+      "description": "OAuth2 / OIDC identity provider linking."
+    },
+    {
+      "name": "Auth",
+      "description": "Session login, MFA, and passwordless / WebAuthn auth."
+    },
+    {
+      "name": "Recovery",
+      "description": "Account recovery via OTP."
+    },
+    {
+      "name": "Privilege Escalation",
+      "description": "Step-up MFA approval workflow for privileged actions."
+    },
+    {
+      "name": "Audit",
+      "description": "Immutable audit log entries and batch notarization."
+    },
+    {
+      "name": "Reports",
+      "description": "Compliance, cost, usage and expiry-forecast reports."
+    },
+    {
+      "name": "Costs",
+      "description": "Infrastructure cost reporting and optimization suggestions."
+    },
+    {
+      "name": "Bridge",
+      "description": "Cross-chain credential anchoring and light-client sync."
+    },
+    {
+      "name": "Tracing",
+      "description": "Distributed trace lookup."
+    },
+    {
+      "name": "GraphQL",
+      "description": "GraphQL endpoint (alternative to the REST surface)."
+    },
+    {
+      "name": "Metrics",
+      "description": "Prometheus-format and JSON operational metrics."
+    }
+  ],
+  "paths": {
+    "/health": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Overall health status",
+        "description": "200 when healthy or degraded, 503 when unhealthy.",
+        "responses": {
+          "200": {
+            "description": "Healthy or degraded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthStatus"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Unhealthy.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health/ready": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Readiness probe",
+        "description": "Returns 503 while dependencies (DB, RPC, etc.) are not yet ready to serve traffic.",
+        "responses": {
+          "200": {
+            "description": "Ready."
+          },
+          "503": {
+            "description": "Not ready."
+          }
+        }
+      }
+    },
+    "/health/live": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Liveness probe",
+        "description": "Always 200 while the process is running; used by orchestrators to detect a hung process.",
+        "responses": {
+          "200": {
+            "description": "Alive."
+          }
+        }
+      }
+    },
+    "/api/verify/batch": {
+      "post": {
+        "tags": [
+          "Verification"
+        ],
+        "summary": "Batch-verify credential/claim pairs",
+        "description": "Verifies many `(credential_id, claim_type)` pairs in one round trip. Duplicate pairs are deduplicated and resolved once; results are fanned back out in input order.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerifyBatchClaimsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Per-item verification results plus a summary.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchVerificationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/verify/{id}": {
+      "get": {
+        "tags": [
+          "Verification"
+        ],
+        "summary": "Look up the current verification status of a single credential",
+        "description": "Canonical verification endpoint that a credential-export QR code links to. When `claim_type` is supplied, also returns a verification proof for that claim.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "claim_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "When present, also returns a signed verification proof for this claim."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current credential status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "credential_id": {
+                      "type": "integer"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "verified",
+                        "failed",
+                        "not_found",
+                        "revoked",
+                        "expired",
+                        "error"
+                      ]
+                    },
+                    "checked_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "claim_type": {
+                      "type": "string"
+                    },
+                    "proof": {
+                      "$ref": "#/components/schemas/BatchVerificationResult/properties/proof"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid credential id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/slices": {
+      "get": {
+        "tags": [
+          "Slices"
+        ],
+        "summary": "List quorum slices (cursor-paginated)",
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Opaque base64 cursor from a previous response."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of slices.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Slice"
+                      }
+                    },
+                    "pagination": {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid cursor.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/slices/{id}": {
+      "get": {
+        "tags": [
+          "Slices"
+        ],
+        "summary": "Get a quorum slice by id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The slice.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Slice"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Slice not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/api-keys": {
+      "post": {
+        "tags": [
+          "API Keys"
+        ],
+        "summary": "Generate a new API key",
+        "description": "The full secret is returned exactly once, in this response. Callers must persist it — it cannot be retrieved again (only rotated).",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyCreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing name.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authorization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "API Keys"
+        ],
+        "summary": "List the caller's active API keys",
+        "responses": {
+          "200": {
+            "description": "Keys (secrets never included).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "lastUsedAt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "format": "date-time"
+                          },
+                          "active": {
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authorization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/api-keys/{id}": {
+      "get": {
+        "tags": [
+          "API Keys"
+        ],
+        "summary": "Get a single API key",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "lastUsedAt": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time"
+                    },
+                    "active": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "API Keys"
+        ],
+        "summary": "Revoke an API key",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Revoked."
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/api-keys/{id}/rotate": {
+      "post": {
+        "tags": [
+          "API Keys"
+        ],
+        "summary": "Rotate an API key",
+        "description": "Issues a new secret; the old key keeps working until `gracePeriodMs` elapses.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "gracePeriodMs": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "New key issued.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyCreateResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Key already inactive.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/api-keys/{id}/usage": {
+      "get": {
+        "tags": [
+          "API Keys"
+        ],
+        "summary": "Get usage history for a key",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Usage entries.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/api-keys/stats/overview": {
+      "get": {
+        "tags": [
+          "API Keys"
+        ],
+        "summary": "Get the caller's key statistics",
+        "responses": {
+          "200": {
+            "description": "Aggregate stats.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authorization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/api-keys": {
+      "post": {
+        "tags": [
+          "API Keys"
+        ],
+        "summary": "Generate a new API key",
+        "description": "The full secret is returned exactly once, in this response. Callers must persist it — it cannot be retrieved again (only rotated).",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyCreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing name.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authorization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "API Keys"
+        ],
+        "summary": "List the caller's active API keys",
+        "responses": {
+          "200": {
+            "description": "Keys (secrets never included).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "lastUsedAt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "format": "date-time"
+                          },
+                          "active": {
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authorization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/api-keys/{id}": {
+      "get": {
+        "tags": [
+          "API Keys"
+        ],
+        "summary": "Get a single API key",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "lastUsedAt": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time"
+                    },
+                    "active": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "API Keys"
+        ],
+        "summary": "Revoke an API key",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Revoked."
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/api-keys/{id}/rotate": {
+      "post": {
+        "tags": [
+          "API Keys"
+        ],
+        "summary": "Rotate an API key",
+        "description": "Issues a new secret; the old key keeps working until `gracePeriodMs` elapses.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "gracePeriodMs": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "New key issued.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyCreateResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Key already inactive.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/api-keys/{id}/usage": {
+      "get": {
+        "tags": [
+          "API Keys"
+        ],
+        "summary": "Get usage history for a key",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Usage entries.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/api-keys/stats/overview": {
+      "get": {
+        "tags": [
+          "API Keys"
+        ],
+        "summary": "Get the caller's key statistics",
+        "responses": {
+          "200": {
+            "description": "Aggregate stats.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid authorization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/webhooks": {
+      "post": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Register a webhook",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "events": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "credential_issued",
+                        "credential_attested",
+                        "credential_revoked"
+                      ]
+                    },
+                    "minItems": 1
+                  },
+                  "secret": {
+                    "type": "string",
+                    "description": "Used to HMAC-sign delivered payloads."
+                  }
+                },
+                "required": [
+                  "url",
+                  "events"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Registered.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Webhook"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid url or events.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "List registered webhooks",
+        "responses": {
+          "200": {
+            "description": "Webhooks.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Webhook"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/webhooks/deliveries/log": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Get the webhook delivery log",
+        "responses": {
+          "200": {
+            "description": "Delivery attempts.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/webhooks/dead-letters": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "List deliveries that exhausted retries",
+        "responses": {
+          "200": {
+            "description": "Dead-lettered deliveries.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/webhooks/dead-letters/{id}/replay": {
+      "post": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Re-queue a dead-lettered delivery",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Re-queued.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/webhooks/{id}": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Get a webhook",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The webhook.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Webhook"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Remove a webhook",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Removed."
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/gdpr/personal-data": {
+      "post": {
+        "tags": [
+          "GDPR"
+        ],
+        "summary": "Store a credential's personal data (encrypted, off-chain)",
+        "description": "Encrypts `personalData` with a per-credential key and returns a sha256 commitment the issuer should anchor on-chain. See docs/crypto-shredding-architecture.md.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "credentialId": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "subject": {
+                    "type": "string",
+                    "description": "Stellar address; must match the on-chain credential subject."
+                  },
+                  "personalData": {}
+                },
+                "required": [
+                  "credentialId",
+                  "subject",
+                  "personalData"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Stored.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input or subject mismatch.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Credential not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Key already destroyed (erased).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/gdpr/personal-data/{credentialId}/status": {
+      "get": {
+        "tags": [
+          "GDPR"
+        ],
+        "summary": "Get vault status for a credential (no decryption)",
+        "parameters": [
+          {
+            "name": "credentialId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid credentialId.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/gdpr/personal-data/{credentialId}": {
+      "get": {
+        "tags": [
+          "GDPR"
+        ],
+        "summary": "Retrieve (decrypted) personal data for a credential",
+        "parameters": [
+          {
+            "name": "credentialId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Decrypted record.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid credentialId.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No personal data stored for this credential.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "The decryption key has been erased (right-to-erasure completed).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/gdpr/request": {
+      "post": {
+        "tags": [
+          "GDPR"
+        ],
+        "summary": "Submit a right-to-erasure request",
+        "description": "Completes immediately (key destroyed) if the credential has no current attestors; otherwise waits for every current attestor to POST /api/gdpr/consent.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "credentialId": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                },
+                "required": [
+                  "credentialId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Request created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GdprRequest"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid credentialId.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Credential not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/gdpr/request/{requestId}": {
+      "get": {
+        "tags": [
+          "GDPR"
+        ],
+        "summary": "Get a GDPR request by id",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GdprRequest"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/gdpr/consent": {
+      "post": {
+        "tags": [
+          "GDPR"
+        ],
+        "summary": "Attestor consent to a pending erasure request",
+        "description": "The signer must be a current on-chain attestor for the credential and submit an ed25519 signature over the canonical consent message. When the last required consent lands, the credential's decryption key is destroyed.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "requestId": {
+                    "type": "string"
+                  },
+                  "attestorAddress": {
+                    "type": "string"
+                  },
+                  "signature": {
+                    "type": "string",
+                    "description": "Hex-encoded ed25519 signature."
+                  }
+                },
+                "required": [
+                  "requestId",
+                  "attestorAddress",
+                  "signature"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Consent recorded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GdprRequest"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request, or request not pending.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid attestor signature.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "attestorAddress is not a current attestor for this credential.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/oauth2/{provider}/authorize": {
+      "get": {
+        "tags": [
+          "OAuth2"
+        ],
+        "summary": "Build the provider's consent-screen URL",
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "google",
+                "microsoft",
+                "github"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Authorization URL and state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "provider": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "state": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Unsupported provider.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/oauth2/callback": {
+      "post": {
+        "tags": [
+          "OAuth2"
+        ],
+        "summary": "Exchange an auth code and link the identity to a Stellar address",
+        "description": "`signature` must be an ed25519 signature (by `stellarAddress`) over the canonical link message, proving control of the address before it is linked to the OAuth2 identity.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "provider": {
+                    "type": "string",
+                    "enum": [
+                      "google",
+                      "microsoft",
+                      "github"
+                    ]
+                  },
+                  "code": {
+                    "type": "string"
+                  },
+                  "stellarAddress": {
+                    "type": "string"
+                  },
+                  "signature": {
+                    "type": "string",
+                    "description": "Hex-encoded 64-byte ed25519 signature."
+                  }
+                },
+                "required": [
+                  "provider",
+                  "code",
+                  "stellarAddress",
+                  "signature"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Identity linked.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing/invalid field.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "OAuth2 exchange failed, or signature invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/oauth2/identities/{stellarAddress}": {
+      "get": {
+        "tags": [
+          "OAuth2"
+        ],
+        "summary": "List OAuth2 identities linked to a Stellar address",
+        "parameters": [
+          {
+            "name": "stellarAddress",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Linked identities.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/attestors": {
+      "get": {
+        "tags": [
+          "Attestors"
+        ],
+        "summary": "List / filter the attestor directory",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Exact match on attestor type."
+          },
+          {
+            "name": "region",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Case-insensitive exact match."
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Substring search across name, region, description."
+          },
+          {
+            "name": "active",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Matching attestors.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total": {
+                      "type": "integer"
+                    },
+                    "attestors": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AttestorStatus"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/attestors/{id}": {
+      "get": {
+        "tags": [
+          "Attestors"
+        ],
+        "summary": "Get a single attestor record with credential stats",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The attestor.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttestorStatus"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown attestor id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/attestors/{id}/status": {
+      "get": {
+        "tags": [
+          "Attestors"
+        ],
+        "summary": "Get live availability metrics for an attestor",
+        "description": "uptime_ratio and avg_response_ms are derived from the last 24h of recorded pings.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Availability status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uptime_ratio": {
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "avg_response_ms": {
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "active_credential_count": {
+                      "type": "integer"
+                    },
+                    "last_seen": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time"
+                    },
+                    "availability": {
+                      "type": "string",
+                      "enum": [
+                        "excellent",
+                        "good",
+                        "degraded",
+                        "offline",
+                        "unknown"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown attestor id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/attestors/{id}/status/ping": {
+      "post": {
+        "tags": [
+          "Attestors"
+        ],
+        "summary": "Record a heartbeat ping result for an attestor",
+        "description": "Called by the monitoring agent or the attestor node itself after each health-check probe.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "type": "boolean"
+                  },
+                  "response_ms": {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                },
+                "required": [
+                  "ok",
+                  "response_ms"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Recorded."
+          },
+          "400": {
+            "description": "Invalid body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown attestor id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/attestor/pending": {
+      "get": {
+        "tags": [
+          "Attestors"
+        ],
+        "summary": "Get the pending attestation queue for an address",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pending queue.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "address": {
+                      "type": "string"
+                    },
+                    "items": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing address.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/attestor/reputation/{address}": {
+      "get": {
+        "tags": [
+          "Attestors"
+        ],
+        "summary": "Get on-chain + derived reputation stats for an attestor address",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Reputation snapshot (30-day window).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "address": {
+                      "type": "string"
+                    },
+                    "attestation_count_score": {
+                      "type": "number"
+                    },
+                    "reputation": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": true
+                    },
+                    "attestation_count": {
+                      "type": "integer"
+                    },
+                    "total_activity": {
+                      "type": "integer"
+                    },
+                    "success_rate": {
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "period_days": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/attestor/batch-attest": {
+      "post": {
+        "tags": [
+          "Attestors"
+        ],
+        "summary": "Attest a batch of credentials against a slice",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "attestor": {
+                    "type": "string"
+                  },
+                  "credential_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "maxItems": 50
+                  },
+                  "slice_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "attestor",
+                  "credential_ids",
+                  "slice_id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Per-credential attestation results.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total": {
+                      "type": "integer"
+                    },
+                    "succeeded": {
+                      "type": "integer"
+                    },
+                    "failed": {
+                      "type": "integer"
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "credential_id": {
+                            "type": "string"
+                          },
+                          "success": {
+                            "type": "boolean"
+                          },
+                          "error": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing/invalid fields, or batch too large.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notifications/preferences": {
+      "put": {
+        "tags": [
+          "Notifications"
+        ],
+        "summary": "Set notification preferences for an address",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationPreferencesRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Saved.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "email/phone required for the enabled channel, or invalid body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notifications/preferences/{address}": {
+      "get": {
+        "tags": [
+          "Notifications"
+        ],
+        "summary": "Get notification preferences for an address",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Preferences.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No preferences found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notifications/history": {
+      "get": {
+        "tags": [
+          "Notifications"
+        ],
+        "summary": "Get notification delivery history",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "History entries.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notifications/send": {
+      "post": {
+        "tags": [
+          "Notifications"
+        ],
+        "summary": "Send (dispatch) a notification and broadcast over WebSocket",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationSendRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Dispatched.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "ws_recipients": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/issuer/{address}/metrics": {
+      "get": {
+        "tags": [
+          "Issuer"
+        ],
+        "summary": "Get issuance metrics for an issuer over a period",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "period_days",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 365,
+              "default": 30
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Metrics.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid period_days.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/analytics/events": {
+      "post": {
+        "tags": [
+          "Analytics"
+        ],
+        "summary": "Record a credential lifecycle event",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnalyticsEventRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Recorded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "event_id": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Analytics"
+        ],
+        "summary": "Query the raw analytics event log",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "issued",
+                "attested",
+                "revoked",
+                "suspended",
+                "verified"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Matching events.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/analytics/metrics": {
+      "get": {
+        "tags": [
+          "Analytics"
+        ],
+        "summary": "Get daily issued/attested/revoked metrics for a date range",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Daily metrics and totals.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid date range.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/analytics/anomalies": {
+      "get": {
+        "tags": [
+          "Analytics"
+        ],
+        "summary": "Detect anomalous issuance days in a date range",
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "threshold",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Anomalous dates.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/analytics/issuer/{address}": {
+      "get": {
+        "tags": [
+          "Analytics"
+        ],
+        "summary": "Get issuer-scoped metrics",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "period_days",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 365,
+              "default": 30
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Issuer metrics.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid period_days.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/analytics/summary": {
+      "get": {
+        "tags": [
+          "Analytics"
+        ],
+        "summary": "Get a platform-wide analytics summary",
+        "responses": {
+          "200": {
+            "description": "Summary.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/analytics/health": {
+      "get": {
+        "tags": [
+          "Analytics"
+        ],
+        "summary": "Analytics subsystem health check",
+        "responses": {
+          "200": {
+            "description": "OK.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "service": {
+                      "type": "string"
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/analytics/credentials": {
+      "get": {
+        "tags": [
+          "Analytics"
+        ],
+        "summary": "Get per-issuer credential issuance breakdown",
+        "parameters": [
+          {
+            "name": "issuer",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "range",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "7d",
+                "30d",
+                "90d"
+              ],
+              "default": "30d"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Issuance totals, breakdown by type, expiry distribution.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing issuer or invalid range.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/analytics/verifications": {
+      "get": {
+        "tags": [
+          "Analytics"
+        ],
+        "summary": "Get verification counts by claim type and verifier",
+        "parameters": [
+          {
+            "name": "range",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "7d",
+                "30d",
+                "90d"
+              ],
+              "default": "30d"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Verification distribution.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid range.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/analytics/disputes": {
+      "get": {
+        "tags": [
+          "Analytics"
+        ],
+        "summary": "Get dispute rate and resolution stats",
+        "parameters": [
+          {
+            "name": "issuer",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "range",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "7d",
+                "30d",
+                "90d"
+              ],
+              "default": "30d"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dispute stats.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid range.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/me/credentials": {
+      "get": {
+        "tags": [
+          "Dashboard"
+        ],
+        "summary": "List the authenticated user's credentials",
+        "responses": {
+          "200": {
+            "description": "Credential summary.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "credentials": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    },
+                    "active_count": {
+                      "type": "integer"
+                    },
+                    "revoked_count": {
+                      "type": "integer"
+                    },
+                    "suspended_count": {
+                      "type": "integer"
+                    },
+                    "expiring_soon": {
+                      "type": "integer",
+                      "description": "Active, non-revoked credentials expiring within 30 days."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No authenticated user address on the request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/me/credentials/{id}": {
+      "get": {
+        "tags": [
+          "Dashboard"
+        ],
+        "summary": "Get full detail for one of the authenticated user’s credentials",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "include_history",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "include_disputes",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Credential detail with attestations, and optionally amendment/dispute history.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No authenticated user address on the request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Credential does not belong to the authenticated user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/me/disputes": {
+      "get": {
+        "tags": [
+          "Dashboard"
+        ],
+        "summary": "List disputes against the user's credentials",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "resolved",
+                "rejected"
+              ]
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "created_at",
+                "status"
+              ],
+              "default": "created_at"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Disputes.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "disputes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    },
+                    "pending_count": {
+                      "type": "integer"
+                    },
+                    "resolved_count": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No authenticated user address on the request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Dashboard"
+        ],
+        "summary": "Create a dispute against a credential",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "credential_id": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "evidence_hash": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "credential_id",
+                  "reason"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing credential_id or reason.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No authenticated user address on the request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/me/access-log": {
+      "get": {
+        "tags": [
+          "Dashboard"
+        ],
+        "summary": "Get the access/audit log for the user's credentials",
+        "parameters": [
+          {
+            "name": "credential_id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500,
+              "default": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Access log entries.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "access_logs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No authenticated user address on the request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Dashboard"
+        ],
+        "summary": "Log a credential access event",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "credential_id": {
+                    "type": "string"
+                  },
+                  "accessed_by": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "duration_seconds": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "credential_id",
+                  "accessed_by",
+                  "reason"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Logged.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required fields.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/me/summary": {
+      "get": {
+        "tags": [
+          "Dashboard"
+        ],
+        "summary": "Get a quick dashboard summary",
+        "responses": {
+          "200": {
+            "description": "Summary counts.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total_credentials": {
+                      "type": "integer"
+                    },
+                    "active_credentials": {
+                      "type": "integer"
+                    },
+                    "pending_disputes": {
+                      "type": "integer"
+                    },
+                    "credentials_expiring_30_days": {
+                      "type": "integer"
+                    },
+                    "last_access_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No authenticated user address on the request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/search": {
+      "get": {
+        "tags": [
+          "Credentials"
+        ],
+        "summary": "Advanced credential search",
+        "description": "Full-text search, faceting, ranking, deduplication and cursor-based pagination. Also supports per-field operators (`attestation_count[gte]=2`, `issuer[regex]=BANK.*`) and nested boolean combinations via `filter[and]`/`filter[or]`/`filter[not]`.",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Full-text search query."
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "style": "form",
+            "explode": true,
+            "description": "Credential type; repeatable."
+          },
+          {
+            "name": "issuer",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true
+          },
+          {
+            "name": "issuer_type",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true
+          },
+          {
+            "name": "subject",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "active",
+                "revoked",
+                "suspended"
+              ]
+            }
+          },
+          {
+            "name": "jurisdiction",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true,
+            "description": "ISO 3166 or supranational code; hierarchical (US matches US-CA, EU matches EU members)."
+          },
+          {
+            "name": "attestation_count_min",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "attestation_count_max",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "created_after",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "created_before",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "expires_after",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "expires_before",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "deduplicate",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Collapse same subject+issuer credentials to the highest version."
+          },
+          {
+            "name": "include_versions",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "include_score",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated: id|type|relevance|created_at|updated_at|recency|reputation."
+          },
+          {
+            "name": "sort_order",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          },
+          {
+            "name": "facets",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated facet names."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Search results with facets and pagination.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Credential"
+                      }
+                    },
+                    "facets": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "pagination": {
+                      "$ref": "#/components/schemas/Pagination"
+                    },
+                    "query_info": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "index_version": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid limit, sort_by, or sort_order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/search/rebuild-index-async": {
+      "post": {
+        "tags": [
+          "Credentials"
+        ],
+        "summary": "Kick off a background full re-index from chain",
+        "description": "The current index stays live and queryable for the whole rebuild; swapped in atomically on completion.",
+        "responses": {
+          "202": {
+            "description": "Rebuild started.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "rebuild_id": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "estimated_duration_ms": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "A rebuild is already in progress.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/search/rebuild-status/{id}": {
+      "get": {
+        "tags": [
+          "Credentials"
+        ],
+        "summary": "Get the status of a background re-index job",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/search/rebuild-history": {
+      "get": {
+        "tags": [
+          "Credentials"
+        ],
+        "summary": "List past re-index jobs",
+        "responses": {
+          "200": {
+            "description": "Rebuild history.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "rebuilds": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/verify-batch": {
+      "post": {
+        "tags": [
+          "Credentials"
+        ],
+        "summary": "Batch-check attestation status against a slice",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "credential_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer",
+                      "minimum": 1
+                    },
+                    "minItems": 1,
+                    "maxItems": 50
+                  },
+                  "slice_id": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                },
+                "required": [
+                  "credential_ids",
+                  "slice_id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Per-credential attestation results.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "credential_id": {
+                            "type": "integer"
+                          },
+                          "attested": {
+                            "type": "boolean"
+                          },
+                          "error": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid credential_ids or slice_id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/search/refresh-index": {
+      "post": {
+        "tags": [
+          "Credentials"
+        ],
+        "summary": "Force a synchronous refresh of the search index from chain",
+        "responses": {
+          "200": {
+            "description": "Refreshed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "index_size": {
+                      "type": "integer"
+                    },
+                    "cache_size": {
+                      "type": "integer"
+                    },
+                    "last_indexed": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/search/index-stats": {
+      "get": {
+        "tags": [
+          "Credentials"
+        ],
+        "summary": "Get search index and metadata-hash cache statistics",
+        "responses": {
+          "200": {
+            "description": "Stats.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/crl": {
+      "get": {
+        "tags": [
+          "Credentials"
+        ],
+        "summary": "Export the revocation list (CRL)",
+        "description": "X.509-compatible JSON structure; `format=pem` wraps it as base64 in a PEM envelope.",
+        "parameters": [
+          {
+            "name": "issuer",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "QuorumProof"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "json",
+                "pem"
+              ],
+              "default": "json"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The CRL.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "version": {
+                      "type": "integer"
+                    },
+                    "issuer": {
+                      "type": "string"
+                    },
+                    "thisUpdate": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "nextUpdate": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "revokedCertificates": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "totalRevoked": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "description": "PEM-encoded CRL when format=pem."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid format.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/shards/stats": {
+      "get": {
+        "tags": [
+          "Credentials"
+        ],
+        "summary": "Get sharded-storage distribution statistics",
+        "responses": {
+          "200": {
+            "description": "Shard stats.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "shard_count": {
+                      "type": "integer"
+                    },
+                    "total_credentials": {
+                      "type": "integer"
+                    },
+                    "shards": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/shards/by-subject": {
+      "get": {
+        "tags": [
+          "Credentials"
+        ],
+        "summary": "Fetch a subject's credentials directly from its shard",
+        "parameters": [
+          {
+            "name": "subject",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Credentials in the subject shard.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "subject": {
+                      "type": "string"
+                    },
+                    "shard_index": {
+                      "type": "integer"
+                    },
+                    "count": {
+                      "type": "integer"
+                    },
+                    "credentials": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Credential"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing subject.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/{id}/metadata-hash": {
+      "get": {
+        "tags": [
+          "Credentials"
+        ],
+        "summary": "Get the metadata hash for a credential (cached)",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Metadata hash.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "credential_id": {
+                      "type": "integer"
+                    },
+                    "metadata_hash": {
+                      "type": "string"
+                    },
+                    "cached": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid credential id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Credential not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/{id}/export": {
+      "get": {
+        "tags": [
+          "Credentials"
+        ],
+        "summary": "Export a credential as JSON, PDF, or a verification QR code",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "json",
+                "pdf",
+                "qrcode"
+              ],
+              "default": "json"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The export. Content-Type depends on `format`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "credential": {
+                      "$ref": "#/components/schemas/Credential"
+                    },
+                    "verification_url": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "exported_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              },
+              "application/pdf": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid credential id or format.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Credential not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/{id}/consent/verifiers": {
+      "get": {
+        "tags": [
+          "Consent"
+        ],
+        "summary": "List verifiers who have accessed a credential",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "holder",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Stellar address of the credential holder."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Verifiers.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "credential_id": {
+                      "type": "integer"
+                    },
+                    "verifiers": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid id or missing holder.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not the credential holder.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Credential not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/{id}/consent/access-log": {
+      "get": {
+        "tags": [
+          "Consent"
+        ],
+        "summary": "Get the full verifier access log for a credential",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "holder",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "verifier",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "access_type",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "enum": [
+                1,
+                2,
+                3
+              ]
+            },
+            "description": "1=share_link, 2=delegation, 3=proof_request."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Access log entries.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "credential_id": {
+                      "type": "integer"
+                    },
+                    "entries": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid id or missing holder.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not the credential holder.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Credential not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/{id}/consent/grants": {
+      "post": {
+        "tags": [
+          "Consent"
+        ],
+        "summary": "Grant a verifier consent to access a credential",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "holder": {
+                    "type": "string"
+                  },
+                  "verifier": {
+                    "type": "string"
+                  },
+                  "expires_at": {
+                    "type": "integer",
+                    "description": "Unix timestamp; 0 = no expiry.",
+                    "default": 0
+                  }
+                },
+                "required": [
+                  "holder",
+                  "verifier"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Granted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing fields or invalid expires_at.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not the credential holder.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Credential not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/{id}/consent/grants/{verifier}": {
+      "get": {
+        "tags": [
+          "Consent"
+        ],
+        "summary": "Get a specific consent grant",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "verifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The grant.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No consent grant found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Consent"
+        ],
+        "summary": "Revoke a verifier consent grant",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "verifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "holder": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "holder"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Revoked.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing holder.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not the credential holder.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Credential not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/{id}/consent/grants/{verifier}/status": {
+      "get": {
+        "tags": [
+          "Consent"
+        ],
+        "summary": "Check whether a consent grant is currently active",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "verifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "credential_id": {
+                      "type": "integer"
+                    },
+                    "verifier": {
+                      "type": "string"
+                    },
+                    "consent_active": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/{id}/consent/access": {
+      "post": {
+        "tags": [
+          "Consent"
+        ],
+        "summary": "Record a verifier access event",
+        "description": "Used by internal services / the bridge relay to log access.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "holder": {
+                    "type": "string"
+                  },
+                  "verifier": {
+                    "type": "string"
+                  },
+                  "access_type": {
+                    "type": "integer",
+                    "enum": [
+                      1,
+                      2,
+                      3
+                    ]
+                  }
+                },
+                "required": [
+                  "holder",
+                  "verifier",
+                  "access_type"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Recorded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing/invalid fields.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not the credential holder.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Credential not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/{id}/share": {
+      "post": {
+        "tags": [
+          "Share Links"
+        ],
+        "summary": "Create a time-limited share link for a credential",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "subject": {
+                    "type": "string",
+                    "description": "Stellar address of the credential holder."
+                  },
+                  "expiry_hours": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 8760
+                  },
+                  "permission": {
+                    "type": "string",
+                    "enum": [
+                      "view_only",
+                      "download"
+                    ]
+                  },
+                  "password": {
+                    "type": "string",
+                    "description": "Optional; omit for a public link."
+                  }
+                },
+                "required": [
+                  "subject",
+                  "expiry_hours",
+                  "permission"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string"
+                    },
+                    "expires_at": {
+                      "type": "integer"
+                    },
+                    "permission": {
+                      "type": "string"
+                    },
+                    "password_protected": {
+                      "type": "boolean"
+                    },
+                    "credential_id": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing/invalid fields.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Only the credential holder can create share links.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Credential not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/share/validate": {
+      "post": {
+        "tags": [
+          "Share Links"
+        ],
+        "summary": "Validate / redeem a share token",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token": {
+                    "type": "string",
+                    "description": "32-char hex."
+                  },
+                  "password": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "token"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Link metadata.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Invalid or missing password.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Link expired, revoked, or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credentials/share/{token}": {
+      "get": {
+        "tags": [
+          "Share Links"
+        ],
+        "summary": "Inspect share-link metadata (no access enforcement)",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Link metadata (password hash redacted).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Share Links"
+        ],
+        "summary": "Revoke a share link early",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "subject": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "subject"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Revoked.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing subject or malformed token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Only the link creator can revoke it.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/recovery/request": {
+      "post": {
+        "tags": [
+          "Recovery"
+        ],
+        "summary": "Start a wallet-recovery request",
+        "description": "Sends an OTP to the contact channel; the request then awaits identity verification and attestor approval.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "credentialId": {
+                    "type": "string"
+                  },
+                  "lostWallet": {
+                    "type": "string",
+                    "pattern": "^G[A-Z2-7]{55}$"
+                  },
+                  "newWallet": {
+                    "type": "string",
+                    "pattern": "^G[A-Z2-7]{55}$"
+                  },
+                  "contactType": {
+                    "type": "string",
+                    "enum": [
+                      "email",
+                      "phone"
+                    ]
+                  },
+                  "contactValue": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "credentialId",
+                  "lostWallet",
+                  "newWallet",
+                  "contactType",
+                  "contactValue"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Request created; OTP sent.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid field.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/recovery/verify-otp": {
+      "post": {
+        "tags": [
+          "Recovery"
+        ],
+        "summary": "Verify the OTP for a recovery request",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "requestId": {
+                    "type": "string"
+                  },
+                  "code": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "requestId",
+                  "code"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Verified; now pending attestor approval.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid code.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Recovery request not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Request is not awaiting verification.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Code expired.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many attempts.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/recovery/resend-otp": {
+      "post": {
+        "tags": [
+          "Recovery"
+        ],
+        "summary": "Resend the OTP for a pending recovery request",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "requestId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "requestId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Resent.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid field.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Recovery request not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Request is not awaiting verification.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/recovery/status/{requestId}": {
+      "get": {
+        "tags": [
+          "Recovery"
+        ],
+        "summary": "Get the status of a recovery request",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request status (contact value redacted).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Recovery request not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/recovery/pending": {
+      "get": {
+        "tags": [
+          "Recovery"
+        ],
+        "summary": "List recovery requests pending attestor approval",
+        "parameters": [
+          {
+            "name": "attestor",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pending requests.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "attestor": {
+                      "type": "string"
+                    },
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid field.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/recovery/approve": {
+      "post": {
+        "tags": [
+          "Recovery"
+        ],
+        "summary": "Approve a pending recovery request",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "requestId": {
+                    "type": "string"
+                  },
+                  "attestor": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "requestId",
+                  "attestor"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Approved; re-issuance initiated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid field.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Recovery request not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Request is not in pending_approval status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/recovery/reject": {
+      "post": {
+        "tags": [
+          "Recovery"
+        ],
+        "summary": "Reject a pending recovery request",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "requestId": {
+                    "type": "string"
+                  },
+                  "attestor": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "requestId",
+                  "attestor"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid field.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Recovery request not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Request is not in pending_approval status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/privilege-escalation/mfa-challenge": {
+      "post": {
+        "tags": [
+          "Privilege Escalation"
+        ],
+        "summary": "Request an MFA challenge for a privileged action",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "userId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Challenge issued.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "userId": {
+                      "type": "string"
+                    },
+                    "expiresAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing userId.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/privilege-escalation/verify-mfa": {
+      "post": {
+        "tags": [
+          "Privilege Escalation"
+        ],
+        "summary": "Verify an MFA code for a pending escalation challenge",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  },
+                  "code": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "userId",
+                  "code"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Verified.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "verified": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing userId or code.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or expired MFA code.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/privilege-escalation/request": {
+      "post": {
+        "tags": [
+          "Privilege Escalation"
+        ],
+        "summary": "Submit a privilege change request",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  },
+                  "newRole": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "approvers": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "userId",
+                  "newRole"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Submitted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing userId or newRole.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/privilege-escalation/approve": {
+      "post": {
+        "tags": [
+          "Privilege Escalation"
+        ],
+        "summary": "Approve a pending privilege change request",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "requestId": {
+                    "type": "string"
+                  },
+                  "approverId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "requestId",
+                  "approverId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Approved.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "approved": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing requestId or approverId.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Request not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/privilege-escalation/reject": {
+      "post": {
+        "tags": [
+          "Privilege Escalation"
+        ],
+        "summary": "Reject a pending privilege change request",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "requestId": {
+                    "type": "string"
+                  },
+                  "approverId": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "requestId",
+                  "approverId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "rejected": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing requestId or approverId.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Request not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/privilege-escalation/audit-log": {
+      "get": {
+        "tags": [
+          "Privilege Escalation"
+        ],
+        "summary": "Get the privilege-escalation audit log",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Log entries.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total": {
+                      "type": "integer"
+                    },
+                    "logs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/privilege-escalation/pending": {
+      "get": {
+        "tags": [
+          "Privilege Escalation"
+        ],
+        "summary": "List pending privilege change approvals",
+        "responses": {
+          "200": {
+            "description": "Pending requests.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total": {
+                      "type": "integer"
+                    },
+                    "requests": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tracing/trace/{traceId}": {
+      "get": {
+        "tags": [
+          "Tracing"
+        ],
+        "summary": "Get all spans for a trace",
+        "parameters": [
+          {
+            "name": "traceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Spans.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "traceId": {
+                      "type": "string"
+                    },
+                    "spanCount": {
+                      "type": "integer"
+                    },
+                    "spans": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Trace not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tracing/span/{traceId}/{spanId}": {
+      "get": {
+        "tags": [
+          "Tracing"
+        ],
+        "summary": "Get a specific span",
+        "parameters": [
+          {
+            "name": "traceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "spanId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The span.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Span not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tracing/jaeger/{traceId}": {
+      "get": {
+        "tags": [
+          "Tracing"
+        ],
+        "summary": "Export a trace in Jaeger format",
+        "parameters": [
+          {
+            "name": "traceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Jaeger-formatted trace.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Trace not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tracing/metrics": {
+      "get": {
+        "tags": [
+          "Tracing"
+        ],
+        "summary": "Get distributed-tracing metrics",
+        "responses": {
+          "200": {
+            "description": "Metrics.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ws/metrics": {
+      "get": {
+        "tags": [
+          "Metrics"
+        ],
+        "summary": "Get WebSocket connection/subscription metrics (JSON)",
+        "responses": {
+          "200": {
+            "description": "Metrics.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metrics/ws": {
+      "get": {
+        "tags": [
+          "Metrics"
+        ],
+        "summary": "WebSocket metrics in Prometheus format",
+        "description": "Tagged with this instance id; scrape every replica and aggregate for cluster-wide totals.",
+        "responses": {
+          "200": {
+            "description": "Prometheus text-exposition format (version 0.0.4).",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metrics/rpc": {
+      "get": {
+        "tags": [
+          "Metrics"
+        ],
+        "summary": "Soroban RPC circuit-breaker metrics in Prometheus format",
+        "responses": {
+          "200": {
+            "description": "Prometheus text-exposition format (version 0.0.4).",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/rpc/circuit-breaker": {
+      "get": {
+        "tags": [
+          "Metrics"
+        ],
+        "summary": "Soroban RPC circuit-breaker state (JSON)",
+        "responses": {
+          "200": {
+            "description": "Circuit breaker state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metrics/events": {
+      "get": {
+        "tags": [
+          "Metrics"
+        ],
+        "summary": "Critical on-chain event monitoring metrics in Prometheus format",
+        "responses": {
+          "200": {
+            "description": "Prometheus text-exposition format (version 0.0.4).",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/events/critical/recent": {
+      "get": {
+        "tags": [
+          "Metrics"
+        ],
+        "summary": "Recent critical on-chain events and their metrics (JSON)",
+        "responses": {
+          "200": {
+            "description": "Recent events.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "metrics": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "Session access token issued by /auth/login or /auth/passwordless/verify. Sent as `Authorization: Bearer <token>`. Required for account/session/MFA endpoints."
+      },
+      "apiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key",
+        "description": "Long-lived API key issued via /api/api-keys. Subject to per-key rate limiting independent of the general IP-based limiter."
+      }
+    },
+    "schemas": {
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Short, machine-oriented error code or summary."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable explanation."
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
+      "ValidationErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "example": "Validation failed"
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "keyword": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
+      "Pagination": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "VerifyBatchRequest": {
+        "type": "object",
+        "properties": {
+          "credential_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "minItems": 1,
+            "maxItems": 50
+          },
+          "slice_id": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "required": [
+          "credential_ids",
+          "slice_id"
+        ],
+        "additionalProperties": false
+      },
+      "VerifyBatchClaimsRequest": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 100,
+            "items": {
+              "type": "object",
+              "properties": {
+                "credential_id": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "claim_type": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 64
+                }
+              },
+              "required": [
+                "credential_id",
+                "claim_type"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "additionalProperties": false
+      },
+      "NotificationPreferencesRequest": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string",
+            "minLength": 1
+          },
+          "email": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "channels": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "email",
+                "sms"
+              ]
+            },
+            "minItems": 1
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "credential_issued",
+                "credential_revoked",
+                "credential_suspended",
+                "credential_attested",
+                "credential_expiring"
+              ]
+            },
+            "minItems": 1
+          },
+          "credential_type_filters": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          "enabled": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "address",
+          "channels",
+          "events"
+        ],
+        "additionalProperties": false
+      },
+      "NotificationSendRequest": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string",
+            "minLength": 1
+          },
+          "event": {
+            "type": "string",
+            "enum": [
+              "credential_issued",
+              "credential_revoked",
+              "credential_suspended",
+              "credential_attested",
+              "credential_expiring"
+            ]
+          },
+          "credential_id": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "credential_type": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "issuer": {
+            "type": "string"
+          },
+          "holder": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "address",
+          "event",
+          "credential_id"
+        ],
+        "additionalProperties": false
+      },
+      "AnalyticsEventRequest": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "issued",
+              "attested",
+              "revoked",
+              "suspended",
+              "verified"
+            ]
+          },
+          "credential_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "timestamp": {
+            "type": "string",
+            "minLength": 1
+          },
+          "issuer": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "attestor": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "credential_id",
+          "timestamp"
+        ],
+        "additionalProperties": false
+      },
+      "AuditVerifyRequest": {
+        "type": "object",
+        "properties": {
+          "batch_id": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "required": [
+          "batch_id"
+        ],
+        "additionalProperties": false
+      },
+      "HealthStatus": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "healthy",
+              "degraded",
+              "unhealthy"
+            ]
+          },
+          "checks": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "BatchVerificationResult": {
+        "type": "object",
+        "properties": {
+          "credential_id": {
+            "type": "integer"
+          },
+          "claim_type": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "verified",
+              "failed",
+              "not_found",
+              "revoked",
+              "expired",
+              "error"
+            ]
+          },
+          "proof": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "verified_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "credential_status": {
+                "type": "string",
+                "enum": [
+                  "active",
+                  "revoked",
+                  "suspended",
+                  "expired"
+                ]
+              },
+              "digest": {
+                "type": "string",
+                "description": "16-hex-char stable digest."
+              }
+            }
+          },
+          "error": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "credential_id",
+          "claim_type",
+          "status"
+        ]
+      },
+      "BatchVerificationResponse": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BatchVerificationResult"
+            }
+          },
+          "summary": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "integer"
+              },
+              "verified": {
+                "type": "integer"
+              },
+              "failed": {
+                "type": "integer"
+              },
+              "not_found": {
+                "type": "integer"
+              },
+              "errors": {
+                "type": "integer"
+              },
+              "duplicates_deduplicated": {
+                "type": "integer"
+              },
+              "execution_time_ms": {
+                "type": "number"
+              }
+            }
+          }
+        }
+      },
+      "Credential": {
+        "type": "object",
+        "description": "A credential as returned by the search index / dashboard endpoints.",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "claim_type": {
+            "type": "string"
+          },
+          "issuer": {
+            "type": "string",
+            "description": "Stellar address of the issuer."
+          },
+          "holder": {
+            "type": "string",
+            "description": "Stellar address of the holder."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "revoked",
+              "suspended",
+              "expired"
+            ]
+          },
+          "metadata_hash": {
+            "type": "string"
+          },
+          "issued_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "claim_type",
+          "issuer",
+          "holder",
+          "status"
+        ]
+      },
+      "Slice": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "credential_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "ApiKey": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "prefix": {
+            "type": "string",
+            "description": "Non-secret prefix used to identify the key in listings."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_used_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "revoked": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "prefix"
+        ]
+      },
+      "ApiKeyCreateResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ApiKey"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "secret": {
+                "type": "string",
+                "description": "Full secret key — returned exactly once, at creation time. Not recoverable afterward."
+              }
+            },
+            "required": [
+              "secret"
+            ]
+          }
+        ]
+      },
+      "Webhook": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "url",
+          "events"
+        ]
+      },
+      "AttestorStatus": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          },
+          "reputation": {
+            "type": "number"
+          },
+          "online": {
+            "type": "boolean"
+          },
+          "last_seen": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "address"
+        ]
+      },
+      "GdprRequest": {
+        "type": "object",
+        "properties": {
+          "request_id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "erasure",
+              "access",
+              "rectification"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "in_progress",
+              "completed",
+              "rejected"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "request_id",
+          "type",
+          "status"
+        ]
+      }
+    }
+  }
+}

--- a/api-server/package-lock.json
+++ b/api-server/package-lock.json
@@ -24,9 +24,11 @@
         "pdfkit": "^0.19.1",
         "pg": "^8.13.1",
         "qrcode": "^1.5.4",
+        "swagger-ui-express": "^5.0.1",
         "ws": "^8.21.0"
       },
       "devDependencies": {
+        "@hey-api/openapi-ts": "^0.99.0",
         "@types/compression": "^1.8.1",
         "@types/express": "^5.0.3",
         "@types/node": "^24.12.0",
@@ -34,8 +36,10 @@
         "@types/pg": "^8.11.10",
         "@types/qrcode": "^1.5.6",
         "@types/supertest": "^7.2.0",
+        "@types/swagger-ui-express": "^4.1.8",
         "@types/ws": "^8.18.1",
         "hardhat": "^3.10.0",
+        "openapi3-ts": "^4.6.1",
         "solc": "^0.8.36",
         "supertest": "^7.2.2",
         "tsx": "^4.19.4",
@@ -600,6 +604,132 @@
         "node": ">=20"
       }
     },
+    "node_modules/@hey-api/codegen-core": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.9.1.tgz",
+      "integrity": "sha512-s97jL1dgTMuiMHv2BZ1X4Tgd99Mf9GOvGdNqNcGwIMmnR+PgYNoraj4Zvp134MKsNCap/m7k0r0vKKnl56pj4w==",
+      "dev": true,
+      "dependencies": {
+        "@hey-api/types": "0.1.4",
+        "ansi-colors": "4.1.3",
+        "c12": "3.3.4",
+        "color-support": "1.1.3"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/json-schema-ref-parser": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.4.tgz",
+      "integrity": "sha512-otmd+zCxbYVBIp/mlMTnGkvlNYLkVKgs3VOIq0kSnenhB1+fRwLPQIeSwyWM6E51oXhUedkYjVsVpkVexeuJOA==",
+      "dev": true,
+      "dependencies": {
+        "@jsdevtools/ono": "7.1.3",
+        "@types/json-schema": "7.0.15",
+        "js-yaml": "4.2.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/openapi-ts": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.99.0.tgz",
+      "integrity": "sha512-SePU/5oEWWkvUBYmvzdYRctseoLuskyhs4ET0RvLIcmzc8yLQoA2R+KtBIQ8bPsoSUB0m4E5SmBnl6aGSA0szQ==",
+      "dev": true,
+      "dependencies": {
+        "@hey-api/codegen-core": "0.9.1",
+        "@hey-api/json-schema-ref-parser": "1.4.4",
+        "@hey-api/shared": "0.5.0",
+        "@hey-api/spec-types": "0.2.0",
+        "@hey-api/types": "0.1.4",
+        "@lukeed/ms": "2.0.2",
+        "ansi-colors": "4.1.3",
+        "color-support": "1.1.3",
+        "commander": "15.0.0",
+        "get-tsconfig": "4.14.0"
+      },
+      "bin": {
+        "openapi-ts": "bin/run.js"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.5.3 || >=6.0.0 || 6.0.1-rc"
+      }
+    },
+    "node_modules/@hey-api/openapi-ts/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "dev": true,
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@hey-api/shared": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.5.0.tgz",
+      "integrity": "sha512-JN/j4Ebh4cJGYIQ5cwWuqe7GeSUyQoz7oC51WqyhKOcrejK6DKZMDkshc5d1eKTRuRL+rjozuRcoUaZZn2DGPw==",
+      "dev": true,
+      "dependencies": {
+        "@hey-api/codegen-core": "0.9.1",
+        "@hey-api/json-schema-ref-parser": "1.4.4",
+        "@hey-api/spec-types": "0.2.0",
+        "@hey-api/types": "0.1.4",
+        "ansi-colors": "4.1.3",
+        "cross-spawn": "7.0.6",
+        "open": "11.0.0",
+        "semver": "7.8.4"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/shared/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@hey-api/spec-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/spec-types/-/spec-types-0.2.0.tgz",
+      "integrity": "sha512-ibQ8Is7evMavzr8GNyJCcTg975d8DpaMUyLmOrQ85UBdy1l6t1KuRAwgChAbesJsIlNV6gjmlXruWyegDX18Fg==",
+      "dev": true,
+      "dependencies": {
+        "@hey-api/types": "0.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/types": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@hey-api/types/-/types-0.1.4.tgz",
+      "integrity": "sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg==",
+      "dev": true
+    },
     "node_modules/@ioredis/commands": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
@@ -623,6 +753,21 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
@@ -1243,6 +1388,12 @@
         "win32"
       ]
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true
+    },
     "node_modules/@scure/base": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
@@ -1519,6 +1670,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -1625,6 +1782,16 @@
       "dependencies": {
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@types/ws": {
@@ -1840,6 +2007,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1999,6 +2172,21 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -2006,6 +2194,85 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/c12": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+      "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^5.0.0",
+        "confbox": "^0.2.4",
+        "defu": "^6.1.6",
+        "dotenv": "^17.3.1",
+        "exsolve": "^1.0.8",
+        "giget": "^3.2.0",
+        "jiti": "^2.6.1",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^2.1.0",
+        "pkg-types": "^2.3.0",
+        "rc9": "^3.0.1"
+      },
+      "peerDependencies": {
+        "magicast": "*"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/c12/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/c12/node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true
+    },
+    "node_modules/c12/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/c12/node_modules/pkg-types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "dev": true,
+      "dependencies": {
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/c12/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/cac": {
@@ -2165,6 +2432,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2336,6 +2612,34 @@
         "node": ">=6"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -2352,6 +2656,24 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -2379,6 +2701,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "dev": true
     },
     "node_modules/destroy": {
       "version": "1.2.0",
@@ -2421,6 +2749,18 @@
       "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
       "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2782,6 +3122,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/exsolve": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+      "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
+      "dev": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3056,6 +3402,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/giget": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
+      "integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
+      "dev": true,
+      "bin": {
+        "giget": "dist/cli.mjs"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3318,6 +3685,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3325,6 +3707,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-retry-allowed": {
@@ -3366,6 +3778,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -3377,6 +3804,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
     },
     "node_modules/js-md5": {
       "version": "0.8.3",
@@ -3396,6 +3832,28 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -3737,6 +4195,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -3781,6 +4245,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "dev": true,
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openapi3-ts": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.6.1.tgz",
+      "integrity": "sha512-XW9MOldkhoICNeXVzzmXzmOW5G73ppOEGmh7fLCqHjgfdEYCGGN+00MlVCeUZgovjjfC56j9tvtDt1zGabNjjA==",
+      "dev": true,
+      "dependencies": {
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/os-tmpdir": {
@@ -3936,6 +4429,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
+      "dev": true
     },
     "node_modules/pg": {
       "version": "8.22.0",
@@ -4142,6 +4641,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -4243,6 +4754,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rc9": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+      "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
+      "dev": true,
+      "dependencies": {
+        "defu": "^6.1.6",
+        "destr": "^2.0.5"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -4307,6 +4828,15 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "license": "ISC"
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
     },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
@@ -4373,6 +4903,18 @@
         "@rollup/rollup-win32-x64-gnu": "4.62.2",
         "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/safe-buffer": {
@@ -4840,6 +5382,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.11",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.11.tgz",
+      "integrity": "sha512-NEZzRuxHHQkbG3GCjNbzz+XRDoM7AztnXyzc2VCW5RXUvZBDW7bb3W29/SPfvav3yOzqnDTOLP2Xzbjxo0bldQ==",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/tiny-inflate": {
@@ -5785,6 +6349,22 @@
         }
       }
     },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -5799,6 +6379,21 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "15.4.1",

--- a/api-server/package.json
+++ b/api-server/package.json
@@ -11,7 +11,9 @@
     "test": "vitest --run",
     "loadtest:ws": "tsx loadtest/wsLoadTest.ts",
     "migrate": "tsx src/migrations/cli.ts up",
-    "migrate:rollback": "tsx src/migrations/cli.ts down"
+    "migrate:rollback": "tsx src/migrations/cli.ts down",
+    "openapi:generate": "tsx scripts/generate-openapi-spec.ts",
+    "generate:client": "npm run openapi:generate && openapi-ts"
   },
   "dependencies": {
     "@ethereumjs/block": "^10.1.2",
@@ -30,9 +32,11 @@
     "pdfkit": "^0.19.1",
     "pg": "^8.13.1",
     "qrcode": "^1.5.4",
+    "swagger-ui-express": "^5.0.1",
     "ws": "^8.21.0"
   },
   "devDependencies": {
+    "@hey-api/openapi-ts": "^0.99.0",
     "@types/compression": "^1.8.1",
     "@types/express": "^5.0.3",
     "@types/node": "^24.12.0",
@@ -40,8 +44,10 @@
     "@types/pg": "^8.11.10",
     "@types/qrcode": "^1.5.6",
     "@types/supertest": "^7.2.0",
+    "@types/swagger-ui-express": "^4.1.8",
     "@types/ws": "^8.18.1",
     "hardhat": "^3.10.0",
+    "openapi3-ts": "^4.6.1",
     "solc": "^0.8.36",
     "supertest": "^7.2.2",
     "tsx": "^4.19.4",

--- a/api-server/scripts/generate-openapi-spec.ts
+++ b/api-server/scripts/generate-openapi-spec.ts
@@ -1,0 +1,26 @@
+/**
+ * Issue #1309 — Writes the generated OpenAPI 3.1 document to
+ * `openapi/openapi.json`.
+ *
+ * The live server always serves a freshly-built spec from
+ * `src/openapi/index.ts` at `/api-docs/openapi.json` — this script exists
+ * so there's a static, diffable artifact in source control (useful for
+ * import into API clients like Postman, and as the input the TypeScript
+ * client generator consumes; see `openapi-ts.config.ts` and the
+ * `generate:client` npm script).
+ *
+ * Run with: npm run openapi:generate
+ */
+import { writeFileSync, mkdirSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { buildOpenApiSpec } from '../src/openapi/index.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const outDir = join(__dirname, '../openapi');
+const outFile = join(outDir, 'openapi.json');
+
+mkdirSync(outDir, { recursive: true });
+writeFileSync(outFile, JSON.stringify(buildOpenApiSpec(), null, 2) + '\n', 'utf-8');
+
+console.log(`Wrote ${outFile}`);

--- a/api-server/src/index.ts
+++ b/api-server/src/index.ts
@@ -22,6 +22,8 @@ import oauth2Router from './routes/oauth2.js';
 import healthRouter from './routes/health.js';
 import privilegeEscalationRouter from './routes/privilegeEscalation.js';
 import tracingRouter from './routes/tracing.js';
+// #1309: Auto-generated OpenAPI docs (Swagger UI / ReDoc)
+import docsRouter from './routes/docs.js';
 import { createDashboardRouter } from './routes/dashboard.js';
 import { cacheControl } from './middleware/cacheControl.js';
 // #1303: CORS middleware
@@ -154,6 +156,9 @@ app.use('/api/me', createDashboardRouter(sorobanClient));
 
 // #1308: Health check endpoints
 app.use('/health', healthRouter);
+
+// #1309: Auto-generated OpenAPI 3.1 docs — JSON spec, Swagger UI, ReDoc.
+app.use('/api-docs', docsRouter);
 
 // #1305: Privilege escalation prevention
 app.use('/api/admin/privilege-escalation', privilegeEscalationRouter);

--- a/api-server/src/openapi/components.ts
+++ b/api-server/src/openapi/components.ts
@@ -1,0 +1,259 @@
+/**
+ * Issue #1309 — Shared OpenAPI 3.1 components.
+ *
+ * Schemas here are referenced by `$ref` from the per-resource path
+ * definitions in `./paths/*`. A handful (marked below) are imported
+ * directly from `middleware/validate.ts` — those are the *actual* AJV
+ * JSON Schema objects the server validates requests against, reused
+ * as-is so the published spec can never drift from real request
+ * validation behaviour.
+ */
+
+import type { ComponentsObject, SchemaObject } from 'openapi3-ts/oas31';
+import { schemas as validationSchemas } from '../middleware/validate.js';
+
+const errorResponse: SchemaObject = {
+  type: 'object',
+  properties: {
+    error: { type: 'string', description: 'Short, machine-oriented error code or summary.' },
+    message: { type: 'string', description: 'Human-readable explanation.' },
+  },
+  required: ['error'],
+};
+
+const validationErrorResponse: SchemaObject = {
+  type: 'object',
+  properties: {
+    error: { type: 'string', example: 'Validation failed' },
+    details: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          path: { type: 'string' },
+          keyword: { type: 'string' },
+          message: { type: 'string' },
+        },
+      },
+    },
+  },
+  required: ['error'],
+};
+
+const pagination: SchemaObject = {
+  type: 'object',
+  properties: {
+    total: { type: 'integer', minimum: 0 },
+    limit: { type: 'integer', minimum: 1 },
+    offset: { type: 'integer', minimum: 0 },
+    next_cursor: { type: ['string', 'null'] },
+  },
+};
+
+export const components: ComponentsObject = {
+  securitySchemes: {
+    bearerAuth: {
+      type: 'http',
+      scheme: 'bearer',
+      bearerFormat: 'JWT',
+      description:
+        'Session access token issued by /auth/login or /auth/passwordless/verify. ' +
+        'Sent as `Authorization: Bearer <token>`. Required for account/session/MFA endpoints.',
+    },
+    apiKeyAuth: {
+      type: 'apiKey',
+      in: 'header',
+      name: 'x-api-key',
+      description:
+        'Long-lived API key issued via /api/api-keys. Subject to per-key rate limiting ' +
+        'independent of the general IP-based limiter.',
+    },
+  },
+  schemas: {
+    ErrorResponse: errorResponse,
+    ValidationErrorResponse: validationErrorResponse,
+    Pagination: pagination,
+
+    // Reused verbatim from the AJV validators that actually run at request
+    // time — see middleware/validate.ts. Keeping a single source of truth
+    // means the documented request shape can never silently diverge from
+    // the enforced one.
+    VerifyBatchRequest: validationSchemas.verifyBatch.body as SchemaObject,
+    VerifyBatchClaimsRequest: validationSchemas.verifyBatchClaims.body as SchemaObject,
+    NotificationPreferencesRequest: validationSchemas.notificationPreferences.body as SchemaObject,
+    NotificationSendRequest: validationSchemas.notificationSend.body as SchemaObject,
+    AnalyticsEventRequest: validationSchemas.analyticsEvent.body as SchemaObject,
+    AuditVerifyRequest: validationSchemas.auditVerify.body as SchemaObject,
+
+    HealthStatus: {
+      type: 'object',
+      properties: {
+        status: { type: 'string', enum: ['healthy', 'degraded', 'unhealthy'] },
+        checks: { type: 'object', additionalProperties: true },
+        timestamp: { type: 'string', format: 'date-time' },
+      },
+      required: ['status'],
+    },
+
+    BatchVerificationResult: {
+      type: 'object',
+      properties: {
+        credential_id: { type: 'integer' },
+        claim_type: { type: 'string' },
+        status: {
+          type: 'string',
+          enum: ['verified', 'failed', 'not_found', 'revoked', 'expired', 'error'],
+        },
+        proof: {
+          type: ['object', 'null'],
+          properties: {
+            verified_at: { type: 'string', format: 'date-time' },
+            credential_status: {
+              type: 'string',
+              enum: ['active', 'revoked', 'suspended', 'expired'],
+            },
+            digest: { type: 'string', description: '16-hex-char stable digest.' },
+          },
+        },
+        error: { type: ['string', 'null'] },
+      },
+      required: ['credential_id', 'claim_type', 'status'],
+    },
+
+    BatchVerificationResponse: {
+      type: 'object',
+      properties: {
+        results: { type: 'array', items: { $ref: '#/components/schemas/BatchVerificationResult' } },
+        summary: {
+          type: 'object',
+          properties: {
+            total: { type: 'integer' },
+            verified: { type: 'integer' },
+            failed: { type: 'integer' },
+            not_found: { type: 'integer' },
+            errors: { type: 'integer' },
+            duplicates_deduplicated: { type: 'integer' },
+            execution_time_ms: { type: 'number' },
+          },
+        },
+      },
+    },
+
+    Credential: {
+      type: 'object',
+      description: 'A credential as returned by the search index / dashboard endpoints.',
+      properties: {
+        id: { type: 'integer' },
+        claim_type: { type: 'string' },
+        issuer: { type: 'string', description: 'Stellar address of the issuer.' },
+        holder: { type: 'string', description: 'Stellar address of the holder.' },
+        status: { type: 'string', enum: ['active', 'revoked', 'suspended', 'expired'] },
+        metadata_hash: { type: 'string' },
+        issued_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'claim_type', 'issuer', 'holder', 'status'],
+    },
+
+    Slice: {
+      type: 'object',
+      properties: {
+        id: { type: 'integer' },
+        name: { type: 'string' },
+        credential_ids: { type: 'array', items: { type: 'integer' } },
+        created_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id'],
+    },
+
+    ApiKey: {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        prefix: { type: 'string', description: 'Non-secret prefix used to identify the key in listings.' },
+        created_at: { type: 'string', format: 'date-time' },
+        last_used_at: { type: ['string', 'null'], format: 'date-time' },
+        revoked: { type: 'boolean' },
+      },
+      required: ['id', 'prefix'],
+    },
+
+    ApiKeyCreateResponse: {
+      allOf: [
+        { $ref: '#/components/schemas/ApiKey' },
+        {
+          type: 'object',
+          properties: {
+            secret: {
+              type: 'string',
+              description: 'Full secret key — returned exactly once, at creation time. Not recoverable afterward.',
+            },
+          },
+          required: ['secret'],
+        },
+      ],
+    },
+
+    Webhook: {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        url: { type: 'string', format: 'uri' },
+        events: { type: 'array', items: { type: 'string' } },
+        created_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'url', 'events'],
+    },
+
+    AttestorStatus: {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        address: { type: 'string' },
+        reputation: { type: 'number' },
+        online: { type: 'boolean' },
+        last_seen: { type: ['string', 'null'], format: 'date-time' },
+      },
+      required: ['id', 'address'],
+    },
+
+    GdprRequest: {
+      type: 'object',
+      properties: {
+        request_id: { type: 'string' },
+        type: { type: 'string', enum: ['erasure', 'access', 'rectification'] },
+        status: { type: 'string', enum: ['pending', 'in_progress', 'completed', 'rejected'] },
+        created_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['request_id', 'type', 'status'],
+    },
+  },
+};
+
+export const tags = [
+  { name: 'Health', description: 'Liveness / readiness probes and service status.' },
+  { name: 'Verification', description: 'Credential and batch claim verification.' },
+  { name: 'Credentials', description: 'Credential search, metadata, revocation list, sharded storage stats.' },
+  { name: 'Slices', description: 'Credential slice (batch) lookups.' },
+  { name: 'Attestors', description: 'Attestor directory, availability and reputation.' },
+  { name: 'Issuer', description: 'Per-issuer metrics and analytics.' },
+  { name: 'Analytics', description: 'Platform-wide event ingestion and derived metrics.' },
+  { name: 'Dashboard', description: 'Credential-holder dashboard (my credentials, disputes, access log).' },
+  { name: 'Notifications', description: 'Notification preferences and delivery.' },
+  { name: 'Webhooks', description: 'Outbound event webhook subscriptions and delivery logs.' },
+  { name: 'GDPR', description: 'Data subject access / erasure requests, consent records.' },
+  { name: 'Consent', description: 'Per-credential verifier consent grants.' },
+  { name: 'Share Links', description: 'Time-limited shareable credential links.' },
+  { name: 'API Keys', description: 'API key issuance, rotation and usage.' },
+  { name: 'OAuth2', description: 'OAuth2 / OIDC identity provider linking.' },
+  { name: 'Auth', description: 'Session login, MFA, and passwordless / WebAuthn auth.' },
+  { name: 'Recovery', description: 'Account recovery via OTP.' },
+  { name: 'Privilege Escalation', description: 'Step-up MFA approval workflow for privileged actions.' },
+  { name: 'Audit', description: 'Immutable audit log entries and batch notarization.' },
+  { name: 'Reports', description: 'Compliance, cost, usage and expiry-forecast reports.' },
+  { name: 'Costs', description: 'Infrastructure cost reporting and optimization suggestions.' },
+  { name: 'Bridge', description: 'Cross-chain credential anchoring and light-client sync.' },
+  { name: 'Tracing', description: 'Distributed trace lookup.' },
+  { name: 'GraphQL', description: 'GraphQL endpoint (alternative to the REST surface).' },
+  { name: 'Metrics', description: 'Prometheus-format and JSON operational metrics.' },
+];

--- a/api-server/src/openapi/index.ts
+++ b/api-server/src/openapi/index.ts
@@ -1,0 +1,129 @@
+/**
+ * Issue #1309 — OpenAPI 3.1 spec generator.
+ *
+ * `buildOpenApiSpec()` assembles the full document from the typed path
+ * fragments in `./paths/*` and the shared `./components`. It is called
+ * fresh on every request to `/api-docs/openapi.json` (see
+ * `../routes/docs.ts`) rather than reading a static file, so the served
+ * spec can never go stale relative to what's in source control — and the
+ * same function is what `scripts/generate-openapi-spec.ts` calls to write
+ * the on-disk snapshot consumed by the TypeScript client generator.
+ *
+ * Only routers that are actually mounted in `index.ts` are represented
+ * here. A handful of route modules exist in the codebase but are not
+ * wired into the running app (only exercised directly by their unit
+ * tests) — documenting those would describe endpoints that 404 in
+ * practice, so they're intentionally excluded.
+ */
+
+import type { OpenAPIObject, PathItemObject } from 'openapi3-ts/oas31';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { components, tags } from './components.js';
+import type { PathsFragment } from './paths/types.js';
+
+import { healthPaths } from './paths/health.js';
+import { verifyPaths } from './paths/verify.js';
+import { slicesPaths } from './paths/slices.js';
+import { apiKeysPaths } from './paths/apiKeys.js';
+import { webhooksPaths } from './paths/webhooks.js';
+import { gdprPaths } from './paths/gdpr.js';
+import { oauth2Paths } from './paths/oauth2.js';
+import { attestorsPaths } from './paths/attestors.js';
+import { notificationsPaths } from './paths/notifications.js';
+import { issuerPaths } from './paths/issuer.js';
+import { analyticsPaths } from './paths/analytics.js';
+import { issuerAnalyticsPaths } from './paths/issuerAnalytics.js';
+import { dashboardPaths } from './paths/dashboard.js';
+import { credentialsPaths } from './paths/credentials.js';
+import { credentialExportPaths } from './paths/credentialExport.js';
+import { consentPaths } from './paths/consent.js';
+import { shareLinksPaths } from './paths/shareLinks.js';
+import { recoveryPaths } from './paths/recovery.js';
+import { privilegeEscalationPaths } from './paths/privilegeEscalation.js';
+import { tracingPaths } from './paths/tracing.js';
+import { metricsPaths } from './paths/metrics.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf-8')) as { version: string };
+
+/** Re-mounts every operation in `fragment` under `newPrefix` instead of `oldPrefix`. */
+function remount(fragment: PathsFragment, oldPrefix: string, newPrefix: string): PathsFragment {
+  const out: PathsFragment = {};
+  for (const [path, item] of Object.entries(fragment)) {
+    if (!path.startsWith(oldPrefix)) {
+      throw new Error(`remount: path "${path}" does not start with "${oldPrefix}"`);
+    }
+    out[newPrefix + path.slice(oldPrefix.length)] = item;
+  }
+  return out;
+}
+
+function mergePaths(...fragments: PathsFragment[]): Record<string, PathItemObject> {
+  const merged: Record<string, PathItemObject> = {};
+  for (const fragment of fragments) {
+    for (const [path, item] of Object.entries(fragment)) {
+      if (merged[path]) {
+        throw new Error(`buildOpenApiSpec: duplicate path definition for "${path}"`);
+      }
+      merged[path] = item;
+    }
+  }
+  return merged;
+}
+
+export function buildOpenApiSpec(): OpenAPIObject {
+  const paths = mergePaths(
+    healthPaths,
+    verifyPaths,
+    slicesPaths,
+    apiKeysPaths,
+    // apiKeysRouter is mounted twice in index.ts: /api/api-keys (legacy)
+    // and /auth/api-keys (issue #1297's spec-mandated path). Same handlers,
+    // same behaviour — re-derive the second path set instead of hand
+    // duplicating every operation object.
+    remount(apiKeysPaths, '/api/api-keys', '/auth/api-keys'),
+    webhooksPaths,
+    gdprPaths,
+    oauth2Paths,
+    attestorsPaths,
+    notificationsPaths,
+    issuerPaths,
+    analyticsPaths,
+    issuerAnalyticsPaths,
+    dashboardPaths,
+    credentialsPaths,
+    credentialExportPaths,
+    consentPaths,
+    shareLinksPaths,
+    recoveryPaths,
+    privilegeEscalationPaths,
+    tracingPaths,
+    metricsPaths,
+  );
+
+  const baseUrl = (process.env.PUBLIC_APP_BASE_URL ?? 'http://localhost:3000').replace(/\/+$/, '');
+
+  return {
+    openapi: '3.1.0',
+    info: {
+      title: 'QuorumProof API',
+      version: pkg.version,
+      description:
+        'REST API for the QuorumProof credential issuance, attestation and verification ' +
+        'platform, backed by Soroban smart contracts on Stellar.\n\n' +
+        'This document is generated from typed operation definitions in ' +
+        '`api-server/src/openapi/paths/*` — see `docs/API_DOCUMENTATION.md` for how to ' +
+        'regenerate it and the TypeScript client after changing a route.',
+      contact: { name: 'QuorumProof', url: 'https://github.com/QuorumProof/QuorumProof' },
+    },
+    servers: [
+      { url: baseUrl, description: 'Configured server (PUBLIC_APP_BASE_URL)' },
+      { url: 'http://localhost:3000', description: 'Local development' },
+    ],
+    tags,
+    paths,
+    components,
+  };
+}

--- a/api-server/src/openapi/paths/analytics.ts
+++ b/api-server/src/openapi/paths/analytics.ts
@@ -1,0 +1,82 @@
+import type { PathsFragment } from './types.js';
+
+const dateRangeParams = [
+  { name: 'start_date', in: 'query' as const, schema: { type: 'string' as const, format: 'date' } },
+  { name: 'end_date', in: 'query' as const, schema: { type: 'string' as const, format: 'date' } },
+];
+
+export const analyticsPaths: PathsFragment = {
+  '/api/analytics/events': {
+    post: {
+      tags: ['Analytics'],
+      summary: 'Record a credential lifecycle event',
+      requestBody: {
+        required: true,
+        content: { 'application/json': { schema: { $ref: '#/components/schemas/AnalyticsEventRequest' } } },
+      },
+      responses: {
+        '201': { description: 'Recorded.', content: { 'application/json': { schema: { type: 'object', properties: { success: { type: 'boolean' }, event_id: { type: 'string' } } } } } },
+        '400': { description: 'Invalid body.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ValidationErrorResponse' } } } },
+      },
+    },
+    get: {
+      tags: ['Analytics'],
+      summary: 'Query the raw analytics event log',
+      parameters: [...dateRangeParams, { name: 'type', in: 'query', schema: { type: 'string', enum: ['issued', 'attested', 'revoked', 'suspended', 'verified'] } }],
+      responses: {
+        '200': { description: 'Matching events.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Invalid query parameters.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/analytics/metrics': {
+    get: {
+      tags: ['Analytics'],
+      summary: 'Get daily issued/attested/revoked metrics for a date range',
+      parameters: dateRangeParams,
+      responses: {
+        '200': { description: 'Daily metrics and totals.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Invalid date range.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/analytics/anomalies': {
+    get: {
+      tags: ['Analytics'],
+      summary: 'Detect anomalous issuance days in a date range',
+      parameters: [...dateRangeParams, { name: 'threshold', in: 'query', schema: { type: 'number' } }],
+      responses: {
+        '200': { description: 'Anomalous dates.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Invalid query parameters.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/analytics/issuer/{address}': {
+    get: {
+      tags: ['Analytics'],
+      summary: 'Get issuer-scoped metrics',
+      parameters: [
+        { name: 'address', in: 'path', required: true, schema: { type: 'string' } },
+        { name: 'period_days', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 365, default: 30 } },
+      ],
+      responses: {
+        '200': { description: 'Issuer metrics.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Invalid period_days.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/analytics/summary': {
+    get: {
+      tags: ['Analytics'],
+      summary: 'Get a platform-wide analytics summary',
+      responses: { '200': { description: 'Summary.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } } },
+    },
+  },
+  '/api/analytics/health': {
+    get: {
+      tags: ['Analytics'],
+      summary: 'Analytics subsystem health check',
+      responses: { '200': { description: 'OK.', content: { 'application/json': { schema: { type: 'object', properties: { status: { type: 'string' }, service: { type: 'string' }, timestamp: { type: 'string', format: 'date-time' } } } } } } },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/apiKeys.ts
+++ b/api-server/src/openapi/paths/apiKeys.ts
@@ -1,0 +1,114 @@
+import type { PathsFragment } from './types.js';
+
+const apiKeySummary = {
+  type: 'object' as const,
+  properties: {
+    id: { type: 'string' as const },
+    name: { type: 'string' as const },
+    createdAt: { type: 'string' as const, format: 'date-time' },
+    lastUsedAt: { type: ['string', 'null'] as const, format: 'date-time' },
+    active: { type: 'boolean' as const },
+  },
+};
+
+export const apiKeysPaths: PathsFragment = {
+  '/api/api-keys': {
+    post: {
+      tags: ['API Keys'],
+      summary: 'Generate a new API key',
+      description:
+        'The full secret is returned exactly once, in this response. Callers must persist it — ' +
+        'it cannot be retrieved again (only rotated).',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: { name: { type: 'string', minLength: 1 } },
+              required: ['name'],
+            },
+          },
+        },
+      },
+      responses: {
+        '201': { description: 'Created.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ApiKeyCreateResponse' } } } },
+        '400': { description: 'Missing name.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '401': { description: 'Missing or invalid authorization.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+    get: {
+      tags: ['API Keys'],
+      summary: "List the caller's active API keys",
+      responses: {
+        '200': { description: 'Keys (secrets never included).', content: { 'application/json': { schema: { type: 'object', properties: { data: { type: 'array', items: apiKeySummary } } } } } },
+        '401': { description: 'Missing or invalid authorization.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/api-keys/{id}': {
+    get: {
+      tags: ['API Keys'],
+      summary: 'Get a single API key',
+      parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+      responses: {
+        '200': { description: 'The key.', content: { 'application/json': { schema: apiKeySummary } } },
+        '404': { description: 'Not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+    delete: {
+      tags: ['API Keys'],
+      summary: 'Revoke an API key',
+      parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+      responses: {
+        '204': { description: 'Revoked.' },
+        '404': { description: 'Not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/api-keys/{id}/rotate': {
+    post: {
+      tags: ['API Keys'],
+      summary: 'Rotate an API key',
+      description: 'Issues a new secret; the old key keeps working until `gracePeriodMs` elapses.',
+      parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+      requestBody: {
+        required: false,
+        content: {
+          'application/json': {
+            schema: { type: 'object', properties: { gracePeriodMs: { type: 'integer', minimum: 1 } } },
+          },
+        },
+      },
+      responses: {
+        '201': { description: 'New key issued.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ApiKeyCreateResponse' } } } },
+        '404': { description: 'Not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '409': { description: 'Key already inactive.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/api-keys/{id}/usage': {
+    get: {
+      tags: ['API Keys'],
+      summary: 'Get usage history for a key',
+      parameters: [
+        { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+        { name: 'limit', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 1000, default: 100 } },
+      ],
+      responses: {
+        '200': { description: 'Usage entries.', content: { 'application/json': { schema: { type: 'object', properties: { data: { type: 'array', items: { type: 'object', additionalProperties: true } } } } } } },
+        '404': { description: 'Not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/api-keys/stats/overview': {
+    get: {
+      tags: ['API Keys'],
+      summary: "Get the caller's key statistics",
+      responses: {
+        '200': { description: 'Aggregate stats.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '401': { description: 'Missing or invalid authorization.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/attestors.ts
+++ b/api-server/src/openapi/paths/attestors.ts
@@ -1,0 +1,173 @@
+import type { PathsFragment } from './types.js';
+
+export const attestorsPaths: PathsFragment = {
+  '/api/attestors': {
+    get: {
+      tags: ['Attestors'],
+      summary: 'List / filter the attestor directory',
+      parameters: [
+        { name: 'type', in: 'query', schema: { type: 'string' }, description: 'Exact match on attestor type.' },
+        { name: 'region', in: 'query', schema: { type: 'string' }, description: 'Case-insensitive exact match.' },
+        { name: 'q', in: 'query', schema: { type: 'string' }, description: 'Substring search across name, region, description.' },
+        { name: 'active', in: 'query', schema: { type: 'boolean' } },
+      ],
+      responses: {
+        '200': {
+          description: 'Matching attestors.',
+          content: {
+            'application/json': {
+              schema: { type: 'object', properties: { total: { type: 'integer' }, attestors: { type: 'array', items: { $ref: '#/components/schemas/AttestorStatus' } } } },
+            },
+          },
+        },
+      },
+    },
+  },
+  '/api/attestors/{id}': {
+    get: {
+      tags: ['Attestors'],
+      summary: 'Get a single attestor record with credential stats',
+      parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+      responses: {
+        '200': { description: 'The attestor.', content: { 'application/json': { schema: { $ref: '#/components/schemas/AttestorStatus' } } } },
+        '404': { description: 'Unknown attestor id.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/attestors/{id}/status': {
+    get: {
+      tags: ['Attestors'],
+      summary: 'Get live availability metrics for an attestor',
+      description: 'uptime_ratio and avg_response_ms are derived from the last 24h of recorded pings.',
+      parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+      responses: {
+        '200': {
+          description: 'Availability status.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  uptime_ratio: { type: ['number', 'null'] },
+                  avg_response_ms: { type: ['number', 'null'] },
+                  active_credential_count: { type: 'integer' },
+                  last_seen: { type: ['string', 'null'], format: 'date-time' },
+                  availability: { type: 'string', enum: ['excellent', 'good', 'degraded', 'offline', 'unknown'] },
+                },
+              },
+            },
+          },
+        },
+        '404': { description: 'Unknown attestor id.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/attestors/{id}/status/ping': {
+    post: {
+      tags: ['Attestors'],
+      summary: 'Record a heartbeat ping result for an attestor',
+      description: 'Called by the monitoring agent or the attestor node itself after each health-check probe.',
+      parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: { ok: { type: 'boolean' }, response_ms: { type: 'number', minimum: 0 } },
+              required: ['ok', 'response_ms'],
+            },
+          },
+        },
+      },
+      responses: {
+        '204': { description: 'Recorded.' },
+        '400': { description: 'Invalid body.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '404': { description: 'Unknown attestor id.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/attestor/pending': {
+    get: {
+      tags: ['Attestors'],
+      summary: 'Get the pending attestation queue for an address',
+      parameters: [{ name: 'address', in: 'query', required: true, schema: { type: 'string' } }],
+      responses: {
+        '200': { description: 'Pending queue.', content: { 'application/json': { schema: { type: 'object', properties: { address: { type: 'string' }, items: { type: 'array', items: {} }, total: { type: 'integer' } } } } } },
+        '400': { description: 'Missing address.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/attestor/reputation/{address}': {
+    get: {
+      tags: ['Attestors'],
+      summary: 'Get on-chain + derived reputation stats for an attestor address',
+      parameters: [{ name: 'address', in: 'path', required: true, schema: { type: 'string' } }],
+      responses: {
+        '200': {
+          description: 'Reputation snapshot (30-day window).',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  address: { type: 'string' },
+                  attestation_count_score: { type: 'number' },
+                  reputation: { type: ['object', 'null'], additionalProperties: true },
+                  attestation_count: { type: 'integer' },
+                  total_activity: { type: 'integer' },
+                  success_rate: { type: ['number', 'null'] },
+                  period_days: { type: 'integer' },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  '/api/attestor/batch-attest': {
+    post: {
+      tags: ['Attestors'],
+      summary: 'Attest a batch of credentials against a slice',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                attestor: { type: 'string' },
+                credential_ids: { type: 'array', items: { type: 'string' }, minItems: 1, maxItems: 50 },
+                slice_id: { type: 'string' },
+              },
+              required: ['attestor', 'credential_ids', 'slice_id'],
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Per-credential attestation results.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  total: { type: 'integer' },
+                  succeeded: { type: 'integer' },
+                  failed: { type: 'integer' },
+                  results: {
+                    type: 'array',
+                    items: { type: 'object', properties: { credential_id: { type: 'string' }, success: { type: 'boolean' }, error: { type: 'string' } } },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '400': { description: 'Missing/invalid fields, or batch too large.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/consent.ts
+++ b/api-server/src/openapi/paths/consent.ts
@@ -1,0 +1,137 @@
+import type { PathsFragment } from './types.js';
+
+const credentialNotFound = { description: 'Credential not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } };
+const forbidden = { description: 'Caller is not the credential holder.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } };
+
+export const consentPaths: PathsFragment = {
+  '/api/credentials/{id}/consent/verifiers': {
+    get: {
+      tags: ['Consent'],
+      summary: 'List verifiers who have accessed a credential',
+      parameters: [
+        { name: 'id', in: 'path', required: true, schema: { type: 'integer', minimum: 1 } },
+        { name: 'holder', in: 'query', required: true, schema: { type: 'string' }, description: 'Stellar address of the credential holder.' },
+      ],
+      responses: {
+        '200': { description: 'Verifiers.', content: { 'application/json': { schema: { type: 'object', properties: { credential_id: { type: 'integer' }, verifiers: { type: 'array', items: {} }, total: { type: 'integer' } } } } } },
+        '400': { description: 'Invalid id or missing holder.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '403': forbidden,
+        '404': credentialNotFound,
+      },
+    },
+  },
+  '/api/credentials/{id}/consent/access-log': {
+    get: {
+      tags: ['Consent'],
+      summary: 'Get the full verifier access log for a credential',
+      parameters: [
+        { name: 'id', in: 'path', required: true, schema: { type: 'integer', minimum: 1 } },
+        { name: 'holder', in: 'query', required: true, schema: { type: 'string' } },
+        { name: 'verifier', in: 'query', schema: { type: 'string' } },
+        { name: 'access_type', in: 'query', schema: { type: 'integer', enum: [1, 2, 3] }, description: '1=share_link, 2=delegation, 3=proof_request.' },
+      ],
+      responses: {
+        '200': { description: 'Access log entries.', content: { 'application/json': { schema: { type: 'object', properties: { credential_id: { type: 'integer' }, entries: { type: 'array', items: { type: 'object', additionalProperties: true } }, total: { type: 'integer' } } } } } },
+        '400': { description: 'Invalid id or missing holder.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '403': forbidden,
+        '404': credentialNotFound,
+      },
+    },
+  },
+  '/api/credentials/{id}/consent/grants': {
+    post: {
+      tags: ['Consent'],
+      summary: 'Grant a verifier consent to access a credential',
+      parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer', minimum: 1 } }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: { holder: { type: 'string' }, verifier: { type: 'string' }, expires_at: { type: 'integer', description: 'Unix timestamp; 0 = no expiry.', default: 0 } },
+              required: ['holder', 'verifier'],
+            },
+          },
+        },
+      },
+      responses: {
+        '201': { description: 'Granted.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Missing fields or invalid expires_at.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '403': forbidden,
+        '404': credentialNotFound,
+      },
+    },
+  },
+  '/api/credentials/{id}/consent/grants/{verifier}': {
+    get: {
+      tags: ['Consent'],
+      summary: 'Get a specific consent grant',
+      parameters: [
+        { name: 'id', in: 'path', required: true, schema: { type: 'integer', minimum: 1 } },
+        { name: 'verifier', in: 'path', required: true, schema: { type: 'string' } },
+      ],
+      responses: {
+        '200': { description: 'The grant.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '404': { description: 'No consent grant found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+    delete: {
+      tags: ['Consent'],
+      summary: 'Revoke a verifier consent grant',
+      parameters: [
+        { name: 'id', in: 'path', required: true, schema: { type: 'integer', minimum: 1 } },
+        { name: 'verifier', in: 'path', required: true, schema: { type: 'string' } },
+      ],
+      requestBody: {
+        required: true,
+        content: { 'application/json': { schema: { type: 'object', properties: { holder: { type: 'string' } }, required: ['holder'] } } },
+      },
+      responses: {
+        '200': { description: 'Revoked.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Missing holder.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '403': forbidden,
+        '404': credentialNotFound,
+      },
+    },
+  },
+  '/api/credentials/{id}/consent/grants/{verifier}/status': {
+    get: {
+      tags: ['Consent'],
+      summary: 'Check whether a consent grant is currently active',
+      parameters: [
+        { name: 'id', in: 'path', required: true, schema: { type: 'integer', minimum: 1 } },
+        { name: 'verifier', in: 'path', required: true, schema: { type: 'string' } },
+      ],
+      responses: {
+        '200': { description: 'Status.', content: { 'application/json': { schema: { type: 'object', properties: { credential_id: { type: 'integer' }, verifier: { type: 'string' }, consent_active: { type: 'boolean' } } } } } },
+      },
+    },
+  },
+  '/api/credentials/{id}/consent/access': {
+    post: {
+      tags: ['Consent'],
+      summary: 'Record a verifier access event',
+      description: 'Used by internal services / the bridge relay to log access.',
+      parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer', minimum: 1 } }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: { holder: { type: 'string' }, verifier: { type: 'string' }, access_type: { type: 'integer', enum: [1, 2, 3] } },
+              required: ['holder', 'verifier', 'access_type'],
+            },
+          },
+        },
+      },
+      responses: {
+        '201': { description: 'Recorded.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Missing/invalid fields.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '403': forbidden,
+        '404': credentialNotFound,
+      },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/credentialExport.ts
+++ b/api-server/src/openapi/paths/credentialExport.ts
@@ -1,0 +1,26 @@
+import type { PathsFragment } from './types.js';
+
+export const credentialExportPaths: PathsFragment = {
+  '/api/credentials/{id}/export': {
+    get: {
+      tags: ['Credentials'],
+      summary: 'Export a credential as JSON, PDF, or a verification QR code',
+      parameters: [
+        { name: 'id', in: 'path', required: true, schema: { type: 'integer', minimum: 1 } },
+        { name: 'format', in: 'query', schema: { type: 'string', enum: ['json', 'pdf', 'qrcode'], default: 'json' } },
+      ],
+      responses: {
+        '200': {
+          description: 'The export. Content-Type depends on `format`.',
+          content: {
+            'application/json': { schema: { type: 'object', properties: { credential: { $ref: '#/components/schemas/Credential' }, verification_url: { type: 'string', format: 'uri' }, exported_at: { type: 'string', format: 'date-time' } } } },
+            'application/pdf': { schema: { type: 'string', format: 'binary' } },
+            'image/png': { schema: { type: 'string', format: 'binary' } },
+          },
+        },
+        '400': { description: 'Invalid credential id or format.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '404': { description: 'Credential not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/credentials.ts
+++ b/api-server/src/openapi/paths/credentials.ts
@@ -1,0 +1,185 @@
+import type { PathsFragment } from './types.js';
+
+export const credentialsPaths: PathsFragment = {
+  '/api/credentials/search': {
+    get: {
+      tags: ['Credentials'],
+      summary: 'Advanced credential search',
+      description:
+        'Full-text search, faceting, ranking, deduplication and cursor-based pagination. ' +
+        'Also supports per-field operators (`attestation_count[gte]=2`, `issuer[regex]=BANK.*`) ' +
+        'and nested boolean combinations via `filter[and]`/`filter[or]`/`filter[not]`.',
+      parameters: [
+        { name: 'q', in: 'query', schema: { type: 'string' }, description: 'Full-text search query.' },
+        { name: 'type', in: 'query', schema: { type: 'array', items: { type: 'integer' } }, style: 'form', explode: true, description: 'Credential type; repeatable.' },
+        { name: 'issuer', in: 'query', schema: { type: 'array', items: { type: 'string' } }, style: 'form', explode: true },
+        { name: 'issuer_type', in: 'query', schema: { type: 'array', items: { type: 'string' } }, style: 'form', explode: true },
+        { name: 'subject', in: 'query', schema: { type: 'string' } },
+        { name: 'status', in: 'query', schema: { type: 'string', enum: ['active', 'revoked', 'suspended'] } },
+        { name: 'jurisdiction', in: 'query', schema: { type: 'array', items: { type: 'string' } }, style: 'form', explode: true, description: 'ISO 3166 or supranational code; hierarchical (US matches US-CA, EU matches EU members).' },
+        { name: 'attestation_count_min', in: 'query', schema: { type: 'integer' } },
+        { name: 'attestation_count_max', in: 'query', schema: { type: 'integer' } },
+        { name: 'created_after', in: 'query', schema: { type: 'string', format: 'date-time' } },
+        { name: 'created_before', in: 'query', schema: { type: 'string', format: 'date-time' } },
+        { name: 'expires_after', in: 'query', schema: { type: 'string', format: 'date-time' } },
+        { name: 'expires_before', in: 'query', schema: { type: 'string', format: 'date-time' } },
+        { name: 'deduplicate', in: 'query', schema: { type: 'boolean' }, description: 'Collapse same subject+issuer credentials to the highest version.' },
+        { name: 'include_versions', in: 'query', schema: { type: 'boolean' } },
+        { name: 'include_score', in: 'query', schema: { type: 'boolean' } },
+        { name: 'cursor', in: 'query', schema: { type: 'string' } },
+        { name: 'limit', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 100, default: 20 } },
+        { name: 'sort_by', in: 'query', schema: { type: 'string' }, description: 'Comma-separated: id|type|relevance|created_at|updated_at|recency|reputation.' },
+        { name: 'sort_order', in: 'query', schema: { type: 'string', enum: ['asc', 'desc'] } },
+        { name: 'facets', in: 'query', schema: { type: 'string' }, description: 'Comma-separated facet names.' },
+      ],
+      responses: {
+        '200': {
+          description: 'Search results with facets and pagination.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: { type: 'array', items: { $ref: '#/components/schemas/Credential' } },
+                  facets: { type: 'object', additionalProperties: true },
+                  pagination: { $ref: '#/components/schemas/Pagination' },
+                  query_info: { type: 'object', additionalProperties: true },
+                  index_version: { type: 'integer' },
+                },
+              },
+            },
+          },
+        },
+        '400': { description: 'Invalid limit, sort_by, or sort_order.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/credentials/search/rebuild-index-async': {
+    post: {
+      tags: ['Credentials'],
+      summary: 'Kick off a background full re-index from chain',
+      description: 'The current index stays live and queryable for the whole rebuild; swapped in atomically on completion.',
+      responses: {
+        '202': { description: 'Rebuild started.', content: { 'application/json': { schema: { type: 'object', properties: { rebuild_id: { type: 'string' }, status: { type: 'string' }, estimated_duration_ms: { type: 'number' } } } } } },
+        '409': { description: 'A rebuild is already in progress.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/credentials/search/rebuild-status/{id}': {
+    get: {
+      tags: ['Credentials'],
+      summary: 'Get the status of a background re-index job',
+      parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+      responses: {
+        '200': { description: 'Job status.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '404': { description: 'Not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/credentials/search/rebuild-history': {
+    get: {
+      tags: ['Credentials'],
+      summary: 'List past re-index jobs',
+      responses: { '200': { description: 'Rebuild history.', content: { 'application/json': { schema: { type: 'object', properties: { rebuilds: { type: 'array', items: { type: 'object', additionalProperties: true } } } } } } } },
+    },
+  },
+  '/api/credentials/verify-batch': {
+    post: {
+      tags: ['Credentials'],
+      summary: 'Batch-check attestation status against a slice',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                credential_ids: { type: 'array', items: { type: 'integer', minimum: 1 }, minItems: 1, maxItems: 50 },
+                slice_id: { type: 'integer', minimum: 1 },
+              },
+              required: ['credential_ids', 'slice_id'],
+            },
+          },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Per-credential attestation results.',
+          content: {
+            'application/json': {
+              schema: { type: 'object', properties: { results: { type: 'array', items: { type: 'object', properties: { credential_id: { type: 'integer' }, attested: { type: 'boolean' }, error: { type: ['string', 'null'] } } } } } },
+            },
+          },
+        },
+        '400': { description: 'Invalid credential_ids or slice_id.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/credentials/search/refresh-index': {
+    post: {
+      tags: ['Credentials'],
+      summary: 'Force a synchronous refresh of the search index from chain',
+      responses: {
+        '200': { description: 'Refreshed.', content: { 'application/json': { schema: { type: 'object', properties: { success: { type: 'boolean' }, index_size: { type: 'integer' }, cache_size: { type: 'integer' }, last_indexed: { type: ['string', 'null'], format: 'date-time' } } } } } },
+      },
+    },
+  },
+  '/api/credentials/search/index-stats': {
+    get: {
+      tags: ['Credentials'],
+      summary: 'Get search index and metadata-hash cache statistics',
+      responses: { '200': { description: 'Stats.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } } },
+    },
+  },
+  '/api/credentials/crl': {
+    get: {
+      tags: ['Credentials'],
+      summary: 'Export the revocation list (CRL)',
+      description: 'X.509-compatible JSON structure; `format=pem` wraps it as base64 in a PEM envelope.',
+      parameters: [
+        { name: 'issuer', in: 'query', schema: { type: 'string', default: 'QuorumProof' } },
+        { name: 'format', in: 'query', schema: { type: 'string', enum: ['json', 'pem'], default: 'json' } },
+      ],
+      responses: {
+        '200': {
+          description: 'The CRL.',
+          content: {
+            'application/json': { schema: { type: 'object', properties: { version: { type: 'integer' }, issuer: { type: 'string' }, thisUpdate: { type: 'string', format: 'date-time' }, nextUpdate: { type: 'string', format: 'date-time' }, revokedCertificates: { type: 'array', items: { type: 'object', additionalProperties: true } }, totalRevoked: { type: 'integer' } } } },
+            'text/plain': { schema: { type: 'string', description: 'PEM-encoded CRL when format=pem.' } },
+          },
+        },
+        '400': { description: 'Invalid format.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/credentials/shards/stats': {
+    get: {
+      tags: ['Credentials'],
+      summary: 'Get sharded-storage distribution statistics',
+      responses: { '200': { description: 'Shard stats.', content: { 'application/json': { schema: { type: 'object', properties: { shard_count: { type: 'integer' }, total_credentials: { type: 'integer' }, shards: { type: 'array', items: { type: 'object', additionalProperties: true } } } } } } } },
+    },
+  },
+  '/api/credentials/shards/by-subject': {
+    get: {
+      tags: ['Credentials'],
+      summary: "Fetch a subject's credentials directly from its shard",
+      parameters: [{ name: 'subject', in: 'query', required: true, schema: { type: 'string' } }],
+      responses: {
+        '200': { description: 'Credentials in the subject shard.', content: { 'application/json': { schema: { type: 'object', properties: { subject: { type: 'string' }, shard_index: { type: 'integer' }, count: { type: 'integer' }, credentials: { type: 'array', items: { $ref: '#/components/schemas/Credential' } } } } } } },
+        '400': { description: 'Missing subject.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/credentials/{id}/metadata-hash': {
+    get: {
+      tags: ['Credentials'],
+      summary: 'Get the metadata hash for a credential (cached)',
+      parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer', minimum: 1 } }],
+      responses: {
+        '200': { description: 'Metadata hash.', content: { 'application/json': { schema: { type: 'object', properties: { credential_id: { type: 'integer' }, metadata_hash: { type: 'string' }, cached: { type: 'boolean' } } } } } },
+        '400': { description: 'Invalid credential id.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '404': { description: 'Credential not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/dashboard.ts
+++ b/api-server/src/openapi/paths/dashboard.ts
@@ -1,0 +1,153 @@
+import type { PathsFragment } from './types.js';
+
+const unauthorized = { description: 'No authenticated user address on the request.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } };
+
+export const dashboardPaths: PathsFragment = {
+  '/api/me/credentials': {
+    get: {
+      tags: ['Dashboard'],
+      summary: "List the authenticated user's credentials",
+      responses: {
+        '200': {
+          description: 'Credential summary.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  credentials: { type: 'array', items: { type: 'object', additionalProperties: true } },
+                  total: { type: 'integer' },
+                  active_count: { type: 'integer' },
+                  revoked_count: { type: 'integer' },
+                  suspended_count: { type: 'integer' },
+                  expiring_soon: { type: 'integer', description: 'Active, non-revoked credentials expiring within 30 days.' },
+                },
+              },
+            },
+          },
+        },
+        '401': unauthorized,
+      },
+    },
+  },
+  '/api/me/credentials/{id}': {
+    get: {
+      tags: ['Dashboard'],
+      summary: 'Get full detail for one of the authenticated user’s credentials',
+      parameters: [
+        { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+        { name: 'include_history', in: 'query', schema: { type: 'boolean' } },
+        { name: 'include_disputes', in: 'query', schema: { type: 'boolean' } },
+      ],
+      responses: {
+        '200': { description: 'Credential detail with attestations, and optionally amendment/dispute history.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '401': unauthorized,
+        '403': { description: 'Credential does not belong to the authenticated user.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/me/disputes': {
+    get: {
+      tags: ['Dashboard'],
+      summary: "List disputes against the user's credentials",
+      parameters: [
+        { name: 'status', in: 'query', schema: { type: 'string', enum: ['pending', 'resolved', 'rejected'] } },
+        { name: 'sort_by', in: 'query', schema: { type: 'string', enum: ['created_at', 'status'], default: 'created_at' } },
+        { name: 'limit', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 100, default: 50 } },
+      ],
+      responses: {
+        '200': { description: 'Disputes.', content: { 'application/json': { schema: { type: 'object', properties: { disputes: { type: 'array', items: { type: 'object', additionalProperties: true } }, total: { type: 'integer' }, pending_count: { type: 'integer' }, resolved_count: { type: 'integer' } } } } } },
+        '401': unauthorized,
+      },
+    },
+    post: {
+      tags: ['Dashboard'],
+      summary: 'Create a dispute against a credential',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: { credential_id: { type: 'string' }, reason: { type: 'string' }, evidence_hash: { type: 'string' } },
+              required: ['credential_id', 'reason'],
+            },
+          },
+        },
+      },
+      responses: {
+        '201': { description: 'Created.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Missing credential_id or reason.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '401': unauthorized,
+      },
+    },
+  },
+  '/api/me/access-log': {
+    get: {
+      tags: ['Dashboard'],
+      summary: "Get the access/audit log for the user's credentials",
+      parameters: [
+        { name: 'credential_id', in: 'query', schema: { type: 'string' } },
+        { name: 'limit', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 500, default: 100 } },
+        { name: 'offset', in: 'query', schema: { type: 'integer', minimum: 0, default: 0 } },
+        { name: 'from', in: 'query', schema: { type: 'string', format: 'date-time' } },
+        { name: 'to', in: 'query', schema: { type: 'string', format: 'date-time' } },
+      ],
+      responses: {
+        '200': { description: 'Access log entries.', content: { 'application/json': { schema: { type: 'object', properties: { access_logs: { type: 'array', items: { type: 'object', additionalProperties: true } }, total: { type: 'integer' } } } } } },
+        '401': unauthorized,
+      },
+    },
+    post: {
+      tags: ['Dashboard'],
+      summary: 'Log a credential access event',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                credential_id: { type: 'string' },
+                accessed_by: { type: 'string' },
+                reason: { type: 'string' },
+                duration_seconds: { type: 'number' },
+              },
+              required: ['credential_id', 'accessed_by', 'reason'],
+            },
+          },
+        },
+      },
+      responses: {
+        '201': { description: 'Logged.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Missing required fields.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/me/summary': {
+    get: {
+      tags: ['Dashboard'],
+      summary: 'Get a quick dashboard summary',
+      responses: {
+        '200': {
+          description: 'Summary counts.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  total_credentials: { type: 'integer' },
+                  active_credentials: { type: 'integer' },
+                  pending_disputes: { type: 'integer' },
+                  credentials_expiring_30_days: { type: 'integer' },
+                  last_access_at: { type: ['string', 'null'], format: 'date-time' },
+                },
+              },
+            },
+          },
+        },
+        '401': unauthorized,
+      },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/gdpr.ts
+++ b/api-server/src/openapi/paths/gdpr.ts
@@ -1,0 +1,124 @@
+import type { PathsFragment } from './types.js';
+
+export const gdprPaths: PathsFragment = {
+  '/api/gdpr/personal-data': {
+    post: {
+      tags: ['GDPR'],
+      summary: "Store a credential's personal data (encrypted, off-chain)",
+      description:
+        'Encrypts `personalData` with a per-credential key and returns a sha256 commitment ' +
+        'the issuer should anchor on-chain. See docs/crypto-shredding-architecture.md.',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                credentialId: { type: 'integer', minimum: 1 },
+                subject: { type: 'string', description: 'Stellar address; must match the on-chain credential subject.' },
+                personalData: {},
+              },
+              required: ['credentialId', 'subject', 'personalData'],
+            },
+          },
+        },
+      },
+      responses: {
+        '201': { description: 'Stored.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Invalid input or subject mismatch.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '404': { description: 'Credential not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '410': { description: 'Key already destroyed (erased).', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/gdpr/personal-data/{credentialId}/status': {
+    get: {
+      tags: ['GDPR'],
+      summary: 'Get vault status for a credential (no decryption)',
+      parameters: [{ name: 'credentialId', in: 'path', required: true, schema: { type: 'integer', minimum: 1 } }],
+      responses: {
+        '200': { description: 'Status.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Invalid credentialId.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/gdpr/personal-data/{credentialId}': {
+    get: {
+      tags: ['GDPR'],
+      summary: 'Retrieve (decrypted) personal data for a credential',
+      parameters: [{ name: 'credentialId', in: 'path', required: true, schema: { type: 'integer', minimum: 1 } }],
+      responses: {
+        '200': { description: 'Decrypted record.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Invalid credentialId.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '404': { description: 'No personal data stored for this credential.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '410': { description: 'The decryption key has been erased (right-to-erasure completed).', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/gdpr/request': {
+    post: {
+      tags: ['GDPR'],
+      summary: 'Submit a right-to-erasure request',
+      description:
+        'Completes immediately (key destroyed) if the credential has no current attestors; ' +
+        'otherwise waits for every current attestor to POST /api/gdpr/consent.',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: { type: 'object', properties: { credentialId: { type: 'integer', minimum: 1 } }, required: ['credentialId'] },
+          },
+        },
+      },
+      responses: {
+        '201': { description: 'Request created.', content: { 'application/json': { schema: { $ref: '#/components/schemas/GdprRequest' } } } },
+        '400': { description: 'Invalid credentialId.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '404': { description: 'Credential not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/gdpr/request/{requestId}': {
+    get: {
+      tags: ['GDPR'],
+      summary: 'Get a GDPR request by id',
+      parameters: [{ name: 'requestId', in: 'path', required: true, schema: { type: 'string' } }],
+      responses: {
+        '200': { description: 'The request.', content: { 'application/json': { schema: { $ref: '#/components/schemas/GdprRequest' } } } },
+        '404': { description: 'Not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/gdpr/consent': {
+    post: {
+      tags: ['GDPR'],
+      summary: 'Attestor consent to a pending erasure request',
+      description:
+        'The signer must be a current on-chain attestor for the credential and submit an ' +
+        'ed25519 signature over the canonical consent message. When the last required ' +
+        "consent lands, the credential's decryption key is destroyed.",
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                requestId: { type: 'string' },
+                attestorAddress: { type: 'string' },
+                signature: { type: 'string', description: 'Hex-encoded ed25519 signature.' },
+              },
+              required: ['requestId', 'attestorAddress', 'signature'],
+            },
+          },
+        },
+      },
+      responses: {
+        '200': { description: 'Consent recorded.', content: { 'application/json': { schema: { $ref: '#/components/schemas/GdprRequest' } } } },
+        '400': { description: 'Invalid request, or request not pending.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '401': { description: 'Invalid attestor signature.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '403': { description: 'attestorAddress is not a current attestor for this credential.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/health.ts
+++ b/api-server/src/openapi/paths/health.ts
@@ -1,0 +1,40 @@
+import type { PathsFragment } from './types.js';
+
+export const healthPaths: PathsFragment = {
+  '/health': {
+    get: {
+      tags: ['Health'],
+      summary: 'Overall health status',
+      description: '200 when healthy or degraded, 503 when unhealthy.',
+      responses: {
+        '200': {
+          description: 'Healthy or degraded.',
+          content: { 'application/json': { schema: { $ref: '#/components/schemas/HealthStatus' } } },
+        },
+        '503': {
+          description: 'Unhealthy.',
+          content: { 'application/json': { schema: { $ref: '#/components/schemas/HealthStatus' } } },
+        },
+      },
+    },
+  },
+  '/health/ready': {
+    get: {
+      tags: ['Health'],
+      summary: 'Readiness probe',
+      description: 'Returns 503 while dependencies (DB, RPC, etc.) are not yet ready to serve traffic.',
+      responses: {
+        '200': { description: 'Ready.' },
+        '503': { description: 'Not ready.' },
+      },
+    },
+  },
+  '/health/live': {
+    get: {
+      tags: ['Health'],
+      summary: 'Liveness probe',
+      description: 'Always 200 while the process is running; used by orchestrators to detect a hung process.',
+      responses: { '200': { description: 'Alive.' } },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/issuer.ts
+++ b/api-server/src/openapi/paths/issuer.ts
@@ -1,0 +1,18 @@
+import type { PathsFragment } from './types.js';
+
+export const issuerPaths: PathsFragment = {
+  '/api/issuer/{address}/metrics': {
+    get: {
+      tags: ['Issuer'],
+      summary: 'Get issuance metrics for an issuer over a period',
+      parameters: [
+        { name: 'address', in: 'path', required: true, schema: { type: 'string' } },
+        { name: 'period_days', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 365, default: 30 } },
+      ],
+      responses: {
+        '200': { description: 'Metrics.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Invalid period_days.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/issuerAnalytics.ts
+++ b/api-server/src/openapi/paths/issuerAnalytics.ts
@@ -1,0 +1,42 @@
+import type { PathsFragment } from './types.js';
+
+const rangeParam = { name: 'range', in: 'query' as const, schema: { type: 'string' as const, enum: ['7d', '30d', '90d'], default: '30d' } };
+
+export const issuerAnalyticsPaths: PathsFragment = {
+  '/api/analytics/credentials': {
+    get: {
+      tags: ['Analytics'],
+      summary: 'Get per-issuer credential issuance breakdown',
+      parameters: [
+        { name: 'issuer', in: 'query', required: true, schema: { type: 'string' } },
+        rangeParam,
+      ],
+      responses: {
+        '200': { description: 'Issuance totals, breakdown by type, expiry distribution.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Missing issuer or invalid range.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/analytics/verifications': {
+    get: {
+      tags: ['Analytics'],
+      summary: 'Get verification counts by claim type and verifier',
+      parameters: [rangeParam],
+      responses: {
+        '200': { description: 'Verification distribution.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Invalid range.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/analytics/disputes': {
+    get: {
+      tags: ['Analytics'],
+      summary: 'Get dispute rate and resolution stats',
+      parameters: [{ name: 'issuer', in: 'query', schema: { type: 'string' } }, rangeParam],
+      responses: {
+        '200': { description: 'Dispute stats.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Invalid range.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/metrics.ts
+++ b/api-server/src/openapi/paths/metrics.ts
@@ -1,0 +1,59 @@
+import type { PathsFragment } from './types.js';
+
+const prometheusText = {
+  '200': {
+    description: 'Prometheus text-exposition format (version 0.0.4).',
+    content: { 'text/plain': { schema: { type: 'string' as const } } },
+  },
+};
+
+export const metricsPaths: PathsFragment = {
+  '/ws/metrics': {
+    get: {
+      tags: ['Metrics'],
+      summary: 'Get WebSocket connection/subscription metrics (JSON)',
+      responses: { '200': { description: 'Metrics.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } } },
+    },
+  },
+  '/metrics/ws': {
+    get: {
+      tags: ['Metrics'],
+      summary: 'WebSocket metrics in Prometheus format',
+      description: 'Tagged with this instance id; scrape every replica and aggregate for cluster-wide totals.',
+      responses: prometheusText,
+    },
+  },
+  '/metrics/rpc': {
+    get: {
+      tags: ['Metrics'],
+      summary: 'Soroban RPC circuit-breaker metrics in Prometheus format',
+      responses: prometheusText,
+    },
+  },
+  '/rpc/circuit-breaker': {
+    get: {
+      tags: ['Metrics'],
+      summary: 'Soroban RPC circuit-breaker state (JSON)',
+      responses: { '200': { description: 'Circuit breaker state.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } } },
+    },
+  },
+  '/metrics/events': {
+    get: {
+      tags: ['Metrics'],
+      summary: 'Critical on-chain event monitoring metrics in Prometheus format',
+      responses: prometheusText,
+    },
+  },
+  '/events/critical/recent': {
+    get: {
+      tags: ['Metrics'],
+      summary: 'Recent critical on-chain events and their metrics (JSON)',
+      responses: {
+        '200': {
+          description: 'Recent events.',
+          content: { 'application/json': { schema: { type: 'object', properties: { metrics: { type: 'object', additionalProperties: true }, events: { type: 'array', items: { type: 'object', additionalProperties: true } } } } } },
+        },
+      },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/notifications.ts
+++ b/api-server/src/openapi/paths/notifications.ts
@@ -1,0 +1,56 @@
+import type { PathsFragment } from './types.js';
+
+export const notificationsPaths: PathsFragment = {
+  '/api/notifications/preferences': {
+    put: {
+      tags: ['Notifications'],
+      summary: 'Set notification preferences for an address',
+      requestBody: {
+        required: true,
+        content: { 'application/json': { schema: { $ref: '#/components/schemas/NotificationPreferencesRequest' } } },
+      },
+      responses: {
+        '200': { description: 'Saved.', content: { 'application/json': { schema: { type: 'object', properties: { success: { type: 'boolean' } } } } } },
+        '400': { description: 'email/phone required for the enabled channel, or invalid body.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ValidationErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/notifications/preferences/{address}': {
+    get: {
+      tags: ['Notifications'],
+      summary: 'Get notification preferences for an address',
+      parameters: [{ name: 'address', in: 'path', required: true, schema: { type: 'string' } }],
+      responses: {
+        '200': { description: 'Preferences.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '404': { description: 'No preferences found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/notifications/history': {
+    get: {
+      tags: ['Notifications'],
+      summary: 'Get notification delivery history',
+      parameters: [{ name: 'address', in: 'query', schema: { type: 'string' } }],
+      responses: {
+        '200': { description: 'History entries.', content: { 'application/json': { schema: { type: 'object', properties: { data: { type: 'array', items: { type: 'object', additionalProperties: true } } } } } } },
+      },
+    },
+  },
+  '/api/notifications/send': {
+    post: {
+      tags: ['Notifications'],
+      summary: 'Send (dispatch) a notification and broadcast over WebSocket',
+      requestBody: {
+        required: true,
+        content: { 'application/json': { schema: { $ref: '#/components/schemas/NotificationSendRequest' } } },
+      },
+      responses: {
+        '200': {
+          description: 'Dispatched.',
+          content: { 'application/json': { schema: { type: 'object', properties: { success: { type: 'boolean' }, ws_recipients: { type: 'integer' } } } } },
+        },
+        '400': { description: 'Invalid body.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ValidationErrorResponse' } } } },
+      },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/oauth2.ts
+++ b/api-server/src/openapi/paths/oauth2.ts
@@ -1,0 +1,59 @@
+import type { PathsFragment } from './types.js';
+
+export const oauth2Paths: PathsFragment = {
+  '/auth/oauth2/{provider}/authorize': {
+    get: {
+      tags: ['OAuth2'],
+      summary: "Build the provider's consent-screen URL",
+      parameters: [{ name: 'provider', in: 'path', required: true, schema: { type: 'string', enum: ['google', 'microsoft', 'github'] } }],
+      responses: {
+        '200': {
+          description: 'Authorization URL and state.',
+          content: { 'application/json': { schema: { type: 'object', properties: { provider: { type: 'string' }, url: { type: 'string', format: 'uri' }, state: { type: 'string' } } } } },
+        },
+        '400': { description: 'Unsupported provider.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/auth/oauth2/callback': {
+    post: {
+      tags: ['OAuth2'],
+      summary: 'Exchange an auth code and link the identity to a Stellar address',
+      description:
+        '`signature` must be an ed25519 signature (by `stellarAddress`) over the canonical ' +
+        'link message, proving control of the address before it is linked to the OAuth2 identity.',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                provider: { type: 'string', enum: ['google', 'microsoft', 'github'] },
+                code: { type: 'string' },
+                stellarAddress: { type: 'string' },
+                signature: { type: 'string', description: 'Hex-encoded 64-byte ed25519 signature.' },
+              },
+              required: ['provider', 'code', 'stellarAddress', 'signature'],
+            },
+          },
+        },
+      },
+      responses: {
+        '200': { description: 'Identity linked.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Missing/invalid field.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '401': { description: 'OAuth2 exchange failed, or signature invalid.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/auth/oauth2/identities/{stellarAddress}': {
+    get: {
+      tags: ['OAuth2'],
+      summary: 'List OAuth2 identities linked to a Stellar address',
+      parameters: [{ name: 'stellarAddress', in: 'path', required: true, schema: { type: 'string' } }],
+      responses: {
+        '200': { description: 'Linked identities.', content: { 'application/json': { schema: { type: 'object', properties: { data: { type: 'array', items: { type: 'object', additionalProperties: true } } } } } } },
+      },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/privilegeEscalation.ts
+++ b/api-server/src/openapi/paths/privilegeEscalation.ts
@@ -1,0 +1,116 @@
+import type { PathsFragment } from './types.js';
+
+const internalError = { description: 'Internal server error.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } };
+
+export const privilegeEscalationPaths: PathsFragment = {
+  '/api/admin/privilege-escalation/mfa-challenge': {
+    post: {
+      tags: ['Privilege Escalation'],
+      summary: 'Request an MFA challenge for a privileged action',
+      requestBody: {
+        required: true,
+        content: { 'application/json': { schema: { type: 'object', properties: { userId: { type: 'string' } }, required: ['userId'] } } },
+      },
+      responses: {
+        '200': { description: 'Challenge issued.', content: { 'application/json': { schema: { type: 'object', properties: { userId: { type: 'string' }, expiresAt: { type: 'string', format: 'date-time' }, message: { type: 'string' } } } } } },
+        '400': { description: 'Missing userId.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '500': internalError,
+      },
+    },
+  },
+  '/api/admin/privilege-escalation/verify-mfa': {
+    post: {
+      tags: ['Privilege Escalation'],
+      summary: 'Verify an MFA code for a pending escalation challenge',
+      requestBody: {
+        required: true,
+        content: { 'application/json': { schema: { type: 'object', properties: { userId: { type: 'string' }, code: { type: 'string' } }, required: ['userId', 'code'] } } },
+      },
+      responses: {
+        '200': { description: 'Verified.', content: { 'application/json': { schema: { type: 'object', properties: { verified: { type: 'boolean' }, message: { type: 'string' } } } } } },
+        '400': { description: 'Missing userId or code.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '401': { description: 'Invalid or expired MFA code.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '500': internalError,
+      },
+    },
+  },
+  '/api/admin/privilege-escalation/request': {
+    post: {
+      tags: ['Privilege Escalation'],
+      summary: 'Submit a privilege change request',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: { userId: { type: 'string' }, newRole: { type: 'string' }, reason: { type: 'string' }, approvers: { type: 'array', items: { type: 'string' } } },
+              required: ['userId', 'newRole'],
+            },
+          },
+        },
+      },
+      responses: {
+        '200': { description: 'Submitted.', content: { 'application/json': { schema: { type: 'object', properties: { requestId: { type: 'string' }, status: { type: 'string' }, message: { type: 'string' } } } } } },
+        '400': { description: 'Missing userId or newRole.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '500': internalError,
+      },
+    },
+  },
+  '/api/admin/privilege-escalation/approve': {
+    post: {
+      tags: ['Privilege Escalation'],
+      summary: 'Approve a pending privilege change request',
+      requestBody: {
+        required: true,
+        content: { 'application/json': { schema: { type: 'object', properties: { requestId: { type: 'string' }, approverId: { type: 'string' } }, required: ['requestId', 'approverId'] } } },
+      },
+      responses: {
+        '200': { description: 'Approved.', content: { 'application/json': { schema: { type: 'object', properties: { approved: { type: 'boolean' }, message: { type: 'string' } } } } } },
+        '400': { description: 'Missing requestId or approverId.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '404': { description: 'Request not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '500': internalError,
+      },
+    },
+  },
+  '/api/admin/privilege-escalation/reject': {
+    post: {
+      tags: ['Privilege Escalation'],
+      summary: 'Reject a pending privilege change request',
+      requestBody: {
+        required: true,
+        content: { 'application/json': { schema: { type: 'object', properties: { requestId: { type: 'string' }, approverId: { type: 'string' }, reason: { type: 'string' } }, required: ['requestId', 'approverId'] } } },
+      },
+      responses: {
+        '200': { description: 'Rejected.', content: { 'application/json': { schema: { type: 'object', properties: { rejected: { type: 'boolean' }, message: { type: 'string' } } } } } },
+        '400': { description: 'Missing requestId or approverId.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '404': { description: 'Request not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '500': internalError,
+      },
+    },
+  },
+  '/api/admin/privilege-escalation/audit-log': {
+    get: {
+      tags: ['Privilege Escalation'],
+      summary: 'Get the privilege-escalation audit log',
+      parameters: [
+        { name: 'userId', in: 'query', schema: { type: 'string' } },
+        { name: 'limit', in: 'query', schema: { type: 'integer', default: 100 } },
+      ],
+      responses: {
+        '200': { description: 'Log entries.', content: { 'application/json': { schema: { type: 'object', properties: { total: { type: 'integer' }, logs: { type: 'array', items: { type: 'object', additionalProperties: true } } } } } } },
+        '500': internalError,
+      },
+    },
+  },
+  '/api/admin/privilege-escalation/pending': {
+    get: {
+      tags: ['Privilege Escalation'],
+      summary: 'List pending privilege change approvals',
+      responses: {
+        '200': { description: 'Pending requests.', content: { 'application/json': { schema: { type: 'object', properties: { total: { type: 'integer' }, requests: { type: 'array', items: { type: 'object', additionalProperties: true } } } } } } },
+        '500': internalError,
+      },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/recovery.ts
+++ b/api-server/src/openapi/paths/recovery.ts
@@ -1,0 +1,124 @@
+import type { PathsFragment } from './types.js';
+
+const notFound = { description: 'Recovery request not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } };
+const badRequest = { description: 'Missing or invalid field.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } };
+
+export const recoveryPaths: PathsFragment = {
+  '/api/recovery/request': {
+    post: {
+      tags: ['Recovery'],
+      summary: 'Start a wallet-recovery request',
+      description: 'Sends an OTP to the contact channel; the request then awaits identity verification and attestor approval.',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                credentialId: { type: 'string' },
+                lostWallet: { type: 'string', pattern: '^G[A-Z2-7]{55}$' },
+                newWallet: { type: 'string', pattern: '^G[A-Z2-7]{55}$' },
+                contactType: { type: 'string', enum: ['email', 'phone'] },
+                contactValue: { type: 'string' },
+              },
+              required: ['credentialId', 'lostWallet', 'newWallet', 'contactType', 'contactValue'],
+            },
+          },
+        },
+      },
+      responses: {
+        '201': { description: 'Request created; OTP sent.', content: { 'application/json': { schema: { type: 'object', properties: { requestId: { type: 'string' }, message: { type: 'string' } } } } } },
+        '400': badRequest,
+      },
+    },
+  },
+  '/api/recovery/verify-otp': {
+    post: {
+      tags: ['Recovery'],
+      summary: 'Verify the OTP for a recovery request',
+      requestBody: {
+        required: true,
+        content: { 'application/json': { schema: { type: 'object', properties: { requestId: { type: 'string' }, code: { type: 'string' } }, required: ['requestId', 'code'] } } },
+      },
+      responses: {
+        '200': { description: 'Verified; now pending attestor approval.', content: { 'application/json': { schema: { type: 'object', properties: { success: { type: 'boolean' }, message: { type: 'string' } } } } } },
+        '400': { description: 'Invalid code.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '404': notFound,
+        '409': { description: 'Request is not awaiting verification.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '410': { description: 'Code expired.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '429': { description: 'Too many attempts.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/recovery/resend-otp': {
+    post: {
+      tags: ['Recovery'],
+      summary: 'Resend the OTP for a pending recovery request',
+      requestBody: {
+        required: true,
+        content: { 'application/json': { schema: { type: 'object', properties: { requestId: { type: 'string' } }, required: ['requestId'] } } },
+      },
+      responses: {
+        '200': { description: 'Resent.', content: { 'application/json': { schema: { type: 'object', properties: { message: { type: 'string' } } } } } },
+        '400': badRequest,
+        '404': notFound,
+        '409': { description: 'Request is not awaiting verification.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/recovery/status/{requestId}': {
+    get: {
+      tags: ['Recovery'],
+      summary: 'Get the status of a recovery request',
+      parameters: [{ name: 'requestId', in: 'path', required: true, schema: { type: 'string' } }],
+      responses: {
+        '200': { description: 'Request status (contact value redacted).', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '404': notFound,
+      },
+    },
+  },
+  '/api/recovery/pending': {
+    get: {
+      tags: ['Recovery'],
+      summary: 'List recovery requests pending attestor approval',
+      parameters: [{ name: 'attestor', in: 'query', required: true, schema: { type: 'string' } }],
+      responses: {
+        '200': { description: 'Pending requests.', content: { 'application/json': { schema: { type: 'object', properties: { attestor: { type: 'string' }, items: { type: 'array', items: { type: 'object', additionalProperties: true } }, total: { type: 'integer' } } } } } },
+        '400': badRequest,
+      },
+    },
+  },
+  '/api/recovery/approve': {
+    post: {
+      tags: ['Recovery'],
+      summary: 'Approve a pending recovery request',
+      requestBody: {
+        required: true,
+        content: { 'application/json': { schema: { type: 'object', properties: { requestId: { type: 'string' }, attestor: { type: 'string' } }, required: ['requestId', 'attestor'] } } },
+      },
+      responses: {
+        '200': { description: 'Approved; re-issuance initiated.', content: { 'application/json': { schema: { type: 'object', properties: { success: { type: 'boolean' }, message: { type: 'string' } } } } } },
+        '400': badRequest,
+        '404': notFound,
+        '409': { description: 'Request is not in pending_approval status.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/recovery/reject': {
+    post: {
+      tags: ['Recovery'],
+      summary: 'Reject a pending recovery request',
+      requestBody: {
+        required: true,
+        content: { 'application/json': { schema: { type: 'object', properties: { requestId: { type: 'string' }, attestor: { type: 'string' }, reason: { type: 'string' } }, required: ['requestId', 'attestor'] } } },
+      },
+      responses: {
+        '200': { description: 'Rejected.', content: { 'application/json': { schema: { type: 'object', properties: { success: { type: 'boolean' }, message: { type: 'string' } } } } } },
+        '400': badRequest,
+        '404': notFound,
+        '409': { description: 'Request is not in pending_approval status.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/shareLinks.ts
+++ b/api-server/src/openapi/paths/shareLinks.ts
@@ -1,0 +1,84 @@
+import type { PathsFragment } from './types.js';
+
+export const shareLinksPaths: PathsFragment = {
+  '/api/credentials/{id}/share': {
+    post: {
+      tags: ['Share Links'],
+      summary: 'Create a time-limited share link for a credential',
+      parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer', minimum: 1 } }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                subject: { type: 'string', description: 'Stellar address of the credential holder.' },
+                expiry_hours: { type: 'integer', minimum: 1, maximum: 8760 },
+                permission: { type: 'string', enum: ['view_only', 'download'] },
+                password: { type: 'string', description: 'Optional; omit for a public link.' },
+              },
+              required: ['subject', 'expiry_hours', 'permission'],
+            },
+          },
+        },
+      },
+      responses: {
+        '201': {
+          description: 'Created.',
+          content: { 'application/json': { schema: { type: 'object', properties: { token: { type: 'string' }, expires_at: { type: 'integer' }, permission: { type: 'string' }, password_protected: { type: 'boolean' }, credential_id: { type: 'integer' } } } } },
+        },
+        '400': { description: 'Missing/invalid fields.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '403': { description: 'Only the credential holder can create share links.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '404': { description: 'Credential not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/credentials/share/validate': {
+    post: {
+      tags: ['Share Links'],
+      summary: 'Validate / redeem a share token',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: { type: 'object', properties: { token: { type: 'string', description: '32-char hex.' }, password: { type: 'string' } }, required: ['token'] },
+          },
+        },
+      },
+      responses: {
+        '200': { description: 'Link metadata.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Malformed token.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '403': { description: 'Invalid or missing password.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '410': { description: 'Link expired, revoked, or invalid.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/credentials/share/{token}': {
+    get: {
+      tags: ['Share Links'],
+      summary: 'Inspect share-link metadata (no access enforcement)',
+      parameters: [{ name: 'token', in: 'path', required: true, schema: { type: 'string' } }],
+      responses: {
+        '200': { description: 'Link metadata (password hash redacted).', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '400': { description: 'Malformed token.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '404': { description: 'Not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+    delete: {
+      tags: ['Share Links'],
+      summary: 'Revoke a share link early',
+      parameters: [{ name: 'token', in: 'path', required: true, schema: { type: 'string' } }],
+      requestBody: {
+        required: true,
+        content: { 'application/json': { schema: { type: 'object', properties: { subject: { type: 'string' } }, required: ['subject'] } } },
+      },
+      responses: {
+        '200': { description: 'Revoked.', content: { 'application/json': { schema: { type: 'object', properties: { success: { type: 'boolean' }, message: { type: 'string' } } } } } },
+        '400': { description: 'Missing subject or malformed token.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '403': { description: 'Only the link creator can revoke it.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+        '404': { description: 'Not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/slices.ts
+++ b/api-server/src/openapi/paths/slices.ts
@@ -1,0 +1,42 @@
+import type { PathsFragment } from './types.js';
+
+export const slicesPaths: PathsFragment = {
+  '/api/slices': {
+    get: {
+      tags: ['Slices'],
+      summary: 'List quorum slices (cursor-paginated)',
+      parameters: [
+        { name: 'cursor', in: 'query', schema: { type: 'string' }, description: 'Opaque base64 cursor from a previous response.' },
+        { name: 'limit', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 100, default: 20 } },
+      ],
+      responses: {
+        '200': {
+          description: 'Paginated list of slices.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: { type: 'array', items: { $ref: '#/components/schemas/Slice' } },
+                  pagination: { $ref: '#/components/schemas/Pagination' },
+                },
+              },
+            },
+          },
+        },
+        '400': { description: 'Invalid cursor.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/slices/{id}': {
+    get: {
+      tags: ['Slices'],
+      summary: 'Get a quorum slice by id',
+      parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer', minimum: 1 } }],
+      responses: {
+        '200': { description: 'The slice.', content: { 'application/json': { schema: { $ref: '#/components/schemas/Slice' } } } },
+        '404': { description: 'Slice not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/tracing.ts
+++ b/api-server/src/openapi/paths/tracing.ts
@@ -1,0 +1,47 @@
+import type { PathsFragment } from './types.js';
+
+export const tracingPaths: PathsFragment = {
+  '/api/tracing/trace/{traceId}': {
+    get: {
+      tags: ['Tracing'],
+      summary: 'Get all spans for a trace',
+      parameters: [{ name: 'traceId', in: 'path', required: true, schema: { type: 'string' } }],
+      responses: {
+        '200': { description: 'Spans.', content: { 'application/json': { schema: { type: 'object', properties: { traceId: { type: 'string' }, spanCount: { type: 'integer' }, spans: { type: 'array', items: { type: 'object', additionalProperties: true } } } } } } },
+        '404': { description: 'Trace not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/tracing/span/{traceId}/{spanId}': {
+    get: {
+      tags: ['Tracing'],
+      summary: 'Get a specific span',
+      parameters: [
+        { name: 'traceId', in: 'path', required: true, schema: { type: 'string' } },
+        { name: 'spanId', in: 'path', required: true, schema: { type: 'string' } },
+      ],
+      responses: {
+        '200': { description: 'The span.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '404': { description: 'Span not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/tracing/jaeger/{traceId}': {
+    get: {
+      tags: ['Tracing'],
+      summary: 'Export a trace in Jaeger format',
+      parameters: [{ name: 'traceId', in: 'path', required: true, schema: { type: 'string' } }],
+      responses: {
+        '200': { description: 'Jaeger-formatted trace.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '404': { description: 'Trace not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/tracing/metrics': {
+    get: {
+      tags: ['Tracing'],
+      summary: 'Get distributed-tracing metrics',
+      responses: { '200': { description: 'Metrics.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } } },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/types.ts
+++ b/api-server/src/openapi/paths/types.ts
@@ -1,0 +1,4 @@
+import type { PathItemObject } from 'openapi3-ts/oas31';
+
+/** A partial `paths` map contributed by one resource's path-definition module. */
+export type PathsFragment = Record<string, PathItemObject>;

--- a/api-server/src/openapi/paths/verify.ts
+++ b/api-server/src/openapi/paths/verify.ts
@@ -1,0 +1,76 @@
+import type { PathsFragment } from './types.js';
+
+export const verifyPaths: PathsFragment = {
+  '/api/verify/batch': {
+    post: {
+      tags: ['Verification'],
+      summary: 'Batch-verify credential/claim pairs',
+      description:
+        'Verifies many `(credential_id, claim_type)` pairs in one round trip. Duplicate ' +
+        'pairs are deduplicated and resolved once; results are fanned back out in input order.',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': { schema: { $ref: '#/components/schemas/VerifyBatchClaimsRequest' } },
+        },
+      },
+      responses: {
+        '200': {
+          description: 'Per-item verification results plus a summary.',
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/BatchVerificationResponse' } },
+          },
+        },
+        '400': {
+          description: 'Malformed request body.',
+          content: { 'application/json': { schema: { $ref: '#/components/schemas/ValidationErrorResponse' } } },
+        },
+      },
+    },
+  },
+  '/api/verify/{id}': {
+    get: {
+      tags: ['Verification'],
+      summary: 'Look up the current verification status of a single credential',
+      description:
+        'Canonical verification endpoint that a credential-export QR code links to. When ' +
+        '`claim_type` is supplied, also returns a verification proof for that claim.',
+      parameters: [
+        { name: 'id', in: 'path', required: true, schema: { type: 'integer', minimum: 1 } },
+        {
+          name: 'claim_type',
+          in: 'query',
+          required: false,
+          schema: { type: 'string' },
+          description: 'When present, also returns a signed verification proof for this claim.',
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'Current credential status.',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  credential_id: { type: 'integer' },
+                  status: {
+                    type: 'string',
+                    enum: ['verified', 'failed', 'not_found', 'revoked', 'expired', 'error'],
+                  },
+                  checked_at: { type: 'string', format: 'date-time' },
+                  claim_type: { type: 'string' },
+                  proof: { $ref: '#/components/schemas/BatchVerificationResult/properties/proof' },
+                },
+              },
+            },
+          },
+        },
+        '400': {
+          description: 'Invalid credential id.',
+          content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } },
+        },
+      },
+    },
+  },
+};

--- a/api-server/src/openapi/paths/webhooks.ts
+++ b/api-server/src/openapi/paths/webhooks.ts
@@ -1,0 +1,82 @@
+import type { PathsFragment } from './types.js';
+
+const webhookEventEnum = { type: 'string' as const, enum: ['credential_issued', 'credential_attested', 'credential_revoked'] };
+
+export const webhooksPaths: PathsFragment = {
+  '/api/webhooks': {
+    post: {
+      tags: ['Webhooks'],
+      summary: 'Register a webhook',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                url: { type: 'string', format: 'uri' },
+                events: { type: 'array', items: webhookEventEnum, minItems: 1 },
+                secret: { type: 'string', description: 'Used to HMAC-sign delivered payloads.' },
+              },
+              required: ['url', 'events'],
+            },
+          },
+        },
+      },
+      responses: {
+        '201': { description: 'Registered.', content: { 'application/json': { schema: { $ref: '#/components/schemas/Webhook' } } } },
+        '400': { description: 'Invalid url or events.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+    get: {
+      tags: ['Webhooks'],
+      summary: 'List registered webhooks',
+      responses: { '200': { description: 'Webhooks.', content: { 'application/json': { schema: { type: 'object', properties: { data: { type: 'array', items: { $ref: '#/components/schemas/Webhook' } } } } } } } },
+    },
+  },
+  '/api/webhooks/deliveries/log': {
+    get: {
+      tags: ['Webhooks'],
+      summary: 'Get the webhook delivery log',
+      responses: { '200': { description: 'Delivery attempts.', content: { 'application/json': { schema: { type: 'object', properties: { data: { type: 'array', items: { type: 'object', additionalProperties: true } } } } } } } },
+    },
+  },
+  '/api/webhooks/dead-letters': {
+    get: {
+      tags: ['Webhooks'],
+      summary: 'List deliveries that exhausted retries',
+      responses: { '200': { description: 'Dead-lettered deliveries.', content: { 'application/json': { schema: { type: 'object', properties: { data: { type: 'array', items: { type: 'object', additionalProperties: true } } } } } } } },
+    },
+  },
+  '/api/webhooks/dead-letters/{id}/replay': {
+    post: {
+      tags: ['Webhooks'],
+      summary: 'Re-queue a dead-lettered delivery',
+      parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+      responses: {
+        '202': { description: 'Re-queued.', content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+        '404': { description: 'Not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+  '/api/webhooks/{id}': {
+    get: {
+      tags: ['Webhooks'],
+      summary: 'Get a webhook',
+      parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+      responses: {
+        '200': { description: 'The webhook.', content: { 'application/json': { schema: { $ref: '#/components/schemas/Webhook' } } } },
+        '404': { description: 'Not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+    delete: {
+      tags: ['Webhooks'],
+      summary: 'Remove a webhook',
+      parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+      responses: {
+        '204': { description: 'Removed.' },
+        '404': { description: 'Not found.', content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } } },
+      },
+    },
+  },
+};

--- a/api-server/src/routes/docs.ts
+++ b/api-server/src/routes/docs.ts
@@ -1,0 +1,45 @@
+/**
+ * Issue #1309 — API documentation endpoints.
+ *
+ *   GET /api-docs/openapi.json  — the generated OpenAPI 3.1 document
+ *   GET /api-docs/              — Swagger UI (interactive, "try it out")
+ *   GET /api-docs/redoc         — ReDoc (three-pane reference viewer)
+ *
+ * The spec is (re)built on every request to openapi.json instead of being
+ * read from a static file, so it always reflects the definitions currently
+ * in `../openapi/paths/*` — see `../openapi/index.ts`.
+ */
+
+import { Router, Request, Response } from 'express';
+import swaggerUi from 'swagger-ui-express';
+import { buildOpenApiSpec } from '../openapi/index.js';
+
+const router = Router();
+
+router.get('/openapi.json', (_req: Request, res: Response) => {
+  res.json(buildOpenApiSpec());
+});
+
+router.use('/', swaggerUi.serve);
+router.get('/', swaggerUi.setup(undefined, {
+  swaggerOptions: { url: 'openapi.json' },
+  customSiteTitle: 'QuorumProof API — Swagger UI',
+}));
+
+router.get('/redoc', (_req: Request, res: Response) => {
+  res.type('html').send(`<!DOCTYPE html>
+<html>
+  <head>
+    <title>QuorumProof API — ReDoc</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>body { margin: 0; padding: 0; }</style>
+  </head>
+  <body>
+    <redoc spec-url="./openapi.json"></redoc>
+    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+  </body>
+</html>`);
+});
+
+export default router;

--- a/api-server/tests/docs.test.ts
+++ b/api-server/tests/docs.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for Issue #1309 — OpenAPI 3.1 generation, Swagger UI, and ReDoc.
+ */
+
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { buildOpenApiSpec } from '../src/openapi/index.js';
+import docsRouter from '../src/routes/docs.js';
+
+function makeApp() {
+  const app = express();
+  app.use('/api-docs', docsRouter);
+  return app;
+}
+
+describe('buildOpenApiSpec', () => {
+  const spec = buildOpenApiSpec();
+
+  it('declares OpenAPI 3.1', () => {
+    expect(spec.openapi).toBe('3.1.0');
+  });
+
+  it('has info.title and info.version', () => {
+    expect(spec.info.title).toBe('QuorumProof API');
+    expect(typeof spec.info.version).toBe('string');
+    expect(spec.info.version.length).toBeGreaterThan(0);
+  });
+
+  it('declares bearer and apiKey security schemes', () => {
+    expect(spec.components?.securitySchemes?.bearerAuth).toBeDefined();
+    expect(spec.components?.securitySchemes?.apiKeyAuth).toBeDefined();
+  });
+
+  it('documents a substantial number of operations', () => {
+    const paths = spec.paths ?? {};
+    let operationCount = 0;
+    for (const item of Object.values(paths)) {
+      for (const method of ['get', 'post', 'put', 'patch', 'delete'] as const) {
+        if (item[method]) operationCount++;
+      }
+    }
+    expect(Object.keys(paths).length).toBeGreaterThan(50);
+    expect(operationCount).toBeGreaterThan(50);
+  });
+
+  it('includes the batch verification endpoint reusing the AJV validation schema', () => {
+    const op = spec.paths?.['/api/verify/batch']?.post;
+    expect(op).toBeDefined();
+    const schema =
+      op?.requestBody &&
+      'content' in op.requestBody
+        ? op.requestBody.content['application/json']?.schema
+        : undefined;
+    expect(schema).toEqual({ $ref: '#/components/schemas/VerifyBatchClaimsRequest' });
+  });
+
+  it('re-mounts the api-keys paths under /auth/api-keys as well as /api/api-keys', () => {
+    expect(spec.paths?.['/api/api-keys']).toBeDefined();
+    expect(spec.paths?.['/auth/api-keys']).toBeDefined();
+    expect(spec.paths?.['/api/api-keys/{id}/rotate']).toBeDefined();
+    expect(spec.paths?.['/auth/api-keys/{id}/rotate']).toBeDefined();
+  });
+
+  it('every $ref in the document resolves to an existing component', () => {
+    const refs: string[] = [];
+    const walk = (node: unknown): void => {
+      if (Array.isArray(node)) {
+        node.forEach(walk);
+        return;
+      }
+      if (node && typeof node === 'object') {
+        const obj = node as Record<string, unknown>;
+        if (typeof obj.$ref === 'string') refs.push(obj.$ref);
+        Object.values(obj).forEach(walk);
+      }
+    };
+    walk(spec);
+
+    expect(refs.length).toBeGreaterThan(0);
+    for (const ref of refs) {
+      expect(ref.startsWith('#/')).toBe(true);
+      const parts = ref.slice(2).split('/');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let node: any = spec;
+      for (const part of parts) {
+        expect(node && typeof node === 'object' && part in node).toBe(true);
+        node = node[part];
+      }
+    }
+  });
+
+  it('does not document routers that are not actually mounted in index.ts', () => {
+    // #925/#1301 audit routers, and the auth / passwordless-auth / bridge /
+    // graphql / reports / costs / verification routers, exist in the
+    // codebase but are never app.use()'d in src/index.ts — only exercised
+    // directly by their own unit tests. Documenting them would describe
+    // endpoints that 404 on the real server.
+    const paths = Object.keys(spec.paths ?? {});
+    expect(paths.some((p) => p.startsWith('/api/audit'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('/api/bridge'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('/api/reports'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('/api/costs'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('/api/graphql'))).toBe(false);
+  });
+});
+
+describe('GET /api-docs/openapi.json', () => {
+  it('serves the generated spec as JSON', async () => {
+    const res = await request(makeApp()).get('/api-docs/openapi.json');
+    expect(res.status).toBe(200);
+    expect(res.body.openapi).toBe('3.1.0');
+    expect(res.body.paths).toBeDefined();
+  });
+});
+
+describe('GET /api-docs/ (Swagger UI)', () => {
+  it('serves the Swagger UI HTML shell', async () => {
+    const res = await request(makeApp()).get('/api-docs/');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+    expect(res.text).toContain('swagger-ui');
+  });
+});
+
+describe('GET /api-docs/redoc', () => {
+  it('serves the ReDoc HTML shell pointing at the JSON spec', async () => {
+    const res = await request(makeApp()).get('/api-docs/redoc');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+    expect(res.text).toContain('<redoc');
+    expect(res.text).toContain('openapi.json');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1309.

API docs were manual and drifted from the real routes. This adds an OpenAPI 3.1 document generated from typed definitions living next to the code, served interactively, plus a generated TypeScript client — so the docs can't go stale without a test catching it.

- **OpenAPI 3.1 generation** — `api-server/src/openapi/` is a typed registry: one `paths/*.ts` file per route module (mirroring `src/routes/*.ts`), assembled by `buildOpenApiSpec()`. A handful of request schemas (`VerifyBatchClaimsRequest`, `NotificationSendRequest`, etc.) are imported directly from the real AJV validators in `middleware/validate.ts`, so the documented shape can't drift from what's actually enforced.
- **Swagger UI** — `GET /api-docs/` (interactive, "try it out").
- **ReDoc** — `GET /api-docs/redoc` (three-pane reference viewer).
- **JSON spec** — `GET /api-docs/openapi.json`, rebuilt fresh on every request (never a stale cached file). A static snapshot is also committed to `api-server/openapi/openapi.json` for external tooling (Postman import, contract diffing) and as the input to the client generator.
- **TypeScript client** — `npm run generate:client` (in `api-server/`) runs `@hey-api/openapi-ts` against the committed spec and writes a typed `fetch`-based client (one function per operation) to `api-server/generated/` (gitignored, like `dist/` — regenerate on demand).

Only routers actually mounted in `src/index.ts` are documented. While wiring this up I found several route modules that exist in the codebase but are **not** actually reachable on the running server — `audit.ts`, `authAudit.ts`, `auth.ts`, `passwordlessAuth.ts`, `bridge.ts`, `graphql.ts`, `reports.ts`, `costs.ts`, `verification.ts` are only exercised directly by their own unit tests, never `app.use()`'d. Documenting them would describe endpoints that 404 in practice, so they're excluded — `tests/docs.test.ts` asserts this stays true. (Separate pre-existing issue, out of scope here — flagging in case it's useful.)

Full write-up: [`api-server/docs/API_DOCUMENTATION.md`](api-server/docs/API_DOCUMENTATION.md).

## Test plan

- [x] `npm test` in `api-server/` — 912 passed, 5 skipped (1 unrelated pre-existing hardhat-node integration test needs a local chain node; not run here)
- [x] New `tests/docs.test.ts` (11 tests): spec is valid OpenAPI 3.1 shape, every `$ref` resolves, batch-verify endpoint reuses the real AJV schema, `/api/api-keys` and `/auth/api-keys` are both documented, unmounted routers stay excluded, all three HTTP endpoints return the expected content
- [x] `tsc --noEmit` — zero new type errors (pre-existing baseline errors unchanged, confirmed by diffing against `main`)
- [x] Manually started the dev server and curled all three endpoints (200s), plus validated the JSON spec's refs with a standalone script
- [x] `npm run generate:client` — generates a clean, `tsc --noEmit`-clean client (864-line SDK + 3712-line types across ~113 operations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)