### PR TITLE
fix(zk_verifier): replace fake structural verification with real cryptographic proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,12 +88,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -97,12 +97,6 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -709,15 +703,15 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
  "http",
  "indexmap 2.14.0",
  "slab",
@@ -764,23 +758,34 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -791,46 +796,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "hyper"
-version = "0.14.32"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.10",
+ "smallvec",
  "tokio",
- "tower-service",
- "tracing",
  "want",
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1213,7 +1252,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1386,7 +1425,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -1494,7 +1533,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1525,42 +1564,42 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
+ "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
- "ipnet",
+ "hyper-util",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
 ]
 
 [[package]]
@@ -1571,6 +1610,20 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1594,7 +1647,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1602,12 +1655,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
+name = "rustls"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
- "base64 0.21.7",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1690,7 +1767,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -1858,16 +1935,6 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -2156,9 +2223,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2173,20 +2243,20 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2292,7 +2362,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2315,6 +2385,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
  "tokio",
 ]
 
@@ -2353,6 +2433,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -2402,6 +2521,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2601,6 +2726,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2620,20 +2756,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2647,40 +2774,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2690,21 +2796,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2720,21 +2814,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2744,37 +2826,15 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/benches/tests/benchmarks.rs
+++ b/benches/tests/benchmarks.rs
@@ -524,11 +524,11 @@ fn bench_verify_engineer() {
         qp_client.verify_engineer(
             &sbt_id,
             &zk_id,
-            &admin,
             &engineer,
             &cred_id,
             &QpClaimType::HasDegree,
             &proof,
+            &vk_hash,
             &None,
         );
     });

--- a/contracts/e2e_tests/Cargo.toml
+++ b/contracts/e2e_tests/Cargo.toml
@@ -8,7 +8,7 @@ soroban-sdk = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.12", features = ["json"] }
 dotenv = "0.15"
 anyhow = "1"
 

--- a/contracts/integration_tests/src/chaos.rs
+++ b/contracts/integration_tests/src/chaos.rs
@@ -72,11 +72,11 @@ fn chaos_revoke_after_mint_graceful_degradation() {
     let result = c.qp.verify_engineer(
         &c.sbt.address,
         &c.zk.address,
-        &c.admin,
         &engineer,
         &cred_id,
         &QpClaimType::HasDegree,
         &valid_proof(&env),
+        &BytesN::from_array(&env, &[0u8; 32]),
         &None,
     );
     // Outcome is deterministic; the important property is no uncontrolled panic
@@ -100,11 +100,11 @@ fn chaos_empty_proof_returns_false() {
     let result = c.qp.verify_engineer(
         &c.sbt.address,
         &c.zk.address,
-        &c.admin,
         &engineer,
         &cred_id,
         &QpClaimType::HasDegree,
         &empty_proof,
+        &BytesN::from_array(&env, &[0u8; 32]),
         &None,
     );
     assert!(!result, "chaos: empty proof must yield false, not a panic");
@@ -121,11 +121,11 @@ fn chaos_nonexistent_credential_returns_false() {
     let result = c.qp.verify_engineer(
         &c.sbt.address,
         &c.zk.address,
-        &c.admin,
         &engineer,
         &9999u64,
         &QpClaimType::HasDegree,
         &valid_proof(&env),
+        &BytesN::from_array(&env, &[0u8; 32]),
         &None,
     );
     assert!(!result, "chaos: non-existent credential must yield false");
@@ -262,11 +262,11 @@ fn chaos_mismatched_credential_id_returns_false() {
     let result = c.qp.verify_engineer(
         &c.sbt.address,
         &c.zk.address,
-        &c.admin,
         &engineer,
         &(cred_id + 1),
         &QpClaimType::HasDegree,
         &valid_proof(&env),
+        &BytesN::from_array(&env, &[0u8; 32]),
         &None,
     );
     assert!(!result, "chaos: mismatched credential ID must yield false, not panic");

--- a/contracts/integration_tests/src/lib.rs
+++ b/contracts/integration_tests/src/lib.rs
@@ -62,6 +62,7 @@ mod integration {
         sbt: SbtRegistryContractClient<'a>,
         zk: ZkVerifierContractClient<'a>,
         admin: soroban_sdk::Address,
+        vk_hash: BytesN<32>,
     }
 
     fn setup(env: &Env) -> Contracts<'_> {
@@ -89,7 +90,7 @@ mod integration {
         let vk_hash = BytesN::from_array(env, &[0u8; 32]);
         zk.set_verifying_key(&admin, &vk_hash);
 
-        Contracts { qp, sbt, zk, admin }
+        Contracts { qp, sbt, zk, admin, vk_hash }
     }
 
     fn metadata(env: &Env) -> Bytes {
@@ -273,12 +274,12 @@ mod integration {
         let result = c.qp.verify_engineer(
             &c.sbt.address,
             &c.zk.address,
-            &c.admin,
             &engineer,
             &cred_id,
             &QpClaimType::HasDegree,
             &valid_proof(&env),
-        &None,
+            &c.vk_hash,
+            &None,
         );
         assert!(result);
     }
@@ -297,12 +298,12 @@ mod integration {
         let result = c.qp.verify_engineer(
             &c.sbt.address,
             &c.zk.address,
-            &c.admin,
             &engineer,
             &cred_id,
             &QpClaimType::HasDegree,
             &valid_proof(&env),
-        &None,
+            &c.vk_hash,
+            &None,
         );
         assert!(!result);
     }
@@ -633,11 +634,11 @@ mod integration {
         let result = c.qp.verify_engineer(
             &c.sbt.address,
             &c.zk.address,
-            &c.admin,
             &engineer,
             &(cred_id + 1),
             &QpClaimType::HasDegree,
             &valid_proof(&env),
+            &c.vk_hash,
             &None,
         );
         assert!(!result);

--- a/contracts/integration_tests/src/lib.rs
+++ b/contracts/integration_tests/src/lib.rs
@@ -271,14 +271,29 @@ mod integration {
         let uri = Bytes::from_slice(&env, b"ipfs://QmSBT");
         c.sbt.mint(&engineer, &cred_id, &uri);
 
+        // verify_engineer's production path performs a real BLS12-381 pairing
+        // check bound to (credential_id, claim_type) via
+        // encode_claim_public_inputs, so it needs a genuinely valid proof
+        // against a registered Groth16 verifying key — c.vk_hash/valid_proof()
+        // only satisfy the legacy structural heuristic.
+        let toy_vk = zk_verifier::groth16_test_prover::generate_vk(&env, 900, 2);
+        c.zk.set_groth16_verifying_key(&c.admin, &toy_vk.vk_hash, &toy_vk.vk);
+        let claim_type_value = 1u64; // ClaimType::HasDegree
+        let toy_proof = zk_verifier::groth16_test_prover::generate_proof(
+            &env,
+            &toy_vk,
+            901,
+            &[cred_id, claim_type_value],
+        );
+
         let result = c.qp.verify_engineer(
             &c.sbt.address,
             &c.zk.address,
             &engineer,
             &cred_id,
             &QpClaimType::HasDegree,
-            &valid_proof(&env),
-            &c.vk_hash,
+            &toy_proof.proof,
+            &toy_vk.vk_hash,
             &None,
         );
         assert!(result);

--- a/contracts/integration_tests/tests/integration_tests.rs
+++ b/contracts/integration_tests/tests/integration_tests.rs
@@ -120,14 +120,29 @@ fn full_flow_issue_slice_attest_sbt_zk_proof() {
     let verified = c.zk.verify_claim(&c.admin, &c.qp.address, &cred_id, &ClaimType::HasDegree, &valid_proof(&env));
     assert!(verified);
 
+    // verify_engineer's production path performs a real BLS12-381 pairing
+    // check bound to (credential_id, claim_type) via encode_claim_public_inputs,
+    // so it needs a genuinely valid proof against a registered Groth16 VK —
+    // the legacy vk_hash/valid_proof() fixtures above only satisfy the
+    // structural heuristic the old code path used.
+    let toy_vk = zk_verifier::groth16_test_prover::generate_vk(&env, 910, 2);
+    c.zk.set_groth16_verifying_key(&c.admin, &toy_vk.vk_hash, &toy_vk.vk);
+    let claim_type_value = 1u64; // ClaimType::HasDegree
+    let toy_proof = zk_verifier::groth16_test_prover::generate_proof(
+        &env,
+        &toy_vk,
+        911,
+        &[cred_id, claim_type_value],
+    );
+
     let engineer_ok = c.qp.verify_engineer(
         &c.sbt.address,
         &c.zk.address,
-        &c.admin,
         &holder,
         &cred_id,
         &QpClaimType::HasDegree,
-        &valid_proof(&env),
+        &toy_proof.proof,
+        &toy_vk.vk_hash,
         &None,
     );
     assert!(engineer_ok);

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -11305,37 +11305,42 @@ impl QuorumProofContract {
     /// - `credential_id`: The credential to verify claims against.
     /// - `claim_types`: Ordered list of claim types to verify.
     /// - `proofs`: Ordered list of ZK proofs corresponding to each claim type.
+    /// - `vk_hashes`: Verifying key hashes for each proof.
     ///
     /// # Panics
-    /// Panics if `claim_types` and `proofs` have different lengths.
+    /// Panics if `claim_types`, `proofs`, and `vk_hashes` have different lengths.
     pub fn verify_claim_batch(
         env: Env,
         zk_verifier_id: Address,
-        zk_admin: Address,
         quorum_proof_id: Address,
         credential_id: u64,
         claim_types: Vec<ClaimType>,
         proofs: Vec<soroban_sdk::Bytes>,
+        vk_hashes: Vec<BytesN<32>>,
     ) -> Vec<bool> {
         Self::validate_array_bounds(claim_types.len(), 1, MAX_BATCH_SIZE, "claim_types");
         assert!(
-            claim_types.len() == proofs.len(),
-            "claim_types and proofs lengths must match"
+            claim_types.len() == proofs.len() && proofs.len() == vk_hashes.len(),
+            "claim_types, proofs, and vk_hashes lengths must match"
         );
         let mut results: Vec<bool> = Vec::new(&env);
         for i in 0..claim_types.len() {
+            let claim_type = claim_types.get(i).unwrap();
+            let proof = proofs.get(i).unwrap();
+            let vk_hash = vk_hashes.get(i).unwrap();
+
+            let public_inputs = Self::encode_claim_public_inputs(&env, credential_id, &claim_type);
+
             let args = Vec::from_array(
                 &env,
                 [
-                    zk_admin.clone().into_val(&env),
-                    quorum_proof_id.clone().into_val(&env),
-                    credential_id.into_val(&env),
-                    claim_types.get(i).unwrap().into_val(&env),
-                    proofs.get(i).unwrap().into_val(&env),
+                    proof.into_val(&env),
+                    public_inputs.into_val(&env),
+                    vk_hash.into_val(&env),
                 ],
             );
             let result: bool = env
-                .invoke_contract(&zk_verifier_id, &Symbol::new(&env, "verify_claim"), args);
+                .invoke_contract(&zk_verifier_id, &Symbol::new(&env, "verify_groth16_proof"), args);
             results.push_back(result);
         }
         results
@@ -11469,16 +11474,16 @@ impl QuorumProofContract {
     /// Unified engineer verification entry point.
     ///
     /// Checks that the subject holds an SBT linked to the credential, then delegates
-    /// ZK claim verification to the `zk_verifier` contract.
+    /// ZK claim verification to the `zk_verifier` contract using cryptographic proof verification.
     ///
     /// # Parameters
-    /// - `quorum_proof_id`: Address of this contract (forwarded to the ZK verifier).
     /// - `sbt_registry_id`: Address of the deployed SBT registry contract.
     /// - `zk_verifier_id`: Address of the deployed ZK verifier contract.
     /// - `subject`: The engineer whose credential is being verified.
     /// - `credential_id`: The credential to verify.
     /// - `claim_type`: The specific claim to verify (degree, license, employment).
-    /// - `proof`: The ZK proof bytes for the claim.
+    /// - `proof`: The ZK proof bytes for the claim (BLS12-381 compressed format).
+    /// - `vk_hash`: The verifying key hash for the proof.
     /// - `verifier`: Optional address performing the verification. If `Some`, must be the subject
     ///   or an active delegate for the subject's SBT. If `None`, no caller check is performed.
     ///
@@ -11488,11 +11493,11 @@ impl QuorumProofContract {
         env: Env,
         sbt_registry_id: Address,
         zk_verifier_id: Address,
-        zk_admin: Address,
         subject: Address,
         credential_id: u64,
         claim_type: ClaimType,
         proof: soroban_sdk::Bytes,
+        vk_hash: BytesN<32>,
         verifier: Option<Address>,
     ) -> bool {
         let caller = verifier.unwrap_or_else(|| subject.clone());
@@ -11500,18 +11505,57 @@ impl QuorumProofContract {
         if !Self::is_authorized_verifier(&env, caller, sbt_registry_id, credential_id, subject.clone()) {
             return false;
         }
-        let quorum_proof_id = env.current_contract_address();
+
+        let public_inputs = Self::encode_claim_public_inputs(&env, credential_id, &claim_type);
+
         let args = Vec::from_array(
             &env,
             [
-                zk_admin.clone().into_val(&env),
-                quorum_proof_id.into_val(&env),
-                credential_id.into_val(&env),
-                claim_type.into_val(&env),
                 proof.into_val(&env),
+                public_inputs.into_val(&env),
+                vk_hash.into_val(&env),
             ],
         );
-        env.invoke_contract(&zk_verifier_id, &Symbol::new(&env, "verify_claim"), args)
+        env.invoke_contract(&zk_verifier_id, &Symbol::new(&env, "verify_groth16_proof"), args)
+    }
+
+    /// Encode credential_id and claim_type as public inputs for ZK proof verification.
+    ///
+    /// Creates a 64-byte public input by concatenating:
+    /// - credential_id as 32-byte little-endian field element (bytes 0-31)
+    /// - claim_type as 32-byte little-endian field element (bytes 32-63)
+    ///
+    /// This binds the ZK proof to the specific credential and claim being verified,
+    /// ensuring that a proof valid for one (credential, claim) pair cannot be
+    /// replayed for a different pair.
+    fn encode_claim_public_inputs(env: &Env, credential_id: u64, claim_type: &ClaimType) -> soroban_sdk::Bytes {
+        let mut public_inputs = soroban_sdk::Bytes::new(env);
+
+        let cred_id_bytes = credential_id.to_le_bytes();
+        for byte in &cred_id_bytes {
+            public_inputs.push(*byte);
+        }
+        for _ in 0..(32 - cred_id_bytes.len()) {
+            public_inputs.push(0);
+        }
+
+        let claim_type_value: u64 = match claim_type {
+            ClaimType::HasDegree => 1,
+            ClaimType::HasLicense => 2,
+            ClaimType::HasEmploymentHistory => 3,
+            ClaimType::HasCertification => 4,
+            ClaimType::HasResearchPublication => 5,
+        };
+
+        let claim_bytes = claim_type_value.to_le_bytes();
+        for byte in &claim_bytes {
+            public_inputs.push(*byte);
+        }
+        for _ in 0..(32 - claim_bytes.len()) {
+            public_inputs.push(0);
+        }
+
+        public_inputs
     }
 
     /// Check if a caller is authorized to verify a credential.
@@ -20733,12 +20777,12 @@ mod tests {
         let result = qp.verify_engineer(
             &sbt_id,
             &zk_id,
-            &zk_admin,
             &subject,
             &cred_id,
             &ClaimType::HasDegree,
             &proof,
-        &None,
+            &vk_hash,
+            &None,
         );
         assert!(result);
     }
@@ -20765,16 +20809,19 @@ mod tests {
 
         let cred_id = qp.issue_credential(&issuer, &subject, &1u32, &metadata, &None, &0u64);
 
+        let vk_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+        ZkVerifierContractClient::new(&env, &zk_id).set_verifying_key(&zk_admin, &vk_hash);
+
         let proof = Bytes::from_slice(&env, b"valid-proof");
         let result = qp.verify_engineer(
             &sbt_id,
             &zk_id,
-            &zk_admin,
             &subject,
             &cred_id,
             &ClaimType::HasDegree,
             &proof,
-        &None,
+            &vk_hash,
+            &None,
         );
         assert!(!result);
     }
@@ -20811,12 +20858,12 @@ mod tests {
         let result = qp.verify_engineer(
             &sbt_id,
             &zk_id,
-            &zk_admin,
             &subject,
             &cred_id,
             &ClaimType::HasLicense,
             &proof,
-        &None,
+            &vk_hash,
+            &None,
         );
         assert!(!result);
     }
@@ -20861,11 +20908,11 @@ mod tests {
         let result = qp.verify_engineer(
             &sbt_id,
             &zk_id,
-            &zk_admin,
             &subject,
             &cred_id,
             &ClaimType::HasDegree,
             &proof,
+            &vk_hash,
             &Some(hr_delegate),
         );
         assert!(result);
@@ -20888,6 +20935,8 @@ mod tests {
         let zk_admin = Address::generate(&env);
         ZkVerifierContractClient::new(&env, &zk_id).initialize(&zk_admin);
         sbt.initialize(&zk_admin, &qp_id);
+        let vk_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+        ZkVerifierContractClient::new(&env, &zk_id).set_verifying_key(&zk_admin, &vk_hash);
 
         let issuer = Address::generate(&env);
         let subject = Address::generate(&env);
@@ -20906,11 +20955,11 @@ mod tests {
         let result = qp.verify_engineer(
             &sbt_id,
             &zk_id,
-            &zk_admin,
             &subject,
             &cred_id,
             &ClaimType::HasDegree,
             &proof,
+            &vk_hash,
             &Some(hr_delegate),
         );
         assert!(!result);
@@ -20933,6 +20982,8 @@ mod tests {
         let zk_admin = Address::generate(&env);
         ZkVerifierContractClient::new(&env, &zk_id).initialize(&zk_admin);
         sbt.initialize(&zk_admin, &qp_id);
+        let vk_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+        ZkVerifierContractClient::new(&env, &zk_id).set_verifying_key(&zk_admin, &vk_hash);
 
         let issuer = Address::generate(&env);
         let subject = Address::generate(&env);
@@ -20947,11 +20998,11 @@ mod tests {
         let result = qp.verify_engineer(
             &sbt_id,
             &zk_id,
-            &zk_admin,
             &subject,
             &cred_id,
             &ClaimType::HasDegree,
             &proof,
+            &vk_hash,
             &Some(stranger),
         );
         assert!(!result);
@@ -21717,12 +21768,12 @@ mod tests {
         let verified = qp.verify_engineer(
             &sbt_id,
             &zk_id,
-            &zk_admin,
             &subject,
             &cred_id,
             &ClaimType::HasDegree,
             &proof,
-        &None,
+            &vk_hash,
+            &None,
         );
         assert!(verified);
 
@@ -21731,12 +21782,12 @@ mod tests {
         let not_verified = qp.verify_engineer(
             &sbt_id,
             &zk_id,
-            &zk_admin,
             &subject,
             &cred_id,
             &ClaimType::HasDegree,
             &empty_proof,
-        &None,
+            &vk_hash,
+            &None,
         );
         assert!(!not_verified);
     }

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -19211,21 +19211,6 @@ mod tests {
     use soroban_sdk::testutils::{Address as _, Events as _, Ledger as _, LedgerInfo};
     use soroban_sdk::{vec, Bytes, Env, FromVal, IntoVal};
 
-    /// A 256-byte "proof" that passes zk_verifier's mock Groth16 structural
-    /// checks (non-zero, non-0xFF A/C points) — NOT a real cryptographic
-    /// proof, just a fixture shape zk_verifier::groth16_verify accepts.
-    /// Must be paired with a registered verifying key (`set_verifying_key`)
-    /// or verify_claim panics with "verifying key not set" before even
-    /// looking at the proof bytes.
-    fn structurally_valid_proof(env: &Env) -> Bytes {
-        let mut proof_bytes = [0u8; 256];
-        proof_bytes[0] = 1;
-        proof_bytes[63] = 1;
-        proof_bytes[192] = 1;
-        proof_bytes[255] = 1;
-        Bytes::from_slice(env, &proof_bytes)
-    }
-
     // --- Deployment verification tests ---
 
     #[test]
@@ -20759,10 +20744,9 @@ mod tests {
         let qp = QuorumProofContractClient::new(&env, &qp_id);
         let sbt = SbtRegistryContractClient::new(&env, &sbt_id);
         let zk_admin = Address::generate(&env);
-        ZkVerifierContractClient::new(&env, &zk_id).initialize(&zk_admin);
+        let zk_client = ZkVerifierContractClient::new(&env, &zk_id);
+        zk_client.initialize(&zk_admin);
         sbt.initialize(&zk_admin, &qp_id);
-        let vk_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
-        ZkVerifierContractClient::new(&env, &zk_id).set_verifying_key(&zk_admin, &vk_hash);
 
         let issuer = Address::generate(&env);
         let subject = Address::generate(&env);
@@ -20773,15 +20757,28 @@ mod tests {
         let sbt_uri = Bytes::from_slice(&env, b"ipfs://QmSbt");
         sbt.mint(&subject, &cred_id, &sbt_uri);
 
-        let proof = structurally_valid_proof(&env);
+        // verify_engineer's production path performs a real BLS12-381
+        // pairing check bound to (credential_id, claim_type) via
+        // encode_claim_public_inputs, so it needs a genuinely valid proof
+        // against a registered Groth16 verifying key.
+        let toy_vk = zk_verifier::groth16_test_prover::generate_vk(&env, 800, 2);
+        zk_client.set_groth16_verifying_key(&zk_admin, &toy_vk.vk_hash, &toy_vk.vk);
+        let claim_type_value = 1u64; // ClaimType::HasDegree
+        let toy_proof = zk_verifier::groth16_test_prover::generate_proof(
+            &env,
+            &toy_vk,
+            801,
+            &[cred_id, claim_type_value],
+        );
+
         let result = qp.verify_engineer(
             &sbt_id,
             &zk_id,
             &subject,
             &cred_id,
             &ClaimType::HasDegree,
-            &proof,
-            &vk_hash,
+            &toy_proof.proof,
+            &toy_vk.vk_hash,
             &None,
         );
         assert!(result);
@@ -20883,10 +20880,9 @@ mod tests {
         let qp = QuorumProofContractClient::new(&env, &qp_id);
         let sbt = SbtRegistryContractClient::new(&env, &sbt_id);
         let zk_admin = Address::generate(&env);
-        ZkVerifierContractClient::new(&env, &zk_id).initialize(&zk_admin);
+        let zk_client = ZkVerifierContractClient::new(&env, &zk_id);
+        zk_client.initialize(&zk_admin);
         sbt.initialize(&zk_admin, &qp_id);
-        let vk_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
-        ZkVerifierContractClient::new(&env, &zk_id).set_verifying_key(&zk_admin, &vk_hash);
 
         let issuer = Address::generate(&env);
         let subject = Address::generate(&env);
@@ -20904,15 +20900,28 @@ mod tests {
         let expires_at = env.ledger().timestamp() + 10_000;
         qp.delegate_verification(&subject, &cred_id, &hr_delegate, &expires_at);
 
-        let proof = structurally_valid_proof(&env);
+        // verify_engineer's production path performs a real BLS12-381
+        // pairing check bound to (credential_id, claim_type) via
+        // encode_claim_public_inputs, so it needs a genuinely valid proof
+        // against a registered Groth16 verifying key.
+        let toy_vk = zk_verifier::groth16_test_prover::generate_vk(&env, 810, 2);
+        zk_client.set_groth16_verifying_key(&zk_admin, &toy_vk.vk_hash, &toy_vk.vk);
+        let claim_type_value = 1u64; // ClaimType::HasDegree
+        let toy_proof = zk_verifier::groth16_test_prover::generate_proof(
+            &env,
+            &toy_vk,
+            811,
+            &[cred_id, claim_type_value],
+        );
+
         let result = qp.verify_engineer(
             &sbt_id,
             &zk_id,
             &subject,
             &cred_id,
             &ClaimType::HasDegree,
-            &proof,
-            &vk_hash,
+            &toy_proof.proof,
+            &toy_vk.vk_hash,
             &Some(hr_delegate),
         );
         assert!(result);
@@ -21700,11 +21709,10 @@ mod tests {
         let qp = QuorumProofContractClient::new(&env, &qp_id);
         let sbt = SbtRegistryContractClient::new(&env, &sbt_id);
         let zk_admin = Address::generate(&env);
-        ZkVerifierContractClient::new(&env, &zk_id).initialize(&zk_admin);
+        let zk_client = ZkVerifierContractClient::new(&env, &zk_id);
+        zk_client.initialize(&zk_admin);
         sbt.initialize(&zk_admin, &qp_id);
         qp.initialize(&zk_admin);
-        let vk_hash = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
-        ZkVerifierContractClient::new(&env, &zk_id).set_verifying_key(&zk_admin, &vk_hash);
 
         let issuer = Address::generate(&env);
         let subject = Address::generate(&env);
@@ -21764,15 +21772,28 @@ mod tests {
         assert_eq!(token.owner, subject);
 
         // Step 6: Verify ZK claim via verify_engineer
-        let proof = structurally_valid_proof(&env);
+        //
+        // verify_engineer's production path performs a real BLS12-381
+        // pairing check bound to (credential_id, claim_type) via
+        // encode_claim_public_inputs, so it needs a genuinely valid proof
+        // against a registered Groth16 verifying key.
+        let toy_vk = zk_verifier::groth16_test_prover::generate_vk(&env, 820, 2);
+        zk_client.set_groth16_verifying_key(&zk_admin, &toy_vk.vk_hash, &toy_vk.vk);
+        let claim_type_value = 1u64; // ClaimType::HasDegree
+        let toy_proof = zk_verifier::groth16_test_prover::generate_proof(
+            &env,
+            &toy_vk,
+            821,
+            &[cred_id, claim_type_value],
+        );
         let verified = qp.verify_engineer(
             &sbt_id,
             &zk_id,
             &subject,
             &cred_id,
             &ClaimType::HasDegree,
-            &proof,
-            &vk_hash,
+            &toy_proof.proof,
+            &toy_vk.vk_hash,
             &None,
         );
         assert!(verified);
@@ -21786,7 +21807,7 @@ mod tests {
             &cred_id,
             &ClaimType::HasDegree,
             &empty_proof,
-            &vk_hash,
+            &toy_vk.vk_hash,
             &None,
         );
         assert!(!not_verified);

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -11533,10 +11533,10 @@ impl QuorumProofContract {
 
         let cred_id_bytes = credential_id.to_le_bytes();
         for byte in &cred_id_bytes {
-            public_inputs.push(*byte);
+            public_inputs.push_back(*byte);
         }
         for _ in 0..(32 - cred_id_bytes.len()) {
-            public_inputs.push(0);
+            public_inputs.push_back(0);
         }
 
         let claim_type_value: u64 = match claim_type {
@@ -11549,10 +11549,10 @@ impl QuorumProofContract {
 
         let claim_bytes = claim_type_value.to_le_bytes();
         for byte in &claim_bytes {
-            public_inputs.push(*byte);
+            public_inputs.push_back(*byte);
         }
         for _ in 0..(32 - claim_bytes.len()) {
-            public_inputs.push(0);
+            public_inputs.push_back(0);
         }
 
         public_inputs

--- a/contracts/zk_verifier/src/lib.rs
+++ b/contracts/zk_verifier/src/lib.rs
@@ -980,6 +980,10 @@ impl ZkVerifierContract {
     /// 
     /// Cache keys are derived from: (credential_id, claim_type, proof_hash).
     /// Cache entries expire after `ttl` ledgers.
+    ///
+    /// **Test-only**: like [`groth16_verify`], this verifies via the
+    /// structural/hash-binding heuristic, not real BLS12-381 pairing checks.
+    #[cfg(any(test, feature = "testutils"))]
     pub fn verify_proof_cached(
         env: Env,
         admin: Address,
@@ -1032,6 +1036,10 @@ impl ZkVerifierContract {
     /// 
     /// Cache keys are derived from: (credential_id, claim_type, proof_hash).
     /// Cache entries are stored indefinitely until explicitly cleared.
+    ///
+    /// **Test-only**: wraps [`Self::verify_proof_cached`], which uses the
+    /// structural/hash-binding heuristic, not real BLS12-381 pairing checks.
+    #[cfg(any(test, feature = "testutils"))]
     pub fn verify_claim_with_cache(
         env: Env,
         admin: Address,
@@ -1349,6 +1357,10 @@ impl ZkVerifierContract {
     /// Verify a Groth16 ZK proof anonymously using a holder commitment.
     /// The holder_commitment binds the proof to a specific holder without
     /// revealing their address on-chain.
+    ///
+    /// **Test-only**: like [`groth16_verify`], this verifies via the
+    /// structural/hash-binding heuristic, not real BLS12-381 pairing checks.
+    #[cfg(any(test, feature = "testutils"))]
     pub fn verify_claim_anonymous(
         env: Env,
         _credential_id: u64,

--- a/contracts/zk_verifier/src/lib.rs
+++ b/contracts/zk_verifier/src/lib.rs
@@ -179,6 +179,12 @@ fn proof_binding_hash(
 /// 4. Multiple collision resistance checks
 ///
 /// Returns true if the proof passes all enhanced validation checks.
+///
+/// **WARNING: This is a structural/hash-binding heuristic, NOT actual cryptographic
+/// verification. It only checks byte patterns and hash outputs, not elliptic-curve
+/// pairing math. Use only for testing; production verification must use
+/// [`verify_groth16_proof`] which performs real BLS12-381 pairing checks.**
+#[cfg(any(test, feature = "testutils"))]
 fn groth16_verify(env: &Env, vk_hash: &BytesN<32>, proof: &Bytes) -> bool {
     // 1. Length check
     if proof.len() != GROTH16_PROOF_LEN {
@@ -224,6 +230,9 @@ fn groth16_verify(env: &Env, vk_hash: &BytesN<32>, proof: &Bytes) -> bool {
 }
 
 /// Enhanced VK binding with multiple collision resistance checks
+///
+/// **WARNING: This is not real cryptographic verification. Use only for testing.**
+#[cfg(any(test, feature = "testutils"))]
 fn verify_enhanced_vk_binding(env: &Env, vk_hash: &BytesN<32>, proof: &Bytes) -> bool {
     // Primary binding: SHA-256(vk_hash || proof_bytes)
     let mut binding_input = Bytes::new(env);
@@ -929,6 +938,13 @@ impl ZkVerifierContract {
     ///
     /// The proof must be exactly 256 bytes (BN254 uncompressed: A‖B‖C).
     /// A verifying key hash must have been registered via `set_verifying_key`.
+    ///
+    /// **WARNING: This is a test-only heuristic path that does NOT perform actual
+    /// cryptographic verification. It is only available in test builds. Production
+    /// code must use [`verify_groth16_proof`] which performs real BLS12-381 pairing
+    /// checks and binds the proof to specific credential_id and claim_type via
+    /// public inputs.**
+    #[cfg(any(test, feature = "testutils"))]
     pub fn verify_claim(
         env: Env,
         admin: Address,
@@ -1126,7 +1142,7 @@ impl ZkVerifierContract {
     }
 
     /// Admin-only contract upgrade to new WASM.
-    fn upgrade(env: Env, admin: Address, new_wasm_hash: soroban_sdk::BytesN<32>) {
+    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: soroban_sdk::BytesN<32>) {
         admin.require_auth();
         env.deployer().update_current_contract_wasm(new_wasm_hash);
     }


### PR DESCRIPTION
## Summary

The zk_verifier's production verification path was not actually performing cryptographic verification—it only checked byte patterns and hash collision avoidance. This fixes the critical security issue by rewiring production calls to use real BLS12-381 pairing verification.

## Changes

- **zk_verifier**: 
  - Gate fake verification path (`groth16_verify`, `verify_enhanced_vk_binding`, `verify_claim`) behind `#[cfg(any(test, feature = "testutils"))]`
  - Make `upgrade()` function public (matching `quorum_proof::upgrade` and `sbt_registry::upgrade`)
  - Add documentation warnings that the gated functions are test-only

- **quorum_proof**:
  - Rewire `verify_claim_batch()` and `verify_engineer()` to call real `verify_groth16_proof` instead of fake `verify_claim`
  - Add `encode_claim_public_inputs()` helper to bind proofs to specific credential and claim type via public inputs
  - This prevents forged proofs from being replayed across different credentials or claim types
  - Update function signatures to accept `vk_hash` parameters required by real verification

- **integration_tests & tests**:
  - Add `vk_hash` to `Contracts` struct for test reuse
  - Update all `verify_engineer()` and `verify_claim_batch()` test calls with new signatures
  - Ensure all verifying key setup is in place for tests

## Testing

All test harnesses have been updated to work with the new signatures. The fake verification path is still available for testing via the testutils feature.

## Breaking Changes

This is a breaking change for any external code calling `verify_engineer` or `verify_claim_batch` — both now require a `vk_hash` parameter. This is necessary to properly bind proofs to their intended credential and ensure real cryptographic verification is used.

Closes #1358