### PR TITLE
Fix/1390 1393 contract hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
           cargo build --release --target wasm32-unknown-unknown -p sbt_registry
           cargo build --release --target wasm32-unknown-unknown -p zk_verifier
 
+      # Issue #1391: bare `.unwrap()` in contract code traps opaquely instead of
+      # returning a typed ContractError. Ratchet check — see docs/unwrap-audit.md.
+      - name: Check for new bare .unwrap() calls
+        run: ./scripts/check_unwraps.sh
+
       - name: Run unit tests
         run: cargo test --target x86_64-unknown-linux-gnu --lib --workspace
 

--- a/contracts/quorum_proof/src/circuit_breaker.rs
+++ b/contracts/quorum_proof/src/circuit_breaker.rs
@@ -567,6 +567,154 @@ mod tests {
         });
     }
 
+    /// Issue #1393: the degraded-mode write cap must cover mutating entry
+    /// points that do not route through `require_not_paused` -- `register_did`
+    /// is one of them, guarded by `enforce_write_limit`.
+    #[test]
+    fn degraded_mode_caps_writes_on_register_did() {
+        let test = setup();
+        let client = crate::QuorumProofContractClient::new(&test.env, &test.contract_id);
+
+        client.set_circuit_breaker_config(
+            &test.admin,
+            &CircuitBreakerConfig {
+                ttl_seconds: 86_400,
+                degraded_write_limit: 2,
+                auto_recover: true,
+            },
+        );
+        client.emergency_degrade(&test.admin, &String::from_str(&test.env, "load spike"));
+
+        // Two writes fit inside the cap. Each DID must be distinct, since
+        // register_did rejects duplicates for reasons unrelated to the cap.
+        for did in ["did:example:first", "did:example:second"] {
+            client.register_did(
+                &Address::generate(&test.env),
+                &String::from_str(&test.env, did),
+                &crate::DidKeyType::Ed25519,
+                &soroban_sdk::Bytes::from_array(&test.env, &[7u8; 32]),
+            );
+        }
+
+        // One write past the cap must be rejected with the typed error.
+        let result = client.try_register_did(
+            &Address::generate(&test.env),
+            &String::from_str(&test.env, "did:example:over"),
+            &crate::DidKeyType::Ed25519,
+            &soroban_sdk::Bytes::from_array(&test.env, &[8u8; 32]),
+        );
+        assert_eq!(
+            result,
+            Err(Ok(ContractError::CircuitBreakerDegradedLimitReached))
+        );
+    }
+
+    /// Issue #1393: coverage ratchet. Every `pub fn` in `lib.rs` that writes to
+    /// storage must pass through either `require_not_paused` or
+    /// `enforce_write_limit`, or appear in the exemption list below -- which is
+    /// mirrored, with reasons, in `docs/circuit-breaker-write-coverage.md`.
+    /// Parsing the source keeps this honest as new entry points are added.
+    #[test]
+    fn every_mutating_entry_point_is_write_limited() {
+        const EXEMPT: &[&str] = &[
+            // Circuit breaker and pause controls: must stay callable while the
+            // breaker is engaged, otherwise the contract cannot be recovered.
+            "initialize",
+            "pause",
+            "unpause",
+            "set_circuit_breaker_config",
+            "migrate_state",
+            // Admin configuration: operators need these to tune limits and
+            // policy while the contract is degraded.
+            "set_rate_limit_config",
+            "set_issuer_rate_limit_config",
+            "add_rate_limit_whitelist",
+            "remove_rate_limit_whitelist",
+            "set_congestion_config",
+            "update_congestion_and_adjust",
+            "admin_bypass_rate_limit",
+            "set_issuer_quota",
+            "remove_issuer_quota",
+            "set_pow_difficulty",
+            "set_max_attestors_per_slice",
+            "set_grace_period",
+            "set_reputation_weighting_enabled",
+            "set_transfer_restriction",
+            "set_attestor_reputation_config",
+            "set_holder_reputation_config",
+            // Reached from an already-guarded entry point; guarding again would
+            // consume two write slots for one logical operation.
+            "slash_attestor",
+            "detect_fork",
+            // Read paths whose only write is a cache or audit line derived from
+            // the read itself. Capping them would break monitoring and
+            // verification in Degraded mode without limiting state growth.
+            "get_credential_metadata_schema",
+            "get_metadata_schema_distribution",
+            "validate_contract_state",
+            "get_pow_difficulty",
+            "get_rate_limit_usage",
+            "get_attestation_window",
+            "get_slice_attack_cost_estimate",
+            "get_slice_modifications",
+            "is_attested",
+            "is_quorum",
+            "check_quorum_intersection",
+            "get_proof_request",
+            "get_proof_request_audit_log",
+            "get_attestor_reputation_record",
+            "get_holder_reputation",
+            "verify_credential",
+            "get_attestation_queue",
+            "recommend_attestors",
+            "validate_slice_composition",
+            "bbs_get_revocation_accumulator",
+        ];
+
+        let source = include_str!("lib.rs");
+        let lines: std::vec::Vec<&str> = source.lines().collect();
+        let mut unguarded: std::vec::Vec<&str> = std::vec::Vec::new();
+
+        for (i, line) in lines.iter().enumerate() {
+            let Some(rest) = line.strip_prefix("    pub fn ") else {
+                continue;
+            };
+            let name = rest.split(['(', '<']).next().unwrap_or(rest);
+            if EXEMPT.contains(&name) {
+                continue;
+            }
+
+            let mut mutates = false;
+            let mut guarded = false;
+            for body in lines[i + 1..].iter() {
+                if body.starts_with("    pub fn ")
+                    || body.starts_with("    fn ")
+                    || body.starts_with("    pub(crate) fn ")
+                {
+                    break;
+                }
+                if body.contains(".set(") || body.contains(".remove(") {
+                    mutates = true;
+                }
+                if body.contains("Self::require_not_paused")
+                    || body.contains("Self::enforce_write_limit")
+                {
+                    guarded = true;
+                }
+            }
+
+            if mutates && !guarded {
+                unguarded.push(name);
+            }
+        }
+
+        assert!(
+            unguarded.is_empty(),
+            "mutating entry points missing the degraded write cap: {:?}",
+            unguarded
+        );
+    }
+
     #[test]
     fn degraded_write_limit_check_is_noop_in_paused() {
         let test = setup();

--- a/contracts/quorum_proof/src/key_escrow.rs
+++ b/contracts/quorum_proof/src/key_escrow.rs
@@ -8,6 +8,24 @@
 //! consented to a recovery* -- it never sees the underlying secret, only
 //! the 32-byte share blobs guardians will later feed back into
 //! `bbs_plus_v1::escrow::reconstruct_secret` off-chain.
+//!
+//! ## Guardian rotation (#1392)
+//!
+//! An escrow is deposited once per issuer; a lost or compromised guardian key,
+//! or a change to the guardian set, is handled by
+//! `rotate_key_escrow_guardians`. Rotation is issuer-only and follows the same
+//! off-chain flow as the initial deposit: the issuer re-splits the *same* BBS+
+//! signing key into a fresh `new_threshold`-of-`new_guardians.len()` set with
+//! `bbs_plus_v1::escrow`, then submits the new share blobs here. The old
+//! guardians' share entries are deleted, so shares from before a rotation can
+//! no longer be combined through this contract.
+//!
+//! Rotation is only allowed while `recovered == false` — once a key has been
+//! recovered the escrow is spent and the issuer must deposit a new one against
+//! a new key. Any partial recovery progress (guardians who already called
+//! `submit_recovery_share`) is **reset** by a rotation, since those
+//! submissions refer to shares that no longer exist. That also means rotation
+//! is the issuer's escape hatch if a rogue guardian starts a recovery.
 use crate::{ContractError, DataKeyEscrow, EXTENDED_TTL, STANDARD_TTL};
 use soroban_sdk::{contracttype, panic_with_error, Address, BytesN, Env, String, Vec};
 
@@ -205,8 +223,241 @@ pub fn recover_key(env: &Env, caller: &Address, issuer: &Address) -> Vec<Guardia
     shares
 }
 
+/// Replaces the guardian set, share blobs and threshold of an existing
+/// escrow. Issuer-only: the caller must already be authenticated and
+/// role-checked by the contract entry point before this is invoked. Any
+/// in-progress recovery submissions are cleared, because they refer to shares
+/// that this rotation removes.
+pub fn rotate_key_escrow_guardians(
+    env: &Env,
+    issuer: &Address,
+    new_guardians: Vec<Address>,
+    new_shares: Vec<BytesN<32>>,
+    new_threshold: u32,
+) -> KeyEscrow {
+    let escrow: KeyEscrow = env
+        .storage()
+        .instance()
+        .get(&DataKeyEscrow::Escrow(issuer.clone()))
+        .unwrap_or_else(|| panic_with_error!(env, ContractError::EscrowNotFound));
+
+    if escrow.recovered {
+        panic_with_error!(env, ContractError::EscrowAlreadyRecovered);
+    }
+    if new_guardians.len() != new_shares.len() {
+        panic_with_error!(env, ContractError::InvalidEscrowConfig);
+    }
+    let new_total_shares = new_guardians.len();
+    if new_threshold < 2 || new_threshold > new_total_shares {
+        panic_with_error!(env, ContractError::InvalidEscrowConfig);
+    }
+
+    let old_guardian_count = escrow.total_shares;
+
+    // Drop the previous guardians' shares first: a guardian dropped by this
+    // rotation must not keep a usable entry behind.
+    for guardian in escrow.guardians.iter() {
+        env.storage()
+            .instance()
+            .remove(&DataKeyEscrow::GuardianShare(issuer.clone(), guardian));
+    }
+
+    let mut share_index = 0u32;
+    for (guardian, share) in new_guardians.iter().zip(new_shares.iter()) {
+        share_index += 1;
+        env.storage().instance().set(
+            &DataKeyEscrow::GuardianShare(issuer.clone(), guardian.clone()),
+            &GuardianShare {
+                guardian,
+                share_index,
+                encrypted_share: share,
+            },
+        );
+    }
+
+    // Submissions collected against the old shares are meaningless now.
+    env.storage()
+        .instance()
+        .remove(&DataKeyEscrow::RecoverySubmissions(issuer.clone()));
+
+    let rotated = KeyEscrow {
+        issuer: escrow.issuer,
+        threshold: new_threshold,
+        total_shares: new_total_shares,
+        guardians: new_guardians,
+        created_at: escrow.created_at,
+        recovered: false,
+    };
+    env.storage()
+        .instance()
+        .set(&DataKeyEscrow::Escrow(issuer.clone()), &rotated);
+    env.storage()
+        .instance()
+        .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+
+    let topic = String::from_str(env, crate::TOPIC_KEY_ESCROW_ROTATED);
+    let mut topics: Vec<soroban_sdk::String> = Vec::new(env);
+    topics.push_back(topic);
+    env.events().publish(
+        topics,
+        (
+            crate::TOPIC_KEY_ESCROW_ROTATED,
+            issuer.clone(),
+            old_guardian_count,
+            new_total_shares,
+        ),
+    );
+
+    rotated
+}
+
 pub fn get_key_escrow(env: &Env, issuer: &Address) -> Option<KeyEscrow> {
     env.storage()
         .instance()
         .get(&DataKeyEscrow::Escrow(issuer.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{QuorumProofContract, QuorumProofContractClient};
+    use soroban_sdk::testutils::Address as _;
+
+    const ROLE_ISSUER: u32 = 2;
+
+    struct EscrowTest {
+        env: Env,
+        contract_id: Address,
+        client_issuer: Address,
+        guardians: Vec<Address>,
+    }
+
+    fn shares(env: &Env, count: u32) -> Vec<BytesN<32>> {
+        let mut shares: Vec<BytesN<32>> = Vec::new(env);
+        for i in 0..count {
+            shares.push_back(BytesN::from_array(env, &[i as u8; 32]));
+        }
+        shares
+    }
+
+    fn setup() -> EscrowTest {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let contract_id = env.register_contract(None, QuorumProofContract);
+        let client = QuorumProofContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+        client.assign_role(&admin, &issuer, &ROLE_ISSUER, &0u64);
+
+        let mut guardians: Vec<Address> = Vec::new(&env);
+        for _ in 0..3u32 {
+            guardians.push_back(Address::generate(&env));
+        }
+        client.deposit_key_escrow(&issuer, &guardians, &shares(&env, 3), &2u32);
+
+        EscrowTest {
+            env,
+            contract_id,
+            client_issuer: issuer,
+            guardians,
+        }
+    }
+
+    #[test]
+    fn rotation_replaces_guardian_set_and_threshold() {
+        let test = setup();
+        let client = QuorumProofContractClient::new(&test.env, &test.contract_id);
+
+        let mut new_guardians: Vec<Address> = Vec::new(&test.env);
+        new_guardians.push_back(test.guardians.get(0).unwrap());
+        for _ in 0..3u32 {
+            new_guardians.push_back(Address::generate(&test.env));
+        }
+
+        let rotated = client.rotate_key_escrow_guardians(
+            &test.client_issuer,
+            &new_guardians,
+            &shares(&test.env, 4),
+            &3u32,
+        );
+
+        assert_eq!(rotated.total_shares, 4);
+        assert_eq!(rotated.threshold, 3);
+        assert_eq!(rotated.guardians, new_guardians);
+        assert!(!rotated.recovered);
+
+        // A guardian dropped by the rotation keeps no usable share entry.
+        let dropped = test.guardians.get(2).unwrap();
+        test.env.as_contract(&test.contract_id, || {
+            assert!(!test.env.storage().instance().has(
+                &DataKeyEscrow::GuardianShare(test.client_issuer.clone(), dropped.clone())
+            ));
+        });
+    }
+
+    #[test]
+    #[should_panic]
+    fn rotation_by_non_issuer_is_rejected() {
+        let test = setup();
+        let client = QuorumProofContractClient::new(&test.env, &test.contract_id);
+        let stranger = Address::generate(&test.env);
+
+        client.rotate_key_escrow_guardians(
+            &stranger,
+            &test.guardians,
+            &shares(&test.env, 3),
+            &2u32,
+        );
+    }
+
+    #[test]
+    fn rotation_resets_partial_recovery_progress() {
+        let test = setup();
+        let client = QuorumProofContractClient::new(&test.env, &test.contract_id);
+
+        let submitted =
+            client.submit_recovery_share(&test.guardians.get(0).unwrap(), &test.client_issuer);
+        assert_eq!(submitted, 1);
+
+        let mut new_guardians: Vec<Address> = Vec::new(&test.env);
+        for _ in 0..3u32 {
+            new_guardians.push_back(Address::generate(&test.env));
+        }
+        client.rotate_key_escrow_guardians(
+            &test.client_issuer,
+            &new_guardians,
+            &shares(&test.env, 3),
+            &2u32,
+        );
+
+        test.env.as_contract(&test.contract_id, || {
+            assert!(!test.env.storage().instance().has(
+                &DataKeyEscrow::RecoverySubmissions(test.client_issuer.clone())
+            ));
+        });
+
+        // The first new guardian starts a fresh recovery from zero.
+        let after =
+            client.submit_recovery_share(&new_guardians.get(0).unwrap(), &test.client_issuer);
+        assert_eq!(after, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn rotation_after_recovery_is_rejected() {
+        let test = setup();
+        let client = QuorumProofContractClient::new(&test.env, &test.contract_id);
+
+        client.submit_recovery_share(&test.guardians.get(0).unwrap(), &test.client_issuer);
+        client.submit_recovery_share(&test.guardians.get(1).unwrap(), &test.client_issuer);
+        client.recover_key(&test.client_issuer, &test.client_issuer);
+
+        client.rotate_key_escrow_guardians(
+            &test.client_issuer,
+            &test.guardians,
+            &shares(&test.env, 3),
+            &2u32,
+        );
+    }
 }

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -2870,6 +2870,7 @@ impl QuorumProofContract {
         public_key: soroban_sdk::Bytes,
     ) {
         address.require_auth();
+        Self::enforce_write_limit(&env);
 
         assert!(!did.is_empty(), "DID string cannot be empty");
 
@@ -2967,6 +2968,7 @@ impl QuorumProofContract {
         new_public_key: soroban_sdk::Bytes,
     ) {
         address.require_auth();
+        Self::enforce_write_limit(&env);
 
         let did_bytes: soroban_sdk::Bytes = env
             .storage()
@@ -3001,6 +3003,7 @@ impl QuorumProofContract {
     /// remains on-chain for resolution and audit purposes.
     pub fn deactivate_did(env: Env, address: Address) {
         address.require_auth();
+        Self::enforce_write_limit(&env);
 
         let did_bytes: soroban_sdk::Bytes = env
             .storage()
@@ -3694,6 +3697,22 @@ impl QuorumProofContract {
     /// Read the current circuit breaker configuration.
     pub fn get_circuit_breaker_config(env: Env) -> circuit_breaker::CircuitBreakerConfig {
         circuit_breaker::get_config(&env)
+    }
+
+    /// Apply only the circuit breaker's degraded-mode write cap (issue #1393).
+    ///
+    /// Mutating entry points that deliberately stay callable while the contract
+    /// is paused — or that predate `require_not_paused` and whose pause
+    /// semantics must not change — call this instead, so the Degraded-state
+    /// write cap is contract-wide rather than covering only the
+    /// `require_not_paused` paths. Entry points already calling
+    /// `require_not_paused` are covered by it and must not call this too, or
+    /// they would consume two write slots per call.
+    fn enforce_write_limit(env: &Env) {
+        circuit_breaker::check_and_recover(env);
+        if let Err(e) = circuit_breaker::enforce_degraded_write_limit(env) {
+            panic_with_error!(env, e);
+        }
     }
 
     fn require_not_paused(env: &Env) {
@@ -8698,6 +8717,7 @@ impl QuorumProofContract {
     /// If the removal would make the threshold unreachable, the threshold is clamped to the new total weight.
     pub fn remove_attestor(env: Env, creator: Address, slice_id: u64, attestor: Address) {
         creator.require_auth();
+        Self::enforce_write_limit(&env);
         let mut slice: QuorumSlice = env
             .storage()
             .instance()
@@ -8759,6 +8779,7 @@ impl QuorumProofContract {
     /// the total weight sum (existing + new attestor).
     pub fn add_attestor(env: Env, creator: Address, slice_id: u64, attestor: Address, weight: u32) {
         creator.require_auth();
+        Self::enforce_write_limit(&env);
         Self::require_valid_address(&env, &creator);
         Self::require_valid_address(&env, &attestor);
         let mut slice: QuorumSlice = env
@@ -8824,6 +8845,7 @@ impl QuorumProofContract {
         new_weight: u32,
     ) {
         creator.require_auth();
+        Self::enforce_write_limit(&env);
         Self::validate_weight(new_weight);
         let mut slice: QuorumSlice = env
             .storage()
@@ -8899,6 +8921,7 @@ impl QuorumProofContract {
     /// Must be greater than 0 and cannot exceed the total weight sum of all attestors.
     pub fn update_slice_threshold(env: Env, creator: Address, slice_id: u64, new_threshold: u32) {
         creator.require_auth();
+        Self::enforce_write_limit(&env);
         let mut slice: QuorumSlice = env
             .storage()
             .instance()
@@ -8985,6 +9008,7 @@ impl QuorumProofContract {
         percentage: u32,
     ) {
         creator.require_auth();
+        Self::enforce_write_limit(&env);
         assert!(
             (1..=100).contains(&percentage),
             "percentage threshold must be between 1 and 100"
@@ -9093,6 +9117,7 @@ impl QuorumProofContract {
         expires_at: Option<u64>,
     ) {
         delegator.require_auth();
+        Self::enforce_write_limit(&env);
         Self::require_valid_address(&env, &delegator);
         Self::require_valid_address(&env, &delegate);
 
@@ -9158,6 +9183,7 @@ impl QuorumProofContract {
     /// Issue #896: Revoke a vote delegation
     pub fn revoke_slice_delegation(env: Env, delegator: Address, slice_id: u64) {
         delegator.require_auth();
+        Self::enforce_write_limit(&env);
 
         let delegation: SliceDelegation = env
             .storage()
@@ -10245,6 +10271,7 @@ impl QuorumProofContract {
     /// Add a holder to an issuer's whitelist.
     pub fn add_holder_to_whitelist(env: Env, issuer: Address, holder: Address) {
         issuer.require_auth();
+        Self::enforce_write_limit(&env);
         Self::require_valid_address(&env, &holder);
 
         env.storage().instance().set(
@@ -10289,6 +10316,7 @@ impl QuorumProofContract {
     /// Remove a holder from an issuer's whitelist.
     pub fn remove_holder_from_whitelist(env: Env, issuer: Address, holder: Address) {
         issuer.require_auth();
+        Self::enforce_write_limit(&env);
 
         env.storage()
             .instance()
@@ -10333,6 +10361,7 @@ impl QuorumProofContract {
         threshold: u32,
     ) {
         admin.require_auth();
+        Self::enforce_write_limit(&env);
         let stored_admin: Address = env
             .storage()
             .instance()
@@ -10797,6 +10826,7 @@ impl QuorumProofContract {
     /// Explicitly roll back an expired attestation request.
     /// Anyone can trigger rollback once the window has passed and threshold wasn't met.
     pub fn rollback_attestation_request(env: Env, request_id: u64) {
+        Self::enforce_write_limit(&env);
         let mut request: AttestationRequest = env
             .storage()
             .instance()
@@ -10842,6 +10872,7 @@ impl QuorumProofContract {
 
     /// Check if a credential's attestation request window has expired without reaching threshold.
     pub fn check_and_rollback_attestation(env: Env, request_id: u64) -> bool {
+        Self::enforce_write_limit(&env);
         let mut request: AttestationRequest = env
             .storage()
             .instance()
@@ -11939,6 +11970,7 @@ impl QuorumProofContract {
         parent_type: Option<u32>,
     ) {
         admin.require_auth();
+        Self::enforce_write_limit(&env);
         let stored_admin: Address = env
             .storage()
             .instance()
@@ -12824,6 +12856,7 @@ impl QuorumProofContract {
     /// Panics if no pending recovery exists for the attestor.
     pub fn complete_reputation_recovery(env: Env, admin: Address, attestor: Address) {
         admin.require_auth();
+        Self::enforce_write_limit(&env);
         let stored_admin: Address = env
             .storage()
             .instance()
@@ -14119,6 +14152,7 @@ impl QuorumProofContract {
         metadata: soroban_sdk::Bytes,
     ) {
         attestor.require_auth();
+        Self::enforce_write_limit(&env);
         // Verify the attestor has actually attested this credential
         let records: Vec<AttestationRecord> = env
             .storage()
@@ -15409,6 +15443,7 @@ impl QuorumProofContract {
     /// The amount collected (may be zero if nothing was pending).
     pub fn collect_slashed_stake(env: Env, admin: Address, attestor: Address) -> u64 {
         admin.require_auth();
+        Self::enforce_write_limit(&env);
         let stored_admin: Address = env
             .storage()
             .instance()
@@ -16463,6 +16498,7 @@ impl QuorumProofContract {
     /// Subject approves a pending consent request.
     pub fn approve_credential_request(env: Env, subject: Address, request_id: u64) {
         subject.require_auth();
+        Self::enforce_write_limit(&env);
 
         let mut request: ConsentRequest = env
             .storage()
@@ -16496,6 +16532,7 @@ impl QuorumProofContract {
         nonce: u64,
     ) -> u64 {
         issuer.require_auth();
+        Self::enforce_write_limit(&env);
 
         let request: ConsentRequest = env
             .storage()
@@ -17261,6 +17298,7 @@ impl QuorumProofContract {
         new_priority: AttestationPriority,
     ) {
         caller.require_auth();
+        Self::enforce_write_limit(&env);
         let mut entry: AttestationQueueEntry = env.storage().instance()
             .get(&DataKey3::AttestationQueueEntry(entry_id))
             .expect("queue entry not found");
@@ -17290,6 +17328,7 @@ impl QuorumProofContract {
         entry_id: u64,
     ) {
         caller.require_auth();
+        Self::enforce_write_limit(&env);
         let entry: AttestationQueueEntry = env.storage().instance()
             .get(&DataKey3::AttestationQueueEntry(entry_id))
             .expect("queue entry not found");
@@ -17318,6 +17357,7 @@ impl QuorumProofContract {
         max_entries: u32,
     ) -> u32 {
         caller.require_auth();
+        Self::enforce_write_limit(&env);
         let count: u64 = env.storage().instance()
             .get(&DataKey3::AttestationQueueCount)
             .unwrap_or(0u64);
@@ -17730,6 +17770,7 @@ impl QuorumProofContract {
         threshold: u32,
     ) -> u64 {
         creator.require_auth();
+        Self::enforce_write_limit(&env);
 
         let now = env.ledger().timestamp();
 
@@ -17834,6 +17875,7 @@ impl QuorumProofContract {
         change_description: soroban_sdk::String,
     ) {
         creator.require_auth();
+        Self::enforce_write_limit(&env);
 
         let mut template: SliceTemplate = env
             .storage()
@@ -17991,6 +18033,7 @@ impl QuorumProofContract {
         reason: soroban_sdk::String,
     ) {
         owner.require_auth();
+        Self::enforce_write_limit(&env);
 
         let now = env.ledger().timestamp();
 
@@ -19426,6 +19469,7 @@ impl QuorumProofContract {
         nonce: Bytes,
     ) -> Bytes {
         holder.require_auth();
+        Self::enforce_write_limit(&env);
 
         // Verify credential exists and is BBS+-enabled
         let bbs_cred: BbsCredential = env

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -66,6 +66,7 @@ const TOPIC_TEMPLATE_UPDATED: &str = "TemplateUpdated";
 const TOPIC_ATTESTOR_REPLACEMENT: &str = "AttestorReplaced";
 const TOPIC_KEY_ESCROW_DEPOSITED: &str = "KeyEscrowDeposited";
 const TOPIC_KEY_ESCROW_RECOVERED: &str = "KeyEscrowRecovered";
+const TOPIC_KEY_ESCROW_ROTATED: &str = "KeyEscrowRotated";
 /// `migration::MigrationJob.kind` tag for credential-metadata-schema migrations.
 const MIGRATION_KIND_METADATA_SCHEMA: u32 = 1;
 const STANDARD_TTL: u32 = 16_384;
@@ -17041,6 +17042,31 @@ impl QuorumProofContract {
         Self::require_not_paused(&env);
         crate::rbac::require_role(&env, &issuer, rbac::Role::Issuer);
         crate::key_escrow::deposit_key_escrow(&env, &issuer, guardians, shares, threshold)
+    }
+
+    /// Replaces the guardian set, share blobs and threshold of an existing
+    /// escrow — the recovery path for a lost or compromised guardian key, or
+    /// for adding/removing a guardian. Re-splitting the key happens off-chain
+    /// exactly as for `deposit_key_escrow`. Issuer-only, and only while the
+    /// escrow has not been recovered; any in-progress recovery submissions are
+    /// cleared. See the module docs in `key_escrow.rs` for the full flow.
+    pub fn rotate_key_escrow_guardians(
+        env: Env,
+        issuer: Address,
+        new_guardians: Vec<Address>,
+        new_shares: Vec<BytesN<32>>,
+        new_threshold: u32,
+    ) -> key_escrow::KeyEscrow {
+        issuer.require_auth();
+        Self::require_not_paused(&env);
+        crate::rbac::require_role(&env, &issuer, rbac::Role::Issuer);
+        crate::key_escrow::rotate_key_escrow_guardians(
+            &env,
+            &issuer,
+            new_guardians,
+            new_shares,
+            new_threshold,
+        )
     }
 
     /// A guardian confirms it holds its share and consents to a recovery

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -6279,7 +6279,7 @@ impl QuorumProofContract {
             let type_def: CredentialTypeDef = env.storage()
                 .instance()
                 .get(&DataKey::CredentialType(credential_type))
-                .unwrap();
+                .unwrap_or_else(|| panic_with_error!(&env, ContractError::CredentialTypeNotFound));
             env.storage()
                 .instance()
                 .set(&DataKey10::CredentialTypeDefVersion(id), &type_def.version);
@@ -6521,7 +6521,7 @@ impl QuorumProofContract {
             let type_def: CredentialTypeDef = env.storage()
                 .instance()
                 .get(&DataKey::CredentialType(credential_type))
-                .unwrap();
+                .unwrap_or_else(|| panic_with_error!(env, ContractError::CredentialTypeNotFound));
             env.storage()
                 .instance()
                 .set(&DataKey10::CredentialTypeDefVersion(id), &type_def.version);
@@ -8838,7 +8838,10 @@ impl QuorumProofContract {
             .iter()
             .position(|candidate| candidate == attestor)
             .expect("attestor not in slice") as u32;
-        let old_weight = slice.weights.get(position).unwrap();
+        let old_weight = slice
+            .weights
+            .get(position)
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInSlice));
         slice.weights.set(position, new_weight);
 
         let total_weight = Self::total_slice_weight(&slice.weights);
@@ -12402,7 +12405,7 @@ impl QuorumProofContract {
                 .storage()
                 .instance()
                 .get(&DataKey::Credential(id))
-                .unwrap();
+                .unwrap_or_else(|| panic_with_error!(&env, ContractError::CredentialNotFound));
             if credential.credential_type != type_id {
                 continue;
             }
@@ -17986,7 +17989,10 @@ impl QuorumProofContract {
             .expect("old attestor not in slice");
 
         // Get the weight of the old attestor
-        let attestor_weight = slice.weights.get(attestor_idx as u32).unwrap();
+        let attestor_weight = slice
+            .weights
+            .get(attestor_idx as u32)
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInSlice));
 
         // Update slice
         let mut new_attestors = Vec::new(&env);
@@ -19147,16 +19153,15 @@ impl QuorumProofContract {
         slice: QuorumSlice,
         credential_type: u32,
     ) -> bool {
-        let rule: Option<CompositionRule> = env
+        let rule: CompositionRule = match env
             .storage()
             .instance()
-            .get(&DataKey11::SliceCompositionRule(credential_type));
-
-        if rule.is_none() {
-            return true;
-        }
-
-        let rule = rule.unwrap();
+            .get(&DataKey11::SliceCompositionRule(credential_type))
+        {
+            Some(rule) => rule,
+            // No composition rule configured for this credential type.
+            None => return true,
+        };
         let mut type_counts: Map<u32, u32> = Map::new(&env);
 
         for attestor_addr in slice.attestors.iter() {

--- a/contracts/quorum_proof/src/lib.rs
+++ b/contracts/quorum_proof/src/lib.rs
@@ -3528,6 +3528,13 @@ impl QuorumProofContract {
         state_metrics::collect(&env)
     }
 
+    /// Per-action credential lifecycle counters (`"credential"` for issuance,
+    /// `"revocation"` for revocation), as a map of action label to event
+    /// count. Unauthenticated and O(1), like `get_state_metrics`.
+    pub fn get_credential_action_counts(env: Env) -> soroban_sdk::Map<String, u64> {
+        state_metrics::get_credential_action_counts(&env)
+    }
+
     /// Return the schema version distribution across all credentials.
     /// Scans all credential IDs from 1 to current count and returns counts per schema version.
     pub fn get_metadata_schema_distribution(env: Env) -> soroban_sdk::Map<u32, u32> {
@@ -16133,9 +16140,11 @@ impl QuorumProofContract {
 
     // ── Missing helper methods ────────────────────────────────────────────────
 
-    /// Update credential metrics (no-op stub for tracking purposes).
-    fn update_credential_metrics(_env: &Env, _credential_id: u64, _action: &str) {
-        // Metrics tracking stub — extend as needed
+    /// Record a credential lifecycle event against the per-action counters
+    /// exposed by `get_credential_action_counts` (issue #1390). The credential
+    /// id is not stored — the counters are aggregate, so they stay O(1).
+    fn update_credential_metrics(env: &Env, _credential_id: u64, action: &str) {
+        state_metrics::record_credential_action(env, &String::from_str(env, action));
     }
 
     /// Validate that a metadata hash is non-empty.

--- a/contracts/quorum_proof/src/state_metrics.rs
+++ b/contracts/quorum_proof/src/state_metrics.rs
@@ -13,9 +13,9 @@
 //! iteration over unbounded collections), so this call stays cheap regardless
 //! of how large the deployment has grown.
 
-use soroban_sdk::{contracttype, Env};
+use soroban_sdk::{contracttype, Env, Map, String};
 
-use crate::DataKey;
+use crate::{DataKey, EXTENDED_TTL, STANDARD_TTL};
 
 /// Snapshot of contract-level health indicators, returned by
 /// `get_state_metrics`. Every field is O(1) to compute from existing
@@ -75,5 +75,71 @@ pub fn collect(env: &Env) -> ContractStateMetrics {
         paused,
         state_version,
         storage_entries_estimate,
+    }
+}
+
+/// Storage key for the per-action credential lifecycle counters (issue #1390).
+/// Kept separate from `DataKey` so the counters can grow new action labels
+/// without touching the contract's main key enum.
+#[contracttype]
+#[derive(Clone)]
+pub enum CredentialMetricsKey {
+    /// Single map of `action label -> event count`. One instance entry
+    /// regardless of how many labels the lifecycle paths report.
+    ActionCounts,
+}
+
+/// Increment the counter for one credential lifecycle `action` (e.g.
+/// `"credential"` for an issuance, `"revocation"` for a revocation).
+pub fn record_credential_action(env: &Env, action: &String) {
+    let mut counts = get_credential_action_counts(env);
+    let next = counts.get(action.clone()).unwrap_or(0u64).saturating_add(1);
+    counts.set(action.clone(), next);
+    env.storage()
+        .instance()
+        .set(&CredentialMetricsKey::ActionCounts, &counts);
+    env.storage()
+        .instance()
+        .extend_ttl(STANDARD_TTL, EXTENDED_TTL);
+}
+
+/// Read the per-action credential lifecycle counters. Empty until the first
+/// lifecycle event is recorded.
+pub fn get_credential_action_counts(env: &Env) -> Map<String, u64> {
+    env.storage()
+        .instance()
+        .get(&CredentialMetricsKey::ActionCounts)
+        .unwrap_or(Map::new(env))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::QuorumProofContract;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::Address;
+
+    #[test]
+    fn credential_action_counts_accumulate_per_action() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register_contract(None, QuorumProofContract);
+        crate::QuorumProofContractClient::new(&env, &contract_id).initialize(&admin);
+
+        env.as_contract(&contract_id, || {
+            let issuance = String::from_str(&env, "credential");
+            let revocation = String::from_str(&env, "revocation");
+
+            assert_eq!(get_credential_action_counts(&env).len(), 0);
+
+            record_credential_action(&env, &issuance);
+            record_credential_action(&env, &issuance);
+            record_credential_action(&env, &revocation);
+
+            let counts = get_credential_action_counts(&env);
+            assert_eq!(counts.get(issuance).unwrap(), 2u64);
+            assert_eq!(counts.get(revocation).unwrap(), 1u64);
+        });
     }
 }

--- a/docs/circuit-breaker-write-coverage.md
+++ b/docs/circuit-breaker-write-coverage.md
@@ -1,0 +1,66 @@
+# Circuit Breaker: Degraded-Mode Write Coverage (issue #1393)
+
+`circuit_breaker::enforce_degraded_write_limit` caps the number of writes the
+contract accepts per ledger while it is in `Degraded` state. The cap is only
+meaningful if every state-mutating entry point routes through it.
+
+## The two guards
+
+| Guard | What it does | Used by |
+| --- | --- | --- |
+| `require_not_paused` | auto-recovery check → pause check → degraded write cap | entry points that must be blocked entirely while the contract is paused |
+| `enforce_write_limit` | auto-recovery check → degraded write cap only | mutating entry points that predate `require_not_paused` and whose pause semantics must not change |
+
+An entry point calls **one** of the two, never both: each call consumes a write
+slot, so calling both would charge one logical operation twice.
+
+## Coverage
+
+Every `pub fn` in `contracts/quorum_proof/src/lib.rs` that writes to storage
+passes through one of the two guards, except the entry points listed below.
+`circuit_breaker::tests::every_mutating_entry_point_is_write_limited` parses
+`lib.rs` and fails CI if a new mutating entry point is added without a guard or
+an exemption, so this list cannot silently drift.
+
+## Intentional exemptions
+
+**Recovery controls** — `initialize`, `pause`, `unpause`,
+`set_circuit_breaker_config`, `migrate_state`.
+These are how an operator gets *out* of a degraded or paused contract. Capping
+them could make the contract unrecoverable once the cap is exhausted.
+
+**Admin configuration** — `set_rate_limit_config`,
+`set_issuer_rate_limit_config`, `add_rate_limit_whitelist`,
+`remove_rate_limit_whitelist`, `set_congestion_config`,
+`update_congestion_and_adjust`, `admin_bypass_rate_limit`, `set_issuer_quota`,
+`remove_issuer_quota`, `set_pow_difficulty`, `set_max_attestors_per_slice`,
+`set_grace_period`, `set_reputation_weighting_enabled`,
+`set_transfer_restriction`, `set_attestor_reputation_config`,
+`set_holder_reputation_config`.
+Admin-only, bounded in volume, and the levers operators reach for *while*
+responding to the incident that degraded the contract.
+
+**Reached from a guarded path** — `slash_attestor`, `detect_fork`.
+Both are also invoked internally from entry points that already consume a write
+slot. Guarding them again would charge two slots for one operation.
+
+**Read paths with derived writes** — `get_credential_metadata_schema`,
+`get_metadata_schema_distribution`, `validate_contract_state`,
+`get_pow_difficulty`, `get_rate_limit_usage`, `get_attestation_window`,
+`get_slice_attack_cost_estimate`, `get_slice_modifications`, `is_attested`,
+`is_quorum`, `check_quorum_intersection`, `get_proof_request`,
+`get_proof_request_audit_log`, `get_attestor_reputation_record`,
+`get_holder_reputation`, `verify_credential`, `get_attestation_queue`,
+`recommend_attestors`, `validate_slice_composition`,
+`bbs_get_revocation_accumulator`.
+Their only write is a cache entry or audit line derived from the read itself,
+not caller-supplied state growth. Capping them would break monitoring and
+verification in Degraded mode without limiting what the cap exists to limit.
+
+## Adding a new entry point
+
+If it writes storage: call `Self::require_not_paused(&env)` when it should also
+be blocked while paused, otherwise `Self::enforce_write_limit(&env)`, placed
+immediately after the caller's `require_auth()` so unauthenticated calls cannot
+burn write slots. If it genuinely belongs in one of the categories above, add
+it to `EXEMPT` in the coverage test *and* to this document.

--- a/docs/unwrap-audit.md
+++ b/docs/unwrap-audit.md
@@ -1,0 +1,57 @@
+# `.unwrap()` Audit — `quorum_proof` (issue #1391)
+
+A bare `.unwrap()` aborts the transaction with an opaque host trap rather than
+one of the contract's `ContractError` variants. Off-chain clients and indexers
+cannot map a host trap back to a cause, and tests cannot assert on it
+precisely. This document records the audit of the `.unwrap()` call sites in
+`contracts/quorum_proof/src/lib.rs` and the rule applied to new code.
+
+## Classification
+
+Every non-test call site falls into one of three groups.
+
+### Provably safe — bounded index into a collection just measured
+
+The dominant pattern is `for i in 0..items.len() { let x = items.get(i).unwrap(); }`.
+The index is derived from the same `Vec`'s length in the same call, so `get`
+cannot return `None`. Batch entry points that index *parallel* vectors
+(`issue_credentials_batch`, `verify_claims_batch`, `verify_credentials_batch`,
+`batch_verify_with_expiry`, …) assert that all input vectors have equal length
+before the loop, so the parallel indexing is equally bounded. Left as-is.
+
+### Provably safe — existence checked immediately before
+
+`if env.storage().instance().has(&key) { ... .get(&key).unwrap() }`. Soroban
+contract execution is single-threaded within a transaction, so nothing can
+remove the entry between the check and the read. These were still converted
+where the surrounding function already had a natural error variant, because the
+conversion costs nothing and makes a future refactor that drops the `has` check
+fail loudly and typed.
+
+### Reachable / non-obvious — converted to typed errors
+
+| Call site | Previous failure | Now |
+| --- | --- | --- |
+| `issue_credential`, `issue_inner` — credential type definition lookup | host trap | `ContractError::CredentialTypeNotFound` |
+| `get_credentials_by_type` — credential lookup during the id scan | host trap | `ContractError::CredentialNotFound` |
+| `update_attestor_weight` — attestor weight lookup | host trap | `ContractError::NotInSlice` |
+| `replace_attestor` — old attestor weight lookup | host trap | `ContractError::NotInSlice` |
+| `validate_slice_composition` — composition rule read | host trap | restructured to `match`, no unwrap |
+
+The two weight lookups are the only ones where the invariant is not local: they
+index `slice.weights` with a position found in `slice.attestors`, which relies
+on the two vectors staying the same length across every slice mutation path. A
+typed `NotInSlice` is the right signal if that invariant is ever broken.
+
+## Rule for new code
+
+In contract code, prefer:
+
+```rust
+.unwrap_or_else(|| panic_with_error!(&env, ContractError::SomeVariant))
+```
+
+`scripts/check_unwraps.sh` enforces this as a ratchet in CI: it counts bare
+`.unwrap()` calls in non-test contract source and fails if the count grows.
+When occurrences are removed, lower `BASELINE` in that script to lock the
+improvement in.

--- a/scripts/check_unwraps.sh
+++ b/scripts/check_unwraps.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Issue #1391: guard against new bare `.unwrap()` calls in contract code.
+#
+# A bare `.unwrap()` aborts the transaction with an opaque host trap instead
+# of one of the contract's `ContractError` variants, which off-chain clients
+# and indexers cannot interpret. New non-test contract code should use
+# `.unwrap_or_else(|| panic_with_error!(&env, ContractError::...))` instead.
+#
+# This is a ratchet, not a clean-sweep gate: the remaining occurrences were
+# audited (see docs/unwrap-audit.md) and are provably safe, but the count must
+# not grow. Lower BASELINE whenever occurrences are removed.
+set -euo pipefail
+
+BASELINE=${UNWRAP_BASELINE:-110}
+
+cd "$(dirname "$0")/.."
+
+total=0
+for file in $(find contracts -path '*/src/*.rs' -not -name '*test*.rs' -not -name '*.bak' | sort); do
+    # Only production code: everything before the file's inline test module.
+    count=$(awk '/^#\[cfg\(test\)\]$/ { pending = 1; next }
+                 pending && /^(pub )?mod tests[ ]*\{/ { exit }
+                 { pending = 0; print }' "$file" | grep -c '\.unwrap()' || true)
+    if [ "$count" -gt 0 ]; then
+        printf '%6d  %s\n' "$count" "$file"
+    fi
+    total=$((total + count))
+done
+
+echo "total bare .unwrap() in non-test contract code: $total (baseline $BASELINE)"
+
+if [ "$total" -gt "$BASELINE" ]; then
+    echo "ERROR: new bare .unwrap() calls were added." >&2
+    echo "Use .unwrap_or_else(|| panic_with_error!(&env, ContractError::...)) so the" >&2
+    echo "failure surfaces as a typed contract error." >&2
+    exit 1
+fi
+
+if [ "$total" -lt "$BASELINE" ]; then
+    echo "NOTE: count dropped below the baseline — lower BASELINE in $0 to lock it in."
+fi


### PR DESCRIPTION
## Summary

Four contract-hardening issues, one commit each.

Closes #1390
Closes #1391
Closes #1392
Closes #1393

---

### #1390 — Implement the `update_credential_metrics` no-op stub

Kept the function and gave it real behaviour rather than deleting it, since the
call sites already sit at the right points in the credential lifecycle.

- `state_metrics.rs` gains `record_credential_action` / `get_credential_action_counts`,
  backed by a single `Map<String, u64>` under a new `CredentialMetricsKey::ActionCounts`
  instance entry — one storage entry no matter how many action labels appear, so the
  counters stay O(1) like the rest of `ContractStateMetrics`.
- `update_credential_metrics` now increments the counter for its `action` argument
  (`"credential"` on issuance, `"revocation"` on revocation). The credential id stays
  unused: the counters are aggregate by design.
- New unauthenticated getter `get_credential_action_counts`, alongside `get_state_metrics`.
- Regression test: counters accumulate per action label and start empty.

### #1391 — Audit `.unwrap()` usage

Full audit of the non-test `.unwrap()` call sites in `lib.rs`, written up in
`docs/unwrap-audit.md`. The great majority are provably safe: bounded
`for i in 0..v.len() { v.get(i).unwrap() }` indexing, or a `.get()` immediately
after a `.has()` on the same key. Every batch entry point that indexes parallel
vectors already asserts equal lengths before the loop.

Converted the call sites where the invariant was not local:

| Call site | Was | Now |
| --- | --- | --- |
| `issue_credential`, `issue_inner` — credential type definition | host trap | `CredentialTypeNotFound` |
| `get_credentials_by_type` — credential read during id scan | host trap | `CredentialNotFound` |
| `update_attestor_weight`, `replace_attestor` — attestor weight lookup | host trap | `NotInSlice` |
| `validate_slice_composition` — composition rule read | host trap | restructured to `match`, unwrap removed |

The two weight lookups are the notable ones: they index `slice.weights` with a
position found in `slice.attestors`, which depends on those two vectors staying
in sync across every slice mutation path. A typed `NotInSlice` is the right
signal if that ever breaks.

Going forward, `scripts/check_unwraps.sh` runs in CI (contracts job) as a
ratchet: it counts bare `.unwrap()` in non-test contract source and fails if the
count grows.

No new tests here — the converted sites are not reachable today (that is the
audit's finding), so a test would have to fake corrupted storage to reach them.
The conversion's value is that a future refactor dropping a `has()` check fails
loudly and typed instead of trapping.

### #1392 — Guardian rotation for key escrow

- `rotate_key_escrow_guardians(env, issuer, new_guardians, new_shares, new_threshold)`,
  issuer-only (`require_auth` + `Role::Issuer`), rejected once `recovered == true`.
  Validates the new set with the same rules as `deposit_key_escrow`.
- Old guardians' share entries are deleted before the new ones are written, so a
  guardian dropped by a rotation keeps no usable entry.
- **Mid-recovery rotation resets progress** rather than being blocked: partial
  `RecoverySubmissions` are cleared, because those submissions refer to shares the
  rotation removes. Blocking instead would let a single rogue guardian who submits a
  share freeze the issuer out of rotating away from them.
- Emits `KeyEscrowRotated` with the old and new guardian counts.
- Rotation flow documented in the `key_escrow.rs` module header, next to the existing
  off-chain Shamir notes.
- Tests: rotation replaces the set/threshold and drops old shares; non-issuer rejected;
  partial recovery progress reset and a fresh recovery starts from zero; rotation after
  recovery rejected.

### #1393 — Degraded write cap on all mutating entry points

The cap was reachable only via `require_not_paused`. Many mutating entry points
never call it, so the cap was not contract-wide.

- New `enforce_write_limit` helper: auto-recovery check plus the degraded write cap,
  *without* the pause check — so coverage could be extended without changing any
  entry point's existing pause semantics.
- Added it to 28 mutating entry points that had no guard (DID register/update/deactivate,
  slice attestor and threshold mutations, delegation, holder whitelisting, credential
  type registration, consent issuance, queue mutations, slice templates, attestor
  replacement, BBS+ disclosure proofs, attestation rollbacks). Placed immediately after
  `require_auth()` so unauthenticated callers cannot burn write slots.
- Entry points call one guard or the other, never both — each consumes a slot.
- `docs/circuit-breaker-write-coverage.md` documents both guards, the full exemption
  list, and the reasoning per category (recovery controls, admin config, paths reached
  from an already-guarded entry point, read paths whose only write is a derived
  cache/audit line).
- Tests: `register_did` (previously unprotected) is correctly capped in Degraded mode
  and returns `CircuitBreakerDegradedLimitReached`; plus a coverage ratchet test that
  parses `lib.rs` and fails if a new mutating `pub fn` lands without a guard or a
  documented exemption.

---

### Notes

- The workspace cannot resolve dependencies offline in this environment, so nothing was
  compiled or executed. Changes were made conservatively and by inspection.
- No behaviour outside the four issues was touched; pre-existing issues elsewhere in the
  contract were left alone.