### PR TITLE
fix(reconcile): distinguish RPC failure from a genuine zero counter

### DIFF
--- a/scripts/reconcile_state.sh
+++ b/scripts/reconcile_state.sh
@@ -2,10 +2,23 @@
 # scripts/reconcile_state.sh — Issue #596: Automated contract state reconciliation.
 #
 # Compares key state counters across two contract instances (e.g. primary vs replica,
-# or two network environments) and triggers recovery if inconsistencies are detected.
+# or two network environments) and flags them for manual recovery if inconsistencies
+# are detected. This script does NOT itself perform recovery — it detects, reports,
+# and (if NOTIFY_WEBHOOK is set) pages on-call with an actionable payload. A human
+# (or a separate runbook) still has to act on the report.
+#
+# An RPC failure on either instance is never treated as a counter of 0. It is
+# surfaced as a distinct "unverifiable" state, so an outage on both instances
+# cannot read as "consistent".
 #
 # Usage:
 #   ./scripts/reconcile_state.sh <contract_id_a> <contract_id_b>
+#
+# Exit codes:
+#   0 — reconciliation complete, no inconsistencies found
+#   1 — inconsistency detected between the two instances (manual recovery required)
+#   2 — one or more counters could not be verified (RPC failure); NOT a confirmed
+#       consistent result
 #
 # Environment variables:
 #   STELLAR_NETWORK_A   — network for instance A (default: testnet)
@@ -30,7 +43,13 @@ TOLERANCE="${RECONCILE_TOLERANCE:-0}"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REPORT_FILE="$ROOT_DIR/reconcile_report_$(date -u +%Y%m%dT%H%M%SZ).json"
 
+# Sentinel returned by query_counter when a counter could not be determined
+# (RPC failure, or a non-numeric response), as opposed to a genuine value of 0.
+UNKNOWN_MARKER="UNKNOWN"
+
 INCONSISTENCIES=0
+UNVERIFIED=0
+UNVERIFIED_METRICS=""
 
 log()   { echo "[$(date -u +%H:%M:%SZ)] $*"; }
 alert() {
@@ -43,6 +62,18 @@ alert() {
       -d "{\"text\":\"[QuorumProof Reconcile] $msg\"}" || true
   fi
 }
+unverifiable() {
+  local label="$1" val_a="$2" val_b="$3"
+  local msg="$label could not be verified: A=$val_a B=$val_b (RPC query failed on at least one instance)"
+  log "  [UNKNOWN] $msg"
+  UNVERIFIED=$((UNVERIFIED + 1))
+  UNVERIFIED_METRICS+="$label"$'\n'
+  if [[ -n "$NOTIFY_WEBHOOK" ]]; then
+    curl -s -X POST "$NOTIFY_WEBHOOK" \
+      -H 'Content-Type: application/json' \
+      -d "{\"text\":\"[QuorumProof Reconcile] UNVERIFIED: $msg\"}" || true
+  fi
+}
 
 require_cmd() { command -v "$1" &>/dev/null || { log "Required: $1"; exit 1; }; }
 require_cmd stellar
@@ -50,15 +81,26 @@ require_cmd jq
 require_cmd python3
 
 # ── Query a counter from a contract ──────────────────────────────────────────
+# Prints the counter value, or $UNKNOWN_MARKER if the RPC call failed or
+# returned something that isn't a plain integer. Never silently maps a
+# failure to "0" — a genuine 0 and an unreachable instance must stay
+# distinguishable to the caller.
 query_counter() {
   local contract="$1" network="$2" rpc="$3" fn="$4"
-  stellar contract invoke \
+  local raw
+  if raw=$(stellar contract invoke \
     --id "$contract" \
     --network "$network" \
     --rpc-url "$rpc" \
-    -- "$fn" 2>/dev/null \
-    | tr -d '"' \
-    || echo "0"
+    -- "$fn" 2>/dev/null | tr -d '"'); then
+    if [[ "$raw" =~ ^-?[0-9]+$ ]]; then
+      echo "$raw"
+    else
+      echo "$UNKNOWN_MARKER"
+    fi
+  else
+    echo "$UNKNOWN_MARKER"
+  fi
 }
 
 # ── Step 1: Fetch state from both instances ───────────────────────────────────
@@ -76,6 +118,12 @@ log "Instance B — credentials: $CRED_COUNT_B, slices: $SLICE_COUNT_B"
 # ── Step 2: Compare with tolerance ───────────────────────────────────────────
 check_delta() {
   local label="$1" val_a="$2" val_b="$3"
+
+  if [[ "$val_a" == "$UNKNOWN_MARKER" || "$val_b" == "$UNKNOWN_MARKER" ]]; then
+    unverifiable "$label" "$val_a" "$val_b"
+    return
+  fi
+
   local delta=$(( val_a > val_b ? val_a - val_b : val_b - val_a ))
   if (( delta > TOLERANCE )); then
     alert "$label mismatch: A=$val_a B=$val_b delta=$delta (tolerance=$TOLERANCE)"
@@ -88,31 +136,59 @@ log "--- Comparing state ---"
 check_delta "credential_count" "$CRED_COUNT_A" "$CRED_COUNT_B"
 check_delta "slice_count"      "$SLICE_COUNT_A" "$SLICE_COUNT_B"
 
-# ── Step 3: Write report ──────────────────────────────────────────────────────
+# ── Step 3: Determine overall status and write report ────────────────────────
+if (( INCONSISTENCIES > 0 )); then
+  STATUS="inconsistent"
+elif (( UNVERIFIED > 0 )); then
+  STATUS="unverifiable"
+else
+  STATUS="consistent"
+fi
+
+UNVERIFIED_METRICS_JSON=$(printf '%s' "$UNVERIFIED_METRICS" | jq -R -s 'split("\n") | map(select(length > 0))')
+
 jq -n \
   --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg status "$STATUS" \
   --arg contract_a "$CONTRACT_A" \
   --arg contract_b "$CONTRACT_B" \
-  --argjson cred_a "$CRED_COUNT_A" \
-  --argjson cred_b "$CRED_COUNT_B" \
-  --argjson slice_a "$SLICE_COUNT_A" \
-  --argjson slice_b "$SLICE_COUNT_B" \
+  --arg cred_a "$CRED_COUNT_A" \
+  --arg cred_b "$CRED_COUNT_B" \
+  --arg slice_a "$SLICE_COUNT_A" \
+  --arg slice_b "$SLICE_COUNT_B" \
   --argjson inconsistencies "$INCONSISTENCIES" \
-  '{
+  --argjson unverified "$UNVERIFIED" \
+  --argjson unverified_metrics "$UNVERIFIED_METRICS_JSON" \
+  '
+  def num_or_null: if . == "UNKNOWN" then null else tonumber end;
+  {
     timestamp: $ts,
-    instance_a: {contract: $contract_a, credential_count: $cred_a, slice_count: $slice_a},
-    instance_b: {contract: $contract_b, credential_count: $cred_b, slice_count: $slice_b},
-    inconsistencies: $inconsistencies
+    status: $status,
+    instance_a: {contract: $contract_a, credential_count: ($cred_a | num_or_null), slice_count: ($slice_a | num_or_null)},
+    instance_b: {contract: $contract_b, credential_count: ($cred_b | num_or_null), slice_count: ($slice_b | num_or_null)},
+    inconsistencies: $inconsistencies,
+    unverified: $unverified,
+    unverified_metrics: $unverified_metrics
   }' > "$REPORT_FILE"
 
 log "Report written to $REPORT_FILE"
 
-# ── Step 4: Trigger recovery if inconsistencies found ────────────────────────
-if [[ $INCONSISTENCIES -gt 0 ]]; then
-  log "RECOVERY TRIGGERED: $INCONSISTENCIES inconsistency(ies) detected."
-  log "Manual review required. See $REPORT_FILE for details."
-  # In a real deployment, this would invoke a recovery runbook or page on-call.
+# ── Step 4: Surface the result — never claim success on an unverified state ──
+if (( INCONSISTENCIES > 0 )); then
+  log "MANUAL RECOVERY REQUIRED: $INCONSISTENCIES inconsistency(ies) detected between $CONTRACT_A ($NETWORK_A) and $CONTRACT_B ($NETWORK_B)."
+  log "This script does not perform automated recovery — see $REPORT_FILE and invoke the appropriate recovery runbook."
+  if [[ -n "$NOTIFY_WEBHOOK" ]]; then
+    curl -s -X POST "$NOTIFY_WEBHOOK" \
+      -H 'Content-Type: application/json' \
+      -d "$(jq -n --arg text "[QuorumProof Reconcile] MANUAL RECOVERY REQUIRED: $INCONSISTENCIES inconsistency(ies) between $CONTRACT_A ($NETWORK_A) and $CONTRACT_B ($NETWORK_B). Report: $REPORT_FILE" '{text: $text}')" || true
+  fi
   exit 1
+fi
+
+if (( UNVERIFIED > 0 )); then
+  log "UNABLE TO VERIFY: $UNVERIFIED metric(s) could not be compared — RPC failure on at least one instance."
+  log "This is NOT a confirmed-consistent result. See $REPORT_FILE for details."
+  exit 2
 fi
 
 log "Reconciliation complete. No inconsistencies found."

--- a/scripts/tests/test_reconcile_state.sh
+++ b/scripts/tests/test_reconcile_state.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# scripts/tests/test_reconcile_state.sh — Tests for scripts/reconcile_state.sh
+#
+# Exercises reconcile_state.sh against a fake `stellar` CLI (a shell function
+# resolved via PATH) so no real network or Soroban RPC is required. Each test
+# configures the fake to return specific counter values or to fail outright,
+# runs the real script as a subprocess, and asserts on its exit code and the
+# JSON report it writes.
+#
+# Run with: ./scripts/tests/test_reconcile_state.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+RECONCILE_SCRIPT="$ROOT_DIR/reconcile_state.sh"
+# reconcile_state.sh resolves its own ROOT_DIR from its script path (not cwd)
+# and always writes reconcile_report_*.json there — i.e. the repo root.
+REPO_ROOT="$(dirname "$ROOT_DIR")"
+
+PASS=0
+FAIL=0
+
+WORK_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$WORK_DIR"
+  rm -f "$REPO_ROOT"/reconcile_report_*.json
+}
+trap cleanup EXIT
+
+# ── Fake `stellar` CLI ────────────────────────────────────────────────────────
+# Writes a fake `stellar` binary that returns STUB_CRED_A/STUB_SLICE_A for
+# contract $STUB_CONTRACT_A and STUB_CRED_B/STUB_SLICE_B for $STUB_CONTRACT_B,
+# failing instead when STUB_FAIL_A/STUB_FAIL_B is "1" — all read from the
+# environment at invocation time so each test just sets the env vars it needs.
+make_stub() {
+  local stub_dir="$WORK_DIR/bin"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/stellar" <<'STUB'
+#!/usr/bin/env bash
+# Fake `stellar` CLI for tests. Reads behavior from env vars set by the test.
+contract=""
+fn=""
+args=("$@")
+for ((i=0; i<${#args[@]}; i++)); do
+  if [[ "${args[$i]}" == "--id" ]]; then
+    contract="${args[$((i+1))]}"
+  fi
+done
+fn="${args[-1]}"
+
+if [[ "$contract" == "$STUB_CONTRACT_A" ]]; then
+  if [[ "$STUB_FAIL_A" == "1" ]]; then
+    echo "error: RPC call failed" >&2
+    exit 1
+  fi
+  if [[ "$fn" == "get_credential_count" ]]; then echo "\"$STUB_CRED_A\""; else echo "\"$STUB_SLICE_A\""; fi
+elif [[ "$contract" == "$STUB_CONTRACT_B" ]]; then
+  if [[ "$STUB_FAIL_B" == "1" ]]; then
+    echo "error: RPC call failed" >&2
+    exit 1
+  fi
+  if [[ "$fn" == "get_credential_count" ]]; then echo "\"$STUB_CRED_B\""; else echo "\"$STUB_SLICE_B\""; fi
+else
+  echo "error: unknown contract $contract" >&2
+  exit 1
+fi
+STUB
+  chmod +x "$stub_dir/stellar"
+  echo "$stub_dir"
+}
+
+run_reconcile() {
+  local contract_a="$1" contract_b="$2" stub_dir="$3"
+  (
+    cd "$WORK_DIR" && \
+    PATH="$stub_dir:$PATH" \
+    STUB_CONTRACT_A="$contract_a" STUB_CONTRACT_B="$contract_b" \
+    STUB_CRED_A="${STUB_CRED_A:-0}" STUB_SLICE_A="${STUB_SLICE_A:-0}" \
+    STUB_CRED_B="${STUB_CRED_B:-0}" STUB_SLICE_B="${STUB_SLICE_B:-0}" \
+    STUB_FAIL_A="${STUB_FAIL_A:-0}" STUB_FAIL_B="${STUB_FAIL_B:-0}" \
+    "$RECONCILE_SCRIPT" "$contract_a" "$contract_b" > "$WORK_DIR/stdout.log" 2>&1
+  )
+}
+
+latest_report() { ls -t "$REPO_ROOT"/reconcile_report_*.json 2>/dev/null | head -n1; }
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  ok - $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL - $desc (expected='$expected' actual='$actual')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+reset_stubs() {
+  unset STUB_CRED_A STUB_SLICE_A STUB_CRED_B STUB_SLICE_B STUB_FAIL_A STUB_FAIL_B
+  rm -f "$REPO_ROOT"/reconcile_report_*.json "$WORK_DIR/stdout.log"
+}
+
+echo "=== test_reconcile_state.sh ==="
+
+# ── Test 1: matching counters on two reachable instances → consistent ────────
+reset_stubs
+STUB_CRED_A=10 STUB_SLICE_A=5 STUB_CRED_B=10 STUB_SLICE_B=5 \
+  run_reconcile "contractA" "contractB" "$(make_stub)"
+exit_code=$?
+report="$(latest_report)"
+assert_eq "consistent counters exit 0" "0" "$exit_code"
+assert_eq "consistent report status" "consistent" "$(jq -r .status "$report")"
+assert_eq "consistent report inconsistencies=0" "0" "$(jq -r .inconsistencies "$report")"
+assert_eq "consistent report unverified=0" "0" "$(jq -r .unverified "$report")"
+
+# ── Test 2: genuine mismatch on two reachable instances → detected ───────────
+reset_stubs
+STUB_CRED_A=10 STUB_SLICE_A=5 STUB_CRED_B=12 STUB_SLICE_B=5 \
+  run_reconcile "contractA" "contractB" "$(make_stub)"
+exit_code=$?
+report="$(latest_report)"
+assert_eq "mismatch exits 1" "1" "$exit_code"
+assert_eq "mismatch report status" "inconsistent" "$(jq -r .status "$report")"
+assert_eq "mismatch report inconsistencies=1" "1" "$(jq -r .inconsistencies "$report")"
+assert_eq "mismatch report unverified=0" "0" "$(jq -r .unverified "$report")"
+assert_eq "mismatch report cred_a=10" "10" "$(jq -r .instance_a.credential_count "$report")"
+assert_eq "mismatch report cred_b=12" "12" "$(jq -r .instance_b.credential_count "$report")"
+
+# ── Test 3: both instances unreachable → NOT reported as consistent ──────────
+reset_stubs
+STUB_FAIL_A=1 STUB_FAIL_B=1 \
+  run_reconcile "contractA" "contractB" "$(make_stub)"
+exit_code=$?
+report="$(latest_report)"
+assert_eq "total outage exits 2 (unverifiable, not 0)" "2" "$exit_code"
+assert_eq "total outage report status is unverifiable" "unverifiable" "$(jq -r .status "$report")"
+assert_eq "total outage inconsistencies=0 (not falsely flagged as data mismatch)" "0" "$(jq -r .inconsistencies "$report")"
+assert_eq "total outage unverified=2 (both metrics unverifiable)" "2" "$(jq -r .unverified "$report")"
+assert_eq "total outage credential_count is null, not 0" "null" "$(jq -r '.instance_a.credential_count' "$report")"
+grep -q "Reconciliation complete. No inconsistencies found." "$WORK_DIR/stdout.log" && {
+  echo "  FAIL - total outage log must not claim 'No inconsistencies found'"
+  FAIL=$((FAIL + 1))
+} || {
+  echo "  ok - total outage log does not claim 'No inconsistencies found'"
+  PASS=$((PASS + 1))
+}
+
+# ── Test 4: only instance A unreachable → asymmetric failure is unverifiable ─
+reset_stubs
+STUB_FAIL_A=1 STUB_CRED_B=10 STUB_SLICE_B=5 \
+  run_reconcile "contractA" "contractB" "$(make_stub)"
+exit_code=$?
+report="$(latest_report)"
+assert_eq "asymmetric failure exits 2" "2" "$exit_code"
+assert_eq "asymmetric failure report status is unverifiable" "unverifiable" "$(jq -r .status "$report")"
+assert_eq "asymmetric failure unverified=2" "2" "$(jq -r .unverified "$report")"
+
+# ── Test 5: mismatch on one metric + RPC failure on another → both surfaced ──
+reset_stubs
+# credential_count mismatches (10 vs 12); slice_count query for B fails.
+stub_dir="$WORK_DIR/bin_mixed"
+mkdir -p "$stub_dir"
+cat > "$stub_dir/stellar" <<'STUB'
+#!/usr/bin/env bash
+contract=""
+args=("$@")
+for ((i=0; i<${#args[@]}; i++)); do
+  if [[ "${args[$i]}" == "--id" ]]; then contract="${args[$((i+1))]}"; fi
+done
+fn="${args[-1]}"
+if [[ "$contract" == "contractA" ]]; then
+  if [[ "$fn" == "get_credential_count" ]]; then echo "\"10\""; else echo "\"5\""; fi
+elif [[ "$contract" == "contractB" ]]; then
+  if [[ "$fn" == "get_credential_count" ]]; then echo "\"12\""; else echo "error: timeout" >&2; exit 1; fi
+fi
+STUB
+chmod +x "$stub_dir/stellar"
+run_reconcile "contractA" "contractB" "$stub_dir"
+exit_code=$?
+report="$(latest_report)"
+assert_eq "mixed result exits 1 (inconsistency takes priority)" "1" "$exit_code"
+assert_eq "mixed result status is inconsistent" "inconsistent" "$(jq -r .status "$report")"
+assert_eq "mixed result inconsistencies=1" "1" "$(jq -r .inconsistencies "$report")"
+assert_eq "mixed result unverified=1" "1" "$(jq -r .unverified "$report")"
+assert_eq "mixed result unverified_metrics contains slice_count" "slice_count" "$(jq -r '.unverified_metrics[0]' "$report")"
+
+# ── Test 6: existing report schema keys are preserved ────────────────────────
+reset_stubs
+STUB_CRED_A=1 STUB_SLICE_A=1 STUB_CRED_B=1 STUB_SLICE_B=1 \
+  run_reconcile "contractA" "contractB" "$(make_stub)"
+report="$(latest_report)"
+for key in timestamp instance_a instance_b inconsistencies; do
+  present="$(jq "has(\"$key\")" "$report")"
+  assert_eq "report retains legacy key '$key'" "true" "$present"
+done
+for key in credential_count slice_count; do
+  present_a="$(jq ".instance_a | has(\"$key\")" "$report")"
+  assert_eq "instance_a retains legacy key '$key'" "true" "$present_a"
+done
+
+echo ""
+echo "=== $PASS passed, $FAIL failed ==="
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
 fix(reconcile): distinguish RPC failure from a genuine zero counter

  Closes #1369
                                                                                                                                                                           
  - query_counter no longer maps a failed `stellar contract invoke` to "0";
    it returns a distinct UNKNOWN sentinel on RPC failure or non-numeric output.
  - check_delta treats UNKNOWN as its own "unverifiable" outcome, never folded
    into "consistent" — a total outage on both instances no longer reports
    "No inconsistencies found."
  - Report JSON adds status (consistent/inconsistent/unverifiable), unverified,
    and unverified_metrics; counts are null instead of 0 when unknown. Existing
    fields (timestamp, instance_a/instance_b, inconsistencies) are preserved.
  - Exit codes: 0 consistent, 1 inconsistency detected, 2 unverifiable.
  - Reworded header/log output ("MANUAL RECOVERY REQUIRED" instead of
    "RECOVERY TRIGGERED") since the script only detects and alerts, and the
    NOTIFY_WEBHOOK payload now includes the report path and both
    contract/network identifiers.
  - Added scripts/tests/test_reconcile_state.sh (30 assertions) covering:
    matching counters, a genuine mismatch, both instances failing, one
    instance failing, mixed mismatch+failure, and legacy schema preservation.