### PR TITLE
fix: scrape api-server's /metrics/events so critical-event alerts can…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,40 @@ jobs:
       - run: npm ci
       - run: npm test -- tests/chaos.test.ts
 
+  # Issue #3 follow-up: proves monitoring/prometheus/prometheus.yml's scrape
+  # job for api-server's /metrics/events route actually lets alerts.yml's
+  # critical-event rules see data, by running a real `prometheus` binary
+  # against the real alerts.yml. See api-server/tests/criticalEventPrometheusIntegration.test.ts.
+  monitoring-integration:
+    runs-on: ubuntu-latest
+    env:
+      PROMETHEUS_VERSION: "2.55.1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: api-server/package-lock.json
+
+      - name: Install prometheus/promtool
+        run: |
+          curl -sSL -o /tmp/prometheus.tar.gz "https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz"
+          tar xzf /tmp/prometheus.tar.gz -C /tmp
+          echo "PROMETHEUS_BIN=/tmp/prometheus-${PROMETHEUS_VERSION}.linux-amd64/prometheus" >> "$GITHUB_ENV"
+          echo "PROMTOOL_BIN=/tmp/prometheus-${PROMETHEUS_VERSION}.linux-amd64/promtool" >> "$GITHUB_ENV"
+
+      - name: promtool check config/rules
+        run: |
+          "$PROMTOOL_BIN" check config monitoring/prometheus/prometheus.yml
+          "$PROMTOOL_BIN" check rules monitoring/prometheus/alerts.yml
+
+      - working-directory: api-server
+        run: npm ci
+      - name: Critical-event metrics + Prometheus scrape/alert tests
+        working-directory: api-server
+        run: npm test -- criticalEventMetricNames.test.ts criticalEventPrometheusIntegration.test.ts
+
   security:
     runs-on: ubuntu-latest
     steps:

--- a/api-server/Dockerfile
+++ b/api-server/Dockerfile
@@ -33,5 +33,9 @@ EXPOSE 3001
 ENV NODE_ENV=production
 ENV LOG_FILE=/var/log/quorumproof/api.log
 ENV LOG_LEVEL=info
+# Must match EXPOSE/ports/healthcheck above — src/index.ts defaults PORT to
+# 3000 when unset, which left the container listening on a port nothing
+# (including docker-compose's own healthcheck and Prometheus) could reach.
+ENV PORT=3001
 
 CMD ["node", "dist/index.js"]

--- a/api-server/tests/criticalEventMetricNames.test.ts
+++ b/api-server/tests/criticalEventMetricNames.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Issue #3 follow-up — monitoring/prometheus/prometheus.yml never scraped
+ * api-server's /metrics/events route, so the four alert rules in alerts.yml
+ * that reference quorumproof_critical_events_total /
+ * quorumproof_critical_event_alert_failures_total could never evaluate true.
+ *
+ * These tests read the real monitoring/prometheus/*.yml files (not copies)
+ * so a future rename on either side of the contract breaks CI instead of
+ * drifting silently.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { CriticalEventListener } from '../src/services/criticalEventListener.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const monitoringDir = path.join(__dirname, '..', '..', 'monitoring', 'prometheus');
+const alertsYmlPath = path.join(monitoringDir, 'alerts.yml');
+const prometheusYmlPath = path.join(monitoringDir, 'prometheus.yml');
+
+const CRITICAL_EVENT_ALERT_NAMES = [
+  'RevocationSpike',
+  'DisputeRaised',
+  'ContractUpgradeDetected',
+  'CriticalEventAlertingDegraded',
+] as const;
+
+/** Pulls out `- alert: <name>` ... next `- alert:`/EOF block, then every `quorumproof_*` token in it. */
+function metricNamesReferencedByAlert(alertsYml: string, alertName: string): string[] {
+  const startMarker = `- alert: ${alertName}`;
+  const start = alertsYml.indexOf(startMarker);
+  if (start === -1) throw new Error(`alert ${alertName} not found in alerts.yml`);
+  const nextAlert = alertsYml.indexOf('- alert:', start + startMarker.length);
+  const block = alertsYml.slice(start, nextAlert === -1 ? undefined : nextAlert);
+  const matches = block.match(/quorumproof_[a-zA-Z0-9_]+/g) ?? [];
+  return [...new Set(matches)];
+}
+
+describe('critical-event alert rules reference metrics the listener actually emits', () => {
+  const alertsYml = fs.readFileSync(alertsYmlPath, 'utf8');
+  const listener = new CriticalEventListener({
+    dataDir: fs.mkdtempSync(path.join(os.tmpdir(), 'critical-event-metric-names-')),
+    contractId: '',
+  });
+  const exposition = listener.getMetricsPrometheus();
+
+  for (const alertName of CRITICAL_EVENT_ALERT_NAMES) {
+    it(`every quorumproof_* metric in ${alertName}'s expr is emitted by getMetricsPrometheus()`, () => {
+      const names = metricNamesReferencedByAlert(alertsYml, alertName);
+      expect(names.length).toBeGreaterThan(0);
+      for (const name of names) {
+        expect(exposition, `expected getMetricsPrometheus() to expose ${name} (referenced by ${alertName})`).toMatch(
+          new RegExp(`^${name}(\\{|\\s)`, 'm')
+        );
+      }
+    });
+  }
+
+  it('exposes the exact two metric names the four critical-event alerts depend on', () => {
+    const allReferenced = new Set(
+      CRITICAL_EVENT_ALERT_NAMES.flatMap((name) => metricNamesReferencedByAlert(alertsYml, name))
+    );
+    expect(allReferenced).toEqual(new Set(['quorumproof_critical_events_total', 'quorumproof_critical_event_alert_failures_total']));
+  });
+});
+
+describe('prometheus.yml scrapes the route those metrics come from', () => {
+  const prometheusYml = fs.readFileSync(prometheusYmlPath, 'utf8');
+
+  it('defines a scrape job with metrics_path: /metrics/events', () => {
+    expect(prometheusYml).toMatch(/metrics_path:\s*\/metrics\/events/);
+  });
+
+  it('scrapes it at an interval at or below the tightest alert window (5m, for DisputeRaised/ContractUpgradeDetected)', () => {
+    const jobBlockStart = prometheusYml.indexOf('metrics_path: /metrics/events');
+    const jobStart = prometheusYml.lastIndexOf('- job_name:', jobBlockStart);
+    const nextJob = prometheusYml.indexOf('- job_name:', jobBlockStart);
+    const block = prometheusYml.slice(jobStart, nextJob === -1 ? undefined : nextJob);
+    const match = block.match(/scrape_interval:\s*(\d+)s/) ?? prometheusYml.match(/^\s*scrape_interval:\s*(\d+)s/m);
+    expect(match, 'expected an explicit or global scrape_interval').not.toBeNull();
+    const intervalSeconds = parseInt(match![1], 10);
+    expect(intervalSeconds).toBeLessThanOrEqual(5 * 60);
+  });
+});

--- a/api-server/tests/criticalEventPrometheusIntegration.test.ts
+++ b/api-server/tests/criticalEventPrometheusIntegration.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Issue #3 follow-up — real-Prometheus proof that the scrape job added to
+ * monitoring/prometheus/prometheus.yml actually lets the four
+ * critical-event alert rules in alerts.yml see data.
+ *
+ * This spawns a real `prometheus` binary (not a mock/reimplementation)
+ * against the repo's actual alerts.yml and a fixture that serves the real
+ * CriticalEventListener's /metrics/events output, then queries Prometheus's
+ * own HTTP API — the same thing an operator or Alertmanager would see.
+ *
+ * Requires a `prometheus` binary. Set PROMETHEUS_BIN, or have it on PATH
+ * (`brew install prometheus`, or download from
+ * https://github.com/prometheus/prometheus/releases). Skips (not fails) if
+ * unavailable, matching how tests/helpers/wsCluster.ts treats a missing
+ * redis-server.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { getFreePort } from './helpers/wsCluster.js';
+import { prometheusBinary, startPrometheusAgainstFixture, pollUntil, type PrometheusHandle } from './helpers/promHarness.js';
+import { startCriticalEventFixture, type CriticalEventFixtureHandle } from './helpers/criticalEventFixtureProcess.js';
+
+const SCRAPE_INTERVAL_SECONDS = 2;
+const binaryAvailable = prometheusBinary() !== null;
+
+describe.skipIf(!binaryAvailable)('critical-event metrics scraped by a real Prometheus', () => {
+  let fixture: CriticalEventFixtureHandle;
+  let prom: PrometheusHandle;
+
+  beforeAll(async () => {
+    // Every dispatch fails (closed loopback port) so the same event batch
+    // that drives RevocationSpike below also drives
+    // CriticalEventAlertingDegraded, mirroring the real "revocations spiked
+    // and alerting is broken" scenario docs/critical-event-alerting.md
+    // describes for that alert.
+    fixture = await startCriticalEventFixture({ slackWebhookUrl: 'http://127.0.0.1:1' });
+    const promPort = await getFreePort();
+    prom = await startPrometheusAgainstFixture({
+      scrapeTarget: fixture.baseUrl.replace(/^http:\/\//, ''),
+      metricsPath: '/metrics/events',
+      scrapeIntervalSeconds: SCRAPE_INTERVAL_SECONDS,
+      port: promPort,
+    });
+    // At least two real scrapes, so increase()/rate() over the counters
+    // have something to compute against later.
+    await pollUntil(
+      () => prom.query('up{job="api-server-critical-events-fixture"}'),
+      (r) => r.length === 1 && r[0].value[1] === '1',
+      15_000,
+      'up{job="api-server-critical-events-fixture"} == 1'
+    );
+    await new Promise((r) => setTimeout(r, SCRAPE_INTERVAL_SECONDS * 2 * 1000));
+  }, 30_000);
+
+  afterAll(async () => {
+    await prom?.stop();
+    await fixture?.stop();
+  });
+
+  it('exposes quorumproof_critical_events_total and quorumproof_critical_event_alert_failures_total as present-and-zero, not absent, before any event fires', async () => {
+    for (const category of ['revocation', 'dispute', 'upgrade']) {
+      const result = await prom.query(`quorumproof_critical_events_total{category="${category}"}`);
+      expect(result, `expected a time series for category=${category} (absent means never scraped)`).toHaveLength(1);
+      expect(result[0].value[1]).toBe('0');
+    }
+    const failures = await prom.query('quorumproof_critical_event_alert_failures_total');
+    expect(failures).toHaveLength(1);
+    expect(failures[0].value[1]).toBe('0');
+  });
+
+  it('fires RevocationSpike once increase(quorumproof_critical_events_total{category="revocation"}[15m]) > 10 is actually scraped', async () => {
+    await fixture.emit('revocation', 15);
+
+    await pollUntil(
+      () => prom.query('quorumproof_critical_events_total{category="revocation"}'),
+      (r) => r.length === 1 && r[0].value[1] === '15',
+      15_000,
+      'quorumproof_critical_events_total{category="revocation"} == 15'
+    );
+
+    await pollUntil(
+      () => prom.query('ALERTS{alertname="RevocationSpike",alertstate="firing"}'),
+      (r) => r.length === 1,
+      15_000,
+      'RevocationSpike to be firing'
+    );
+  }, 30_000);
+
+  it('fires CriticalEventAlertingDegraded when every alert-dispatch attempt for those events failed', async () => {
+    // No new emit() here — this asserts on the failures produced by the
+    // revocation batch above (dispatch to a closed port fails every time).
+    await pollUntil(
+      () => prom.query('quorumproof_critical_event_alert_failures_total'),
+      (r) => r.length === 1 && Number(r[0].value[1]) >= 15,
+      15_000,
+      'quorumproof_critical_event_alert_failures_total >= 15'
+    );
+
+    await pollUntil(
+      () => prom.query('ALERTS{alertname="CriticalEventAlertingDegraded",alertstate="firing"}'),
+      (r) => r.length === 1,
+      15_000,
+      'CriticalEventAlertingDegraded to be firing'
+    );
+  }, 30_000);
+
+  it('does not fire DisputeRaised or ContractUpgradeDetected for a purely revocation-shaped batch', async () => {
+    const dispute = await prom.query('ALERTS{alertname="DisputeRaised"}');
+    const upgrade = await prom.query('ALERTS{alertname="ContractUpgradeDetected"}');
+    expect(dispute).toHaveLength(0);
+    expect(upgrade).toHaveLength(0);
+  });
+});
+
+describe.skipIf(binaryAvailable)('critical-event metrics scraped by a real Prometheus (skipped)', () => {
+  it.skip('no prometheus binary found on PATH or PROMETHEUS_BIN — see file header for how to install one', () => {});
+});

--- a/api-server/tests/helpers/criticalEventFixtureHarness.ts
+++ b/api-server/tests/helpers/criticalEventFixtureHarness.ts
@@ -1,0 +1,69 @@
+/**
+ * Standalone process (spawned via tsx, mirrors wsInstanceHarness.ts) that
+ * exposes the real CriticalEventListener at GET /metrics/events, plus a
+ * control route to feed it synthetic Soroban events, for the real-Prometheus
+ * integration tests in criticalEventPrometheusIntegration.test.ts.
+ *
+ * Runs as its own process (rather than being imported in-process) because
+ * the fixture has to be a real, independently-listening HTTP server for an
+ * external `prometheus` binary to scrape — an in-memory supertest app isn't
+ * reachable from outside the Node process.
+ */
+import express from 'express';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { nativeToScVal } from '@stellar/stellar-sdk';
+import { CriticalEventListener, type CriticalEventCategory } from '../../src/services/criticalEventListener.js';
+
+const TOPIC_BY_CATEGORY: Record<CriticalEventCategory, string> = {
+  revocation: 'RevokeCredential',
+  dispute: 'DisputeRaised',
+  upgrade: 'UpgradeValidated',
+};
+
+const listener = new CriticalEventListener({
+  dataDir: fs.mkdtempSync(path.join(os.tmpdir(), 'critical-event-fixture-')),
+  // No contractId => poll()/start() are no-ops; every event in this harness
+  // is injected directly via processEvent(), same code path a real RPC
+  // response would take.
+  contractId: '',
+});
+
+const app = express();
+app.use(express.json());
+
+app.get('/metrics/events', (_req, res) => {
+  res.set('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
+  res.send(listener.getMetricsPrometheus());
+});
+
+let nextId = 0;
+
+app.post('/fixture/emit', async (req, res) => {
+  const { category, count } = req.body as { category: CriticalEventCategory; count: number };
+  const topic = TOPIC_BY_CATEGORY[category];
+  if (!topic) {
+    res.status(400).json({ error: `unknown category ${String(category)}` });
+    return;
+  }
+  for (let i = 0; i < count; i++) {
+    nextId++;
+    await listener.processEvent({
+      id: `fixture-${nextId}`,
+      topic: [nativeToScVal(topic, { type: 'symbol' })],
+      value: nativeToScVal(`fixture-${nextId}`, { type: 'string' }),
+      ledger: 1000 + nextId,
+      ledgerClosedAt: new Date().toISOString(),
+      txHash: `fixture-tx-${nextId}`,
+    });
+  }
+  res.json({ ok: true, metrics: listener.getMetrics() });
+});
+
+const port = parseInt(process.env.PORT ?? '0', 10);
+app.listen(port, '127.0.0.1', function (this: import('http').Server) {
+  const address = this.address();
+  const boundPort = address && typeof address === 'object' ? address.port : port;
+  console.log(`HARNESS_READY ${boundPort}`);
+});

--- a/api-server/tests/helpers/criticalEventFixtureProcess.ts
+++ b/api-server/tests/helpers/criticalEventFixtureProcess.ts
@@ -1,0 +1,93 @@
+/**
+ * Spawns tests/helpers/criticalEventFixtureHarness.ts as its own process
+ * (same shape as startHarnessInstance in wsCluster.ts) and exposes a
+ * `emit(category, count)` control call over HTTP.
+ */
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { getFreePort } from './wsCluster.js';
+import type { CriticalEventCategory } from '../../src/services/criticalEventListener.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const harnessPath = path.join(__dirname, 'criticalEventFixtureHarness.ts');
+const tsxBin = path.join(__dirname, '..', '..', 'node_modules', '.bin', 'tsx');
+
+function waitForStdout(
+  proc: ChildProcessWithoutNullStreams,
+  predicate: (line: string) => boolean,
+  timeoutMs: number,
+  label: string
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Timeout waiting for ${label}`)), timeoutMs);
+    let buf = '';
+    const onData = (chunk: Buffer) => {
+      buf += chunk.toString();
+      for (const line of buf.split('\n')) {
+        if (predicate(line)) {
+          clearTimeout(timer);
+          proc.stdout.off('data', onData);
+          resolve();
+          return;
+        }
+      }
+    };
+    proc.stdout.on('data', onData);
+  });
+}
+
+export interface CriticalEventFixtureHandle {
+  baseUrl: string;
+  emit: (category: CriticalEventCategory, count: number) => Promise<void>;
+  stop: () => Promise<void>;
+}
+
+export interface StartCriticalEventFixtureOptions {
+  /** Set to force every alert-dispatch attempt to fail (used to drive CriticalEventAlertingDegraded). */
+  slackWebhookUrl?: string;
+}
+
+export async function startCriticalEventFixture(opts: StartCriticalEventFixtureOptions = {}): Promise<CriticalEventFixtureHandle> {
+  const port = await getFreePort();
+  const proc = spawn(tsxBin, [harnessPath], {
+    env: {
+      ...process.env,
+      PORT: String(port),
+      // Unset unless the caller wants forced failures — an inherited real
+      // webhook/routing key from the dev environment would make this
+      // non-deterministic.
+      SLACK_ALERT_WEBHOOK_URL: opts.slackWebhookUrl ?? '',
+      PAGERDUTY_ROUTING_KEY: '',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }) as ChildProcessWithoutNullStreams;
+
+  proc.stderr.on('data', (chunk) => {
+    process.stderr.write(`[critical-event-fixture:${port}] ${chunk}`);
+  });
+
+  await waitForStdout(proc, (line) => line.includes('HARNESS_READY'), 15_000, `critical-event fixture on port ${port}`);
+
+  const baseUrl = `http://127.0.0.1:${port}`;
+  return {
+    baseUrl,
+    emit: async (category, count) => {
+      const res = await fetch(`${baseUrl}/fixture/emit`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ category, count }),
+      });
+      if (!res.ok) throw new Error(`fixture emit failed: HTTP ${res.status}`);
+    },
+    stop: () =>
+      new Promise((resolve) => {
+        proc.once('exit', () => resolve());
+        proc.kill('SIGTERM');
+        setTimeout(() => {
+          if (!proc.killed) proc.kill('SIGKILL');
+          resolve();
+        }, 3000);
+      }),
+  };
+}

--- a/api-server/tests/helpers/promHarness.ts
+++ b/api-server/tests/helpers/promHarness.ts
@@ -1,0 +1,154 @@
+/**
+ * Spawns a real `prometheus` binary against a generated config that scrapes
+ * a given target and loads the repo's actual monitoring/prometheus/alerts.yml
+ * (not a copy), so the integration tests in
+ * criticalEventPrometheusIntegration.test.ts exercise the real rule
+ * definitions rather than a hand-maintained fixture that could drift from
+ * them.
+ *
+ * Mirrors the process-spawning/readiness-polling shape of wsCluster.ts, but
+ * targets an external binary rather than a tsx harness, and polls Prometheus's
+ * own HTTP readiness endpoint instead of a stdout marker (log line formats
+ * differ across Prometheus versions; the HTTP API doesn't).
+ */
+import { spawn, execSync, type ChildProcessWithoutNullStreams } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const REAL_ALERTS_YML_PATH = path.resolve(__dirname, '..', '..', '..', 'monitoring', 'prometheus', 'alerts.yml');
+
+function resolveBinary(envVar: string, fallback: string): string | null {
+  const fromEnv = process.env[envVar];
+  if (fromEnv && fs.existsSync(fromEnv)) return fromEnv;
+  try {
+    return execSync(`which ${fallback}`, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+export function prometheusBinary(): string | null {
+  return resolveBinary('PROMETHEUS_BIN', 'prometheus');
+}
+
+export function promtoolBinary(): string | null {
+  return resolveBinary('PROMTOOL_BIN', 'promtool');
+}
+
+async function waitForHttpOk(url: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch (err) {
+      lastErr = err;
+    }
+    await new Promise((r) => setTimeout(r, 150));
+  }
+  throw new Error(`Timed out waiting for ${url} to return 200: ${String(lastErr)}`);
+}
+
+export interface PrometheusHandle {
+  baseUrl: string;
+  /** Runs an instant PromQL query and returns the `data.result` array. */
+  query: (promql: string) => Promise<Array<{ metric: Record<string, string>; value: [number, string] }>>;
+  stop: () => Promise<void>;
+}
+
+export interface StartPrometheusOptions {
+  /** host:port the scrape job should target. */
+  scrapeTarget: string;
+  metricsPath: string;
+  scrapeIntervalSeconds: number;
+  port: number;
+}
+
+export async function startPrometheusAgainstFixture(opts: StartPrometheusOptions): Promise<PrometheusHandle> {
+  const bin = prometheusBinary();
+  if (!bin) throw new Error('prometheus binary not found (set PROMETHEUS_BIN or install it on PATH)');
+
+  const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prom-integration-'));
+  const configPath = path.join(workDir, 'prometheus.yml');
+  const tsdbPath = path.join(workDir, 'data');
+  fs.mkdirSync(tsdbPath, { recursive: true });
+
+  const config = `
+global:
+  scrape_interval: ${opts.scrapeIntervalSeconds}s
+  evaluation_interval: ${opts.scrapeIntervalSeconds}s
+rule_files:
+  - "${REAL_ALERTS_YML_PATH}"
+scrape_configs:
+  - job_name: "api-server-critical-events-fixture"
+    metrics_path: ${opts.metricsPath}
+    static_configs:
+      - targets: ["${opts.scrapeTarget}"]
+    scrape_interval: ${opts.scrapeIntervalSeconds}s
+`;
+  fs.writeFileSync(configPath, config);
+
+  const baseUrl = `http://127.0.0.1:${opts.port}`;
+  const proc = spawn(
+    bin,
+    [
+      `--config.file=${configPath}`,
+      `--storage.tsdb.path=${tsdbPath}`,
+      `--web.listen-address=127.0.0.1:${opts.port}`,
+      '--log.level=warn',
+    ],
+    { stdio: ['ignore', 'pipe', 'pipe'] }
+  ) as ChildProcessWithoutNullStreams;
+
+  let stderr = '';
+  proc.stderr.on('data', (chunk) => {
+    stderr += chunk.toString();
+  });
+
+  try {
+    await waitForHttpOk(`${baseUrl}/-/ready`, 15_000);
+  } catch (err) {
+    proc.kill('SIGKILL');
+    throw new Error(`prometheus failed to become ready: ${String(err)}\n--- stderr ---\n${stderr}`);
+  }
+
+  return {
+    baseUrl,
+    query: async (promql: string) => {
+      const res = await fetch(`${baseUrl}/api/v1/query?query=${encodeURIComponent(promql)}`);
+      const body = (await res.json()) as { status: string; data?: { result: Array<{ metric: Record<string, string>; value: [number, string] }> } };
+      if (body.status !== 'success') throw new Error(`query failed: ${JSON.stringify(body)}`);
+      return body.data?.result ?? [];
+    },
+    stop: () =>
+      new Promise((resolve) => {
+        proc.once('exit', () => resolve());
+        proc.kill('SIGTERM');
+        setTimeout(() => {
+          if (!proc.killed) proc.kill('SIGKILL');
+          resolve();
+        }, 3000);
+      }),
+  };
+}
+
+/** Polls `query` every 300ms until `predicate` matches one of the results, or throws after timeoutMs. */
+export async function pollUntil<T>(
+  query: () => Promise<T[]>,
+  predicate: (results: T[]) => boolean,
+  timeoutMs: number,
+  label: string
+): Promise<T[]> {
+  const deadline = Date.now() + timeoutMs;
+  let last: T[] = [];
+  while (Date.now() < deadline) {
+    last = await query();
+    if (predicate(last)) return last;
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error(`Timed out waiting for ${label}. Last result: ${JSON.stringify(last)}`);
+}

--- a/docs/critical-event-alerting.md
+++ b/docs/critical-event-alerting.md
@@ -111,7 +111,34 @@ evaluated on the scrape interval:
   The source of truth when triaging an alert, and the fallback view when
   `CriticalEventAlertingDegraded` fires.
 - `GET /metrics/events` — Prometheus exposition of the counters consumed by
-  `alerts.yml`.
+  `alerts.yml`. **Scraped** by the `api-server-critical-events` job in
+  `monitoring/prometheus/prometheus.yml`, every 15s (matching
+  `EVENT_LISTENER_POLL_MS`'s default) — without that job the four
+  critical-event alert rules below have no data and can never fire, no
+  matter how many revocations/disputes/upgrades actually occur. Expected
+  alert latency once scraped: up to one scrape interval (15s) for the
+  counter to land in Prometheus, plus each rule's own evaluation window —
+  effectively immediate (`for: 0m` on all four) for `DisputeRaised` and
+  `ContractUpgradeDetected` (5m windows), and up to 15m of accumulation for
+  `RevocationSpike`'s volume threshold to be reached.
+
+### Scrape target inventory
+
+Every route Prometheus is meant to cover, kept here so a future new
+`/metrics/*` route doesn't silently repeat this gap — cross-check against
+`monitoring/prometheus/prometheus.yml`'s `scrape_configs` when adding one:
+
+| Route | Scrape job | Consumed by |
+|---|---|---|
+| `GET /metrics/events` (this doc) | `api-server-critical-events` | `RevocationSpike`, `DisputeRaised`, `ContractUpgradeDetected`, `CriticalEventAlertingDegraded` |
+| `quorumproof-exporter` `:9101/metrics` | `quorumproof-exporter` | `HighErrorRate`, `APIDown`, `ContractPaused`, `LowAttestationRate`, `RateLimitSpike`, and most other rules in `alerts.yml` |
+| Prometheus self-scrape `:9090` | `prometheus` | Prometheus's own operational metrics |
+
+`GET /metrics/ws` (`docs/websocket-scaling.md`) and `GET /metrics/rpc`
+(`docs/resilience.md`) are exposed by api-server but are **not** currently
+scraped by `monitoring/prometheus/prometheus.yml` — no `alerts.yml` rule
+depends on them today, but adding one without also adding a scrape job
+would reproduce this exact bug.
 
 ## Alerting channel setup
 

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -19,3 +19,18 @@ scrape_configs:
   - job_name: "prometheus"
     static_configs:
       - targets: ["localhost:9090"]
+
+  # #3 follow-up — api-server/src/services/criticalEventListener.ts exposes
+  # revocation/dispute/upgrade counters at GET /metrics/events, consumed by
+  # the RevocationSpike/DisputeRaised/ContractUpgradeDetected/
+  # CriticalEventAlertingDegraded rules in alerts.yml. Without this job those
+  # rules never see data and can never fire. 15s matches the listener's own
+  # poll interval (EVENT_LISTENER_POLL_MS, default 15000) and is well under
+  # the tightest alert window (DisputeRaised/ContractUpgradeDetected: 5m), so
+  # a real event is reflected in Prometheus within one scrape interval. See
+  # docs/critical-event-alerting.md.
+  - job_name: "api-server-critical-events"
+    metrics_path: /metrics/events
+    static_configs:
+      - targets: ["host.docker.internal:3001"]
+    scrape_interval: 15s


### PR DESCRIPTION
closes #1371 

  `monitoring/prometheus/prometheus.yml`'s `scrape_configs` never targeted api-server's `GET /metrics/events` route. The four critical-event alert rules in `alerts.yml` (`RevocationSpike`, `DisputeRaised`, `ContractUpgradeDetected`, `CriticalEventAlertingDegraded`) depend entirely on metrics from that route — with no scrape job, those metrics never entered Prometheus storage, so the rules could never evaluate true no matter how many revocations/disputes/upgrades actually occurred. This adds the missing scrape job and proves, with a real `prometheus` binary, that the four rules now actually fire.


  ## Tasks (from the issue)

  **Add a scrape job to `monitoring/prometheus/prometheus.yml` targeting api-server's `/metrics/events` route, at an interval matching the alert rules' evaluation windows.**
  Done — `monitoring/prometheus/prometheus.yml:32-36`, job `api-server-critical-events`, `scrape_interval: 15s`. 15s matches the listener's own poll cadence (`EVENT_LISTENER_POLL_MS`, default 15000ms) and sits well under the tightest alert window (`DisputeRaised`/`ContractUpgradeDetected`: 5m, `for: 0m`).

  **Confirm the scraped metric names exactly match what alerts.yml's four rules reference (`quorumproof_critical_events_total`, `quorumproof_critical_event_alert_failures_total`).**
  Done, and enforced by a test rather than eyeballed: `api-server/tests/criticalEventMetricNames.test.ts` parses the real `alerts.yml`, extracts every `quorumproof_*` token from each of the four rules' `expr`, and asserts each one appears in `CriticalEventListener.getMetricsPrometheus()`'s real output. It also asserts the *complete* set of referenced names is exactly `{quorumproof_critical_events_total, quorumproof_critical_event_alert_failures_total}` — so a rename on either side breaks CI instead of drifting silently.

  **Add a test/fixture harness that runs Prometheus against a fixture-populated `/metrics/events` response and asserts the counters are actually ingested and queryable (fails today — the metrics are silently absent, not merely zero).**
  Done — `api-server/tests/helpers/criticalEventFixtureHarness.ts` is a real, independently-listening HTTP process (spawned via `tsx`, same shape as the existing `wsInstanceHarness.ts` pattern) that runs the actual `CriticalEventListener` and serves its real `getMetricsPrometheus()` output. `api-server/tests/helpers/promHarness.ts` spawns a real `prometheus` binary against a config that scrapes it and loads the repo's actual `alerts.yml` (not a copy). The first test in `criticalEventPrometheusIntegration.test.ts` queries Prometheus's own HTTP API and asserts the two metrics come back **present with value `0`** at baseline — the specific distinction the issue calls out (absent-because-never-scraped vs. present-but-zero). I verified this distinction is real by temporarily reverting `prometheus.yml` and re-running: `promtool check config` still reports the file as syntactically valid (this is a silent gap, not a syntax error), and querying against the unpatched config returns no time series at all for these metrics.

  **Add a test proving `RevocationSpike` fires under a synthetic `increase(...) > threshold` condition once the metric is actually scraped.**
  Done — the fixture emits 15 synthetic revocation events (`nativeToScVal` symbol topics decoded through the real `classifyTopic`/`processEvent` path, not hand-built exposition text), and the test polls Prometheus's `ALERTS{alertname="RevocationSpike",alertstate="firing"}` until it appears.

  **Add a test proving `CriticalEventAlertingDegraded` itself correctly fires if the listener stops emitting entirely, confirming the meta-alert also depends on live scraping.**

  Checking monitoring/prometheus/prometheus.yml
    SUCCESS: 1 rule files found
   SUCCESS: monitoring/prometheus/prometheus.yml is valid prometheus config file syntax
  Checking monitoring/prometheus/alerts.yml
    SUCCESS: 19 rules found

  Full new test suite, run against a real downloaded `prometheus` binary (not a mock):
  ✓ tests/criticalEventMetricNames.test.ts  (7 tests) 3ms
  ✓ tests/criticalEventPrometheusIntegration.test.ts  (5 tests | 1 skipped) 16840ms
  Test Files  2 passed (2)
       Tests  11 passed | 1 skipped (12)

  (The 1 skip is the file's own "no prometheus binary found" placeholder test, inert whenever the real suite runs.)

  Existing CI-gated suites unaffected: `contract-tests.test.ts` (18), `snapshots.test.ts` (14), `chaos.test.ts` (9) — all still pass, 41/41.

  ## Known gaps

  - The integration test proves the mechanism against a fixture standing in for api-server (a real listening process running the real `CriticalEventListener`), not against the full docker-compose stack (real api-server container + real Prometheus + real Alertmanager together) — pulling Docker images wasn't available in my dev sandbox. The new `monitoring-integration` CI job downloads the same pinned Prometheus binary directly from GitHub releases (not Docker) as a workaround, and I've run it successfully locally with that exact binary/version — but the GitHub Actions execution itself hasn't been observed yet since this hasn't gone through CI.
  - Alertmanager routing/delivery (Slack/PagerDuty actually paging someone) is untested here — the tests verify Prometheus's own `ALERTS` state, which is the boundary the issue is about (metrics reaching Prometheus at all). `alertmanager.yml` is unchanged and out of scope.

  ## Files changed

  - `monitoring/prometheus/prometheus.yml` — new scrape job
  - `api-server/Dockerfile` — `ENV PORT=3001` (aside, see above)
  - `docs/critical-event-alerting.md` — scrape interval, alert latency, scrape-target inventory
`promtool check config`/`check rules` (Prometheus v2.55.1) against the real files:
Checking monitoring/prometheus/prometheus.yml
  SUCCESS: 1 rule files found
 SUCCESS: monitoring/prometheus/prometheus.yml is valid prometheus config file syntax
Checking monitoring/prometheus/alerts.yml
  SUCCESS: 19 rules found

Full new test suite, run against a real downloaded `prometheus` binary (not a mock):
✓ tests/criticalEventMetricNames.test.ts  (7 tests) 3ms
✓ tests/criticalEventPrometheusIntegration.test.ts  (5 tests | 1 skipped) 16840ms
Test Files  2 passed (2)
     Tests  11 passed | 1 skipped (12)
(The 1 skip is the file's own "no prometheus binary found" placeholder test, inert whenever the real suite runs.)

Existing CI-gated suites unaffected: `contract-tests.test.ts` (18), `snapshots.test.ts` (14), `chaos.test.ts` (9) — all still pass, 41/41.

## Known gaps

- The integration test proves the mechanism against a fixture standing in for api-server (a real listening process running the real `CriticalEventListener`), not against the full docker-compose stack (real api-server container + real Prometheus + real Alertmanager together) — pulling Docker images wasn't available in my dev sandbox. The new `monitoring-integration` CI job downloads the same pinned Prometheus binary directly from GitHub releases (not Docker) as a workaround, and I've run it successfully locally with that exact binary/version — but the GitHub Actions execution itself hasn't been observed yet since this hasn't gone through CI.
- Alertmanager routing/delivery (Slack/PagerDuty actually paging someone) is untested here — the tests verify Prometheus's own `ALERTS` state, which is the boundary the issue is about (metrics reaching Prometheus at all). `alertmanager.yml` is unchanged and out of scope.

## Files changed

- `monitoring/prometheus/prometheus.yml` — new scrape job
- `api-server/Dockerfile` — `ENV PORT=3001` (aside, see above)
- `docs/critical-event-alerting.md` — scrape interval, alert latency, scrape-target inventory
- `.github/workflows/ci.yml` — new `monitoring-integration` job (installs pinned Prometheus, runs `promtool check`, runs the two new test files)
- `api-server/tests/criticalEventMetricNames.test.ts` — new
- `api-server/tests/criticalEventPrometheusIntegration.test.ts` — new
- `api-server/tests/helpers/criticalEventFixtureHarness.ts` — new
- `api-server/tests/helpers/criticalEventFixtureProcess.ts` — new
- `api-server/tests/helpers/promHarness.ts` — new

Tip: Use /btw to ask a quick side question without interrupting Claude's current work