### PR TITLE
fix: make failover.sh's --check and --verify actually check something

### DIFF
--- a/docs/multi-region-deployment.md
+++ b/docs/multi-region-deployment.md
@@ -195,24 +195,51 @@ Verify contract state is consistent across regions:
 # ==> Verifying contract state consistency...
 #
 #     testnet (CAAAAAAA...):
-#       primary: 42 credentials
-#       backup: 42 credentials
+#       testnet-backup: 42 credentials
+#       testnet: 42 credentials
 #       ✓ Consistent
 #
 #     mainnet (CAAAAAAA...):
-#       primary: 100 credentials
-#       backup: 100 credentials
+#       mainnet-backup: 100 credentials
+#       mainnet: 100 credentials
 #       ✓ Consistent
+```
+
+If a query fails on either side, it is never treated as a matching count of
+0 — it is surfaced explicitly instead:
+
+```
+#     testnet (CAAAAAAA...):
+#       testnet-backup: UNKNOWN credentials
+#       testnet: 42 credentials
+#       ? Could not verify (one or more endpoints did not return a valid count)
 ```
 
 ### Consistency Checks
 
-The verification script checks:
+`--verify` checks:
 
-1. **Credential count** — Same across all RPC endpoints
-2. **Slice count** — Same across all RPC endpoints
-3. **Contract state hash** — Identical across regions
-4. **Attestation records** — Consistent across endpoints
+1. **Credential count** — compared between a network's primary endpoint and
+   its `-backup` endpoint, via a real Soroban RPC call
+   (`stellar contract invoke ... get_credential_count`, simulated against
+   each endpoint) — the same mechanism `scripts/reconcile_state.sh` uses for
+   cross-instance comparison
+
+Slice count, a contract state hash, and attestation records are **not**
+checked by this script. Earlier revisions of this doc listed all four as
+checked; that described capabilities `failover.sh` never had.
+
+Because Horizon (the `-backup` endpoint for both networks by default) has no
+Soroban RPC and cannot serve contract-state queries, `--verify` will report
+"Could not verify" for the backup side against stock config. To get a real
+cross-region divergence check, point the backup override
+(`RPC_TESTNET_BACKUP` / `RPC_MAINNET_BACKUP`) at a second genuine Soroban RPC
+endpoint in another region/provider rather than Horizon.
+
+`--check` validates reachability using the protocol each endpoint type
+actually speaks: `getHealth` (JSON-RPC) for Soroban RPC endpoints, and a
+check for `horizon_version` on the root endpoint for Horizon endpoints —
+neither endpoint type has a `/health` REST route.
 
 ### Handling Inconsistencies
 

--- a/scripts/failover.sh
+++ b/scripts/failover.sh
@@ -6,7 +6,7 @@
 #   ./scripts/failover.sh --switch <endpoint>  # Switch to alternate endpoint
 #   ./scripts/failover.sh --verify             # Verify consistency across regions
 #
-# Requires: curl, jq
+# Requires: curl, jq, stellar (CLI, used by --verify)
 
 set -euo pipefail
 
@@ -19,12 +19,14 @@ if [[ -f "$ROOT_DIR/.env" ]]; then
   source "$ROOT_DIR/.env"
 fi
 
-# RPC endpoints
+# RPC endpoints. Overridable via env (same convention as CONTRACT_IDS below)
+# so tests can point --check/--verify at fake endpoints without touching the
+# real network.
 declare -A RPC_ENDPOINTS=(
-  ["testnet"]="https://soroban-testnet.stellar.org"
-  ["testnet-backup"]="https://horizon-testnet.stellar.org"
-  ["mainnet"]="https://soroban-mainnet.stellar.org"
-  ["mainnet-backup"]="https://horizon.stellar.org"
+  ["testnet"]="${RPC_TESTNET:-https://soroban-testnet.stellar.org}"
+  ["testnet-backup"]="${RPC_TESTNET_BACKUP:-https://horizon-testnet.stellar.org}"
+  ["mainnet"]="${RPC_MAINNET:-https://soroban-mainnet.stellar.org}"
+  ["mainnet-backup"]="${RPC_MAINNET_BACKUP:-https://horizon.stellar.org}"
 )
 
 # Contract IDs
@@ -33,17 +35,37 @@ declare -A CONTRACT_IDS=(
   ["mainnet"]="${CONTRACT_QUORUM_PROOF_MAINNET:-}"
 )
 
+# Strip a leading "--" so the documented --check/--switch/--verify flags
+# (used throughout this file's own usage comment) actually match below.
+# Also fixes: previously only bare `check`/`switch`/`verify` matched, so
+# every documented invocation fell through to the usage/error branch.
 COMMAND="${1:-check}"
+COMMAND="${COMMAND#--}"
 
-# Check RPC endpoint health
+# Horizon exposes no JSON-RPC and has no /health route; Soroban RPC is
+# JSON-RPC only and has no REST routes at all. They need different checks.
+is_horizon_endpoint() {
+  [[ "$1" == *horizon* ]]
+}
+
+# Check RPC endpoint health using the protocol each endpoint actually speaks.
 check_endpoint() {
   local endpoint="$1"
   local timeout=5
-  
-  if curl -s --max-time "$timeout" "$endpoint/health" > /dev/null 2>&1; then
-    return 0
+  local body
+
+  if is_horizon_endpoint "$endpoint"; then
+    # Horizon's root endpoint returns its landing-page JSON on success
+    # (history_latest_ledger, horizon_version, ...). There is no /health.
+    body=$(curl -s --max-time "$timeout" "$endpoint/" 2>/dev/null) || return 1
+    echo "$body" | jq -e '.horizon_version' > /dev/null 2>&1
   else
-    return 1
+    # Soroban RPC is JSON-RPC only; getHealth is the documented health
+    # check and returns {"result":{"status":"healthy"}} on success.
+    body=$(curl -s --max-time "$timeout" -X POST "$endpoint" \
+      -H 'Content-Type: application/json' \
+      -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}' 2>/dev/null) || return 1
+    [[ "$(echo "$body" | jq -r '.result.status // empty' 2>/dev/null)" == "healthy" ]]
   fi
 }
 
@@ -87,60 +109,99 @@ switch_endpoint() {
   fi
 }
 
+# Sentinel for "could not determine this endpoint's count", as distinct from
+# a genuine count of 0 (RPC failure, unreachable endpoint, or an endpoint —
+# e.g. Horizon — that cannot serve contract state at all).
+UNKNOWN_MARKER="UNKNOWN"
+
+# Query credential_count via a real Soroban RPC call (stellar contract invoke
+# simulates the contract's get_credential_count read against $endpoint),
+# following the same pattern already used for cross-instance comparison in
+# scripts/reconcile_state.sh's query_counter. Prints $UNKNOWN_MARKER — never
+# 0 — on any failure, so an unreachable/incompatible endpoint can't be
+# mistaken for a genuine empty state.
+query_credential_count() {
+  local contract="$1" network="$2" endpoint="$3"
+  local raw
+  # Always returns 0: printing $UNKNOWN_MARKER *is* the successful outcome
+  # for a failed query. Callers capture this via plain assignment under
+  # `set -e`, where a non-zero return here would abort the whole script.
+  if raw=$(stellar contract invoke \
+    --id "$contract" \
+    --network "$network" \
+    --rpc-url "$endpoint" \
+    -- get_credential_count 2>/dev/null | tr -d '"'); then
+    if [[ "$raw" =~ ^-?[0-9]+$ ]]; then
+      echo "$raw"
+      return 0
+    fi
+  fi
+  echo "$UNKNOWN_MARKER"
+}
+
 # Verify consistency across regions
 verify_consistency() {
   echo "==> Verifying contract state consistency..."
   echo ""
-  
+
   for network in "${!CONTRACT_IDS[@]}"; do
     contract_id="${CONTRACT_IDS[$network]}"
-    
+
     if [[ -z "$contract_id" ]]; then
       echo "    ⊘ $network: No contract ID configured"
       continue
     fi
-    
-    # Get credential count from each endpoint
-    declare -A counts
-    
-    for endpoint_name in "${!RPC_ENDPOINTS[@]}"; do
-      if [[ "$endpoint_name" != *"backup"* ]]; then
+
+    # Get credential count from this network's own primary and backup
+    # endpoints only.
+    # Also fixes: this previously matched every "*backup*" key regardless of
+    # network (e.g. mainnet-backup was queried using the testnet contract
+    # id), which made the comparison meaningless.
+    #
+    # Also fixes: `declare -A counts` alone does not clear a pre-existing
+    # array at this scope, so with both testnet and mainnet configured the
+    # second iteration silently inherited stale entries from the first
+    # (visible once compared with `${!counts[@]}` below). `=()` resets it.
+    declare -A counts=()
+
+    for endpoint_name in "$network" "$network-backup"; do
+      endpoint="${RPC_ENDPOINTS[$endpoint_name]:-}"
+      if [[ -z "$endpoint" ]]; then
         continue
       fi
-      
-      endpoint="${RPC_ENDPOINTS[$endpoint_name]}"
-      
-      if check_endpoint "$endpoint"; then
-        # Query contract state
-        count=$(curl -s "$endpoint/contracts/$contract_id/state" 2>/dev/null | jq '.credential_count // 0' || echo "0")
-        counts["$endpoint_name"]="$count"
-      fi
+      counts["$endpoint_name"]=$(query_credential_count "$contract_id" "$network" "$endpoint")
     done
-    
-    # Compare counts
+
+    # Compare counts. Any UNKNOWN makes the result explicitly unverifiable —
+    # it must never be treated as a matching value.
     echo "    $network ($contract_id):"
-    
+
     local first_count=""
     local consistent=true
-    
+    local unverifiable=false
+
     for endpoint_name in "${!counts[@]}"; do
       count="${counts[$endpoint_name]}"
-      
-      if [[ -z "$first_count" ]]; then
+
+      if [[ "$count" == "$UNKNOWN_MARKER" ]]; then
+        unverifiable=true
+      elif [[ -z "$first_count" ]]; then
         first_count="$count"
       elif [[ "$count" != "$first_count" ]]; then
         consistent=false
       fi
-      
+
       echo "      $endpoint_name: $count credentials"
     done
-    
-    if [[ "$consistent" == true ]]; then
+
+    if [[ "$unverifiable" == true ]]; then
+      echo "      ? Could not verify (one or more endpoints did not return a valid count)"
+    elif [[ "$consistent" == true ]]; then
       echo "      ✓ Consistent"
     else
       echo "      ✗ Inconsistent state detected"
     fi
-    
+
     echo ""
   done
 }

--- a/scripts/tests/test_failover.sh
+++ b/scripts/tests/test_failover.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# scripts/tests/test_failover.sh — Tests for scripts/failover.sh
+#
+# Exercises failover.sh against fake `curl` and `stellar` binaries (shell
+# scripts resolved via PATH) so no real network or Soroban RPC is required.
+# Each test configures a fake's behavior via env vars, runs the real script
+# as a subprocess, and asserts on its stdout.
+#
+# Run with: ./scripts/tests/test_failover.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+FAILOVER_SCRIPT="$ROOT_DIR/failover.sh"
+
+PASS=0
+FAIL=0
+
+WORK_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$WORK_DIR"; }
+trap cleanup EXIT
+
+# ── Fake `curl` ───────────────────────────────────────────────────────────────
+# Used by check_endpoint. Behavior is controlled by STUB_SOROBAN_HEALTHY,
+# STUB_HORIZON_HEALTHY and STUB_CURL_FAIL, read from the environment at
+# invocation time. Distinguishes Soroban vs Horizon requests the same way
+# failover.sh does: by whether "horizon" appears in the URL.
+make_curl_stub() {
+  local stub_dir="$WORK_DIR/bin_curl"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/curl" <<'STUB'
+#!/usr/bin/env bash
+url=""
+for a in "$@"; do
+  case "$a" in http*) url="$a" ;; esac
+done
+
+if [[ "${STUB_CURL_FAIL:-0}" == "1" ]]; then
+  exit 1
+fi
+
+if [[ "$url" == *horizon* ]]; then
+  if [[ "${STUB_HORIZON_HEALTHY:-0}" == "1" ]]; then
+    echo '{"horizon_version":"22.0.0","history_latest_ledger":100}'
+  else
+    echo '{"error":"not found"}'
+  fi
+else
+  if [[ "${STUB_SOROBAN_HEALTHY:-0}" == "1" ]]; then
+    echo '{"jsonrpc":"2.0","id":1,"result":{"status":"healthy"}}'
+  else
+    echo '{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found"}}'
+  fi
+fi
+STUB
+  chmod +x "$stub_dir/curl"
+  echo "$stub_dir"
+}
+
+# ── Fake `stellar` ────────────────────────────────────────────────────────────
+# Used by query_credential_count (verify_consistency). Returns STUB_COUNT_A/B
+# for whichever RPC URL matches STUB_RPC_A/STUB_RPC_B, failing instead when
+# STUB_FAIL_A/STUB_FAIL_B is "1".
+make_stellar_stub() {
+  local stub_dir="$WORK_DIR/bin_stellar"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/stellar" <<'STUB'
+#!/usr/bin/env bash
+rpc=""
+args=("$@")
+for ((i=0; i<${#args[@]}; i++)); do
+  if [[ "${args[$i]}" == "--rpc-url" ]]; then rpc="${args[$((i+1))]}"; fi
+done
+
+if [[ "$rpc" == "$STUB_RPC_A" ]]; then
+  if [[ "${STUB_FAIL_A:-0}" == "1" ]]; then echo "error: RPC call failed" >&2; exit 1; fi
+  echo "\"${STUB_COUNT_A:-0}\""
+elif [[ "$rpc" == "$STUB_RPC_B" ]]; then
+  if [[ "${STUB_FAIL_B:-0}" == "1" ]]; then echo "error: RPC call failed" >&2; exit 1; fi
+  echo "\"${STUB_COUNT_B:-0}\""
+else
+  echo "error: unknown rpc $rpc" >&2
+  exit 1
+fi
+STUB
+  chmod +x "$stub_dir/stellar"
+  echo "$stub_dir"
+}
+
+run_failover() {
+  local subcommand="$1" stub_dir="$2"
+  shift 2
+  (
+    cd "$WORK_DIR" && \
+    PATH="$stub_dir:$PATH" \
+    "$FAILOVER_SCRIPT" "$subcommand" "$@" > "$WORK_DIR/stdout.log" 2>"$WORK_DIR/stderr.log"
+  )
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  ok - $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL - $desc (expected to find '$needle')"
+    echo "         --- actual output ---"
+    while IFS= read -r line; do echo "         $line"; done <<<"$haystack"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "  ok - $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL - $desc (did not expect to find '$needle')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== test_failover.sh ==="
+
+# ── Test 1: --check reports a healthy Soroban RPC + Horizon pair as reachable ─
+# Fails today: check_endpoint curls "$endpoint/health", which is a real route
+# on neither endpoint type, so this always reported "unreachable".
+out=$(RPC_TESTNET="https://fake-soroban.test" \
+      RPC_TESTNET_BACKUP="https://fake-horizon.test" \
+      RPC_MAINNET="https://fake-soroban-2.test" \
+      RPC_MAINNET_BACKUP="https://fake-horizon-2.test" \
+      STUB_SOROBAN_HEALTHY=1 STUB_HORIZON_HEALTHY=1 \
+      run_failover "--check" "$(make_curl_stub)"; cat "$WORK_DIR/stdout.log")
+assert_contains "healthy testnet (soroban) reported reachable" "✓ testnet:" "$out"
+assert_contains "healthy testnet-backup (horizon) reported reachable" "✓ testnet-backup:" "$out"
+assert_contains "healthy mainnet (soroban) reported reachable" "✓ mainnet:" "$out"
+assert_contains "healthy mainnet-backup (horizon) reported reachable" "✓ mainnet-backup:" "$out"
+assert_not_contains "no endpoint reported unreachable" "unreachable" "$out"
+
+# ── Test 2: --check reports a Soroban RPC endpoint that answers but isn't
+# healthy (getHealth returns a JSON-RPC error) as unreachable ────────────────
+out=$(RPC_TESTNET="https://fake-soroban.test" \
+      RPC_TESTNET_BACKUP="https://fake-horizon.test" \
+      STUB_SOROBAN_HEALTHY=0 STUB_HORIZON_HEALTHY=1 \
+      run_failover "--check" "$(make_curl_stub)"; cat "$WORK_DIR/stdout.log")
+assert_contains "unhealthy soroban getHealth reported unreachable" "✗ testnet: https://fake-soroban.test (unreachable)" "$out"
+
+# ── Test 3: --check reports a genuinely unreachable endpoint (connection
+# failure) as unreachable, not reachable ──────────────────────────────────────
+out=$(RPC_TESTNET_BACKUP="https://fake-horizon.test" \
+      STUB_CURL_FAIL=1 \
+      run_failover "--check" "$(make_curl_stub)"; cat "$WORK_DIR/stdout.log")
+assert_contains "connection failure reported unreachable" "✗ testnet-backup: https://fake-horizon.test (unreachable)" "$out"
+
+# ── Test 4: --verify reports Consistent when both endpoints agree ────────────
+out=$(CONTRACT_QUORUM_PROOF_TESTNET="CONTRACTID" \
+      RPC_TESTNET="https://fake-a.test" RPC_TESTNET_BACKUP="https://fake-b.test" \
+      STUB_RPC_A="https://fake-a.test" STUB_RPC_B="https://fake-b.test" \
+      STUB_COUNT_A=10 STUB_COUNT_B=10 \
+      run_failover "--verify" "$(make_stellar_stub)"; cat "$WORK_DIR/stdout.log")
+assert_contains "matching counts report Consistent" "✓ Consistent" "$out"
+assert_not_contains "matching counts do not report Inconsistent" "Inconsistent state detected" "$out"
+
+# ── Test 5: --verify reports Inconsistent when counts genuinely diverge ──────
+# Fails today: the state query always resolved to 0 on both sides via
+# `jq ... || echo "0"`, so this could never be detected.
+out=$(CONTRACT_QUORUM_PROOF_TESTNET="CONTRACTID" \
+      RPC_TESTNET="https://fake-a.test" RPC_TESTNET_BACKUP="https://fake-b.test" \
+      STUB_RPC_A="https://fake-a.test" STUB_RPC_B="https://fake-b.test" \
+      STUB_COUNT_A=10 STUB_COUNT_B=17 \
+      run_failover "--verify" "$(make_stellar_stub)"; cat "$WORK_DIR/stdout.log")
+assert_contains "diverging counts report Inconsistent state detected" "✗ Inconsistent state detected" "$out"
+assert_not_contains "diverging counts do not report Consistent" "✓ Consistent" "$out"
+
+# ── Test 6: --verify surfaces an RPC failure as "could not verify", never as
+# a matching count of 0 that reads as consistent ─────────────────────────────
+out=$(CONTRACT_QUORUM_PROOF_TESTNET="CONTRACTID" \
+      RPC_TESTNET="https://fake-a.test" RPC_TESTNET_BACKUP="https://fake-b.test" \
+      STUB_RPC_A="https://fake-a.test" STUB_RPC_B="https://fake-b.test" \
+      STUB_COUNT_A=10 STUB_FAIL_B=1 \
+      run_failover "--verify" "$(make_stellar_stub)"; cat "$WORK_DIR/stdout.log")
+assert_contains "RPC failure surfaced as UNKNOWN, not 0" "testnet-backup: UNKNOWN credentials" "$out"
+assert_contains "RPC failure reports Could not verify" "? Could not verify" "$out"
+assert_not_contains "RPC failure never reads as Consistent" "✓ Consistent" "$out"
+assert_not_contains "RPC failure never reads as a false 0-count inconsistency label bypass" "Inconsistent state detected" "$out"
+
+# ── Test 7: with both networks configured, each network's result only
+# reflects its own two endpoints — no cross-network leakage or stale data
+# carried over from the previous iteration ───────────────────────────────────
+out=$(CONTRACT_QUORUM_PROOF_TESTNET="TESTCONTRACT" CONTRACT_QUORUM_PROOF_MAINNET="MAINCONTRACT" \
+      RPC_TESTNET="https://fake-t.test" RPC_TESTNET_BACKUP="https://fake-tb.test" \
+      RPC_MAINNET="https://fake-m.test" RPC_MAINNET_BACKUP="https://fake-mb.test" \
+      STUB_RPC_A="https://fake-t.test" STUB_RPC_B="https://fake-tb.test" \
+      STUB_COUNT_A=5 STUB_COUNT_B=5 \
+      run_failover "--verify" "$(make_stellar_stub)"; cat "$WORK_DIR/stdout.log")
+# testnet's own two endpoints (stubbed) should be Consistent...
+assert_contains "testnet block reports Consistent from its own endpoints" "TESTCONTRACT):
+      testnet-backup: 5 credentials
+      testnet: 5 credentials
+      ✓ Consistent" "$out"
+# ...and mainnet (unstubbed RPC, real stellar not present) must report
+# Could not verify using ONLY its own two endpoint lines - not testnet's.
+mainnet_block=$(awk '/MAINCONTRACT\):/{flag=1} flag{print} /^$/{if(flag) exit}' <<<"$out")
+assert_not_contains "mainnet block does not leak testnet's endpoint entries" "testnet:" "$mainnet_block"
+assert_not_contains "mainnet block does not leak testnet-backup's entry" "testnet-backup:" "$mainnet_block"
+assert_contains "mainnet block reports Could not verify on its own unreachable endpoints" "Could not verify" "$mainnet_block"
+
+echo ""
+echo "=== $PASS passed, $FAIL failed ==="
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Summary

scripts/failover.sh never actually checked anything: check_endpoint curled $endpoint/health, a route that exists on neither Soroban RPC (JSON-RPC only) nor Horizon (no /health at all), so --check/--switch always reported every endpoint unreachable. Separately, verify_consistency queried $endpoint/contracts/$contract_id/state — not a real route on either endpoint type — masked the failure with jq '.credential_count // 0' || echo "0", and therefore always concluded "✓ Consistent" regardless of real divergence.

closes #1370

Issue tasks, answered

Replace check_endpoint's REST call with a real Soroban JSON-RPC getHealth call (and the Horizon-appropriate equivalent for Horizon endpoints).
Done. check_endpoint now branches on is_horizon_endpoint (*horizon* in the URL): Soroban RPC gets a POST JSON-RPC getHealth call, asserting result.status == "healthy"; Horizon gets a GET on its root endpoint, asserting the horizon_version key is present (Horizon has no /health). See scripts/failover.sh:45-70.

Replace verify_consistency's state query with a real Soroban RPC call that can actually retrieve contract state... following the working pattern already used in exporter.py's _fetch_state_metrics.
Done, but via a different (and I'd argue more faithful) working precedent already in this repo: scripts/reconcile_state.sh's query_counter, which solves this exact problem — cross-instance credential_count comparison via a real Soroban RPC call — and already ships with its own passing test suite. query_credential_count (scripts/failover.sh:117-140) mirrors it: stellar contract invoke --id ... --network ... --rpc-url ... -- get_credential_count. I didn't hand-roll getLedgerEntries + SCVal XDR decoding in bash — reconcile_state.sh already proved out a simpler, working mechanism for the identical field, in the identical language, in this identical repo. Flagging this as a deliberate deviation from the issue's literal suggestion in case a reviewer wants raw ledger-entry reads instead.

Make an RPC call failure during verify_consistency surface as an explicit "could not verify" result rather than silently resolving to a count of 0.
Done. query_credential_count returns the UNKNOWN sentinel (never 0) on any failure. The comparison loop treats any UNKNOWN as unverifiable=true, which prints ? Could not verify (...) and takes priority over both "Consistent" and "Inconsistent". See scripts/failover.sh:170-198 and docs/multi-region-deployment.md's new "Could not verify" example output.

Add a test pointing --check at a real or faithfully mocked healthy Soroban RPC endpoint and asserting it reports reachable.
scripts/tests/test_failover.sh, Test 1 — mocked curl returns a healthy getHealth response; asserts all four configured endpoints (both Soroban and Horizon) report ✓ ... reachable. This fails on the pre-fix script (confirmed by reverting locally and re-running).

Add a test seeding two endpoints with deliberately different credential counts and asserting --verify reports inconsistency.
Test 5 — mocked stellar CLI returns 10 for one endpoint, 17 for the other; asserts ✗ Inconsistent state detected and not ✓ Consistent.

Add a test proving an RPC call failure during verification is surfaced as an error/unknown state, not silently treated as a matching count of 0.
Test 6 — mocked stellar fails for one endpoint; asserts the output shows UNKNOWN credentials (never 0) and ? Could not verify, and never ✓ Consistent.

Preserve the script's existing CLI flags and output format for callers/dashboards that parse it, unless a documented change is necessary.
Flags unchanged. Output format unchanged except: (a) the new ? Could not verify (...) status line, which is a necessary format change per the task above — the whole point is that dashboards must stop reading a masked 0 as "consistent" — documented in docs/multi-region-deployment.md; (b) verify_consistency's per-endpoint lines now key off the network's own two endpoint names (testnet/testnet-backup) instead of the doc's stale primary/backup labels, which never matched the script's actual output even before this PR (doc bug, fixed alongside the accuracy pass below).

Confirm the disaster-recovery/multi-region docs accurately describe what --check/--verify actually validate now.
Updated docs/multi-region-deployment.md's "Consistency Verification" section: corrected the sample output, added the "Could not verify" example, replaced the false four-item checklist (credential count / slice count / state hash / attestation records — only the first was ever implemented) with the honest one-item scope, and documented that the default Horizon backup can't serve this query at all (see Known gaps). docs/disaster-recovery.md doesn't describe the script's internals, so it needed no change.

Also fixes (surfaced, not buried)

Three bugs outside the issue's literal text, each necessary to make the fix above actually work rather than just relocate the false-positive:

1. --check/--switch/--verify never matched anything. COMMAND="${1:-check}" was compared against bare check/switch/verify in the case statement, so every documented invocation (including the ones in this very issue and in docs/multi-region-deployment.md) fell through to the usage/error branch and exited 1. Fixed by stripping a leading -- before the match (scripts/failover.sh:38-43). Without this, none of the acceptance-criteria tests could even invoke the script as documented.
2. verify_consistency compared endpoints across networks. The old filter (endpoint_name == *backup*) matched every backup-tagged endpoint regardless of network, so checking testnet's contract also queried mainnet-backup (and vice versa) — comparing unrelated contracts on unrelated networks. Now scoped to "$network" and "$network-backup" only (scripts/failover.sh:162). Caught by writing Test 4/5/6 and by a dedicated Test 7 (multi-network isolation) that fails without this fix.
3. Stale counts array leaked between network iterations. declare -A counts inside the for network in ... loop does not clear a pre-existing array at that scope (verified interactively), so with both testnet and mainnet contract IDs configured, the second network's report silently included the first network's endpoint entries too. Fixed with declare -A counts=(). Test 7 fails without this fix (verified by reverting locally).

Evidence

- shellcheck scripts/failover.sh scripts/tests/test_failover.sh — clean, zero warnings.
- scripts/tests/test_failover.sh — 7 test cases, 19 assertions, all passing:
=== 19 passed, 0 failed ===
- Reproduce: bash scripts/tests/test_failover.sh (bash ≥4 required for associative arrays — see Known gaps).
- Regression proof for both "Also fixes" array/scoping bugs: manually reverted each fix locally and re-ran the suite — Test 7 fails without the declare -A counts=() fix (18 passed, 1 failed), confirming the test isn't vacuous.
- scripts/tests/test_reconcile_state.sh (pre-existing, untouched) still passes: 30 passed, 0 failed — no regression in the sibling script this PR's design borrows from.
- CI impact: grep -n "scripts/failover\|scripts/tests\|docs/multi-region" .github/workflows/*.yml returns no matches — no GitHub Actions workflow reads any file this PR touches, so there is no CI job for this change to turn red. (Also true of the pre-existing test_reconcile_state.sh, which isn't wired into CI either — bash script tests in this repo are run manually, not gated.)

Known gaps

- No CI job runs scripts/tests/*.sh. This matches existing repo practice (test_reconcile_state.sh isn't wired in either) — not something this PR introduces, but calling it out since "tests exist" and "tests run in CI" aren't the same claim.
- Default config still can't detect real divergence for either network. Since Horizon (the default *-backup endpoint) cannot serve contract-state queries at all, --verify against stock config will report "Could not verify" for the backup side, never a real consistency comparison. A genuine cross-region check requires pointing RPC_TESTNET_BACKUP/RPC_MAINNET_BACKUP at a second real Soroban RPC endpoint. Documented in docs/multi-region-deployment.md; not fixed here because it's an infrastructure/config decision (which second Soroban RPC provider to use), not a code bug.
- switch_endpoint's sed -i uses GNU syntax (no backup-suffix argument), which fails on BSD sed (macOS). Pre-existing, untouched by this PR, and a non-issue for this repo's CI (Ubuntu/GNU sed) — noted only because I hit it while testing locally on macOS.
- switch_endpoint still permits switching STELLAR_RPC_URL to a Horizon URL, which the application's Soroban client cannot actually use for contract calls. Pre-existing design issue in the failover/doc story (the "Manual Failover" section still recommends this), out of scope for this fix, flagged for visibility.
- Local testing requires bash ≥4 for associative arrays (macOS ships bash 3.2, which silently mishandles declare -A). Verified on GNU bash 5.3 via Homebrew. This is pre-existing to the script (not introduced here) — noting it because it cost real time to discover.

---